### PR TITLE
feat(action-password-update): Introduce `initialized` event

### DIFF
--- a/packages/action-password-update/README.md
+++ b/packages/action-password-update/README.md
@@ -12,4 +12,5 @@
 
 | Name                   | Description
 |------------------------|------------
+| `initialized`          | This event is fired once the dialog is fully initialized (validation rules have been loaded and rendered)
 | `success`              | This event is fired after password has been updated successfully

--- a/packages/action-password-update/src/components/PasswordUpdateDialog/PasswordUpdateDialog.js
+++ b/packages/action-password-update/src/components/PasswordUpdateDialog/PasswordUpdateDialog.js
@@ -21,6 +21,14 @@ class PasswordUpdateDialog extends Component {
     }
   }
 
+  componentDidUpdate() {
+    if (this.props.validationRules) {
+      window.requestAnimationFrame(() => {
+        this.props.initialized()
+      })
+    }
+  }
+
   render() {
     const {password, validationRules, updateOldPassword, updateNewPassword, updateNewPasswordRepeat}
       = this.props
@@ -113,6 +121,7 @@ PasswordUpdateDialog.propTypes = {
   updateNewPasswordRepeat: React.PropTypes.func.isRequired,
   fetchValidationRules: React.PropTypes.func.isRequired,
   savePassword: React.PropTypes.func.isRequired,
+  initialized: React.PropTypes.func.isRequired,
   intl: intlShape.isRequired
 }
 

--- a/packages/action-password-update/src/components/PasswordUpdateDialog/PasswordUpdateDialog.spec.js
+++ b/packages/action-password-update/src/components/PasswordUpdateDialog/PasswordUpdateDialog.spec.js
@@ -20,6 +20,28 @@ describe('action-password-update', () => {
         expect(fetchValidationRules).to.have.property('callCount', 1);
       })
 
+      it('calls initialized callback once rules rendered', () => {
+        window.requestAnimationFrame = fn => fn()
+
+        const initialized = sinon.spy();
+
+        const wrapper = mount(<PasswordUpdateDialog
+          fetchValidationRules={() => undefined}
+          validationRules={null}
+          password={{}}
+          intl={intl}
+          initialized={initialized}
+        />)
+
+        expect(initialized).to.have.property('callCount', 0);
+
+        wrapper.setProps({
+          validationRules: []
+        })
+
+        expect(initialized).to.have.property('callCount', 1);
+      })
+
       it ('displays LoadMask until rules loaded', () => {
         const wrapper = shallow(<PasswordUpdateDialog
           fetchValidationRules={() => undefined}

--- a/packages/action-password-update/src/containers/PasswordUpdateDialogContainer.js
+++ b/packages/action-password-update/src/containers/PasswordUpdateDialogContainer.js
@@ -1,6 +1,7 @@
 import {connect} from 'react-redux'
 import {injectIntl} from 'react-intl'
 import PasswordUpdateDialog from '../components/PasswordUpdateDialog'
+import {initialized} from '../modules/actions'
 import {updateOldPassword, updateNewPassword, updateNewPasswordRepeat, savePassword} from '../modules/password'
 import {fetchValidationRules} from '../modules/validationRules'
 
@@ -9,7 +10,8 @@ const mapActionCreators = {
   updateNewPassword,
   updateNewPasswordRepeat,
   fetchValidationRules,
-  savePassword
+  savePassword,
+  initialized
 }
 
 const mapStateToProps = state => {

--- a/packages/action-password-update/src/modules/actions.js
+++ b/packages/action-password-update/src/modules/actions.js
@@ -1,0 +1,5 @@
+export const INITIALIZED = 'INITIALIZED'
+
+export const initialized = () => ({
+  type: INITIALIZED
+})

--- a/packages/action-password-update/src/modules/reducers.js
+++ b/packages/action-password-update/src/modules/reducers.js
@@ -1,3 +1,4 @@
+import mainSagas from './sagas'
 import password, { sagas as passwordSagas } from './password/'
 import validationRules, { sagas as validationRulesSagas } from './validationRules/'
 import {intlReducer} from 'react-intl-redux'
@@ -9,6 +10,7 @@ export default {
 }
 
 export const sagas = [
+  mainSagas,
   passwordSagas,
   validationRulesSagas
 ]

--- a/packages/action-password-update/src/modules/sagas.js
+++ b/packages/action-password-update/src/modules/sagas.js
@@ -1,0 +1,14 @@
+import * as actions from './actions'
+import {call, fork, take} from 'redux-saga/effects'
+import {ExternalEvents} from 'tocco-util'
+
+export function* initializeWatcher() {
+  yield take(actions.INITIALIZED)
+  yield call(ExternalEvents.invokeExternalEvent, 'initialized')
+}
+
+export default function* sagas() {
+  yield [
+    fork(initializeWatcher)
+  ]
+}

--- a/packages/action-password-update/src/modules/sagas.spec.js
+++ b/packages/action-password-update/src/modules/sagas.spec.js
@@ -1,0 +1,26 @@
+import {fork, call, take} from 'redux-saga/effects'
+import sagas, {initializeWatcher} from './sagas'
+import * as actions from './actions'
+import {ExternalEvents} from 'tocco-util'
+
+
+describe('action-password-update', () => {
+  describe('sagas', () => {
+    describe('root saga', () => {
+      it('should fork child sagas', () => {
+        const generator = sagas()
+        expect(generator.next().value).to.deep.equal([fork(initializeWatcher)])
+        expect(generator.next().done).to.equal(true)
+      })
+    })
+
+    describe('initializeWatcher', () => {
+      it('should invoke initialized event', () => {
+        const generator = initializeWatcher()
+        expect(generator.next().value).to.deep.equal(take(actions.INITIALIZED))
+        expect(generator.next().value).to.deep.equal(call(ExternalEvents.invokeExternalEvent, 'initialized'))
+        expect(generator.next().done).to.equal(true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
- This event is fired once the dialog is fully initialized (validation rules
  have been loaded and rendered)
- Can, for instance, be used to center the application container in the
  view screen