### PR TITLE
chore(tocco-client): load server libs locally

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,10 @@
 *.spec.js
-docs/**
 node_modules/**
 coverage/**
 .idea/
+
+server/static/node_modules
+
 packages/*/dist/**
 packages/*/node_modules/**
 packages/*/coverage/**

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ http://localhost:8080
 ### Getting started
 ```
 npm install --global lerna@^2.0.0-beta.28
-npm install
+npm run setup
 lerna bootstrap
 npm start --package={PACKAGE_NAME}
 ```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "deploy:standalone": "better-npm-run deploy:standalone",
     "publish": "better-npm-run publish",
     "codecov": "cat ./coverage/lcov/lcov.info | codecov",
-    "coveralls": "cat ./coverage/lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "coveralls": "cat ./coverage/lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "setup": "npm install && cd server/static && npm install"
   },
   "betterScripts": {
     "compile": {

--- a/server/index.html
+++ b/server/index.html
@@ -4,9 +4,9 @@
   <title>Tocco React</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.0/react.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.0/react-dom.js"></script>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <script src="node_modules/react/dist/react.js"></script>
+  <script src="node_modules/react-dom/dist/react-dom.js"></script>
+  <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.css">
 </head>
 <body>
 <div id="root"></div>

--- a/server/main.js
+++ b/server/main.js
@@ -5,13 +5,10 @@ import webpackConfig from '../build/webpack.config'
 import historyApiFallback from 'koa-connect-history-api-fallback'
 import serve from 'koa-static'
 import proxy from 'koa-proxy'
-import _debug from 'debug'
 import config from '../config'
 import webpackDevMiddleware from './middleware/webpack-dev'
 import webpackHMRMiddleware from './middleware/webpack-hmr'
 
-const debug = _debug('app:server')
-const paths = config.utils_paths
 const app = new Koa()
 
 // Enable koa-proxy if it has been enabled in the config.
@@ -26,35 +23,13 @@ app.use(convert(historyApiFallback({
   verbose: false
 })))
 
-// ------------------------------------
-// Apply Webpack HMR Middleware
-// ------------------------------------
 if (config.env === 'development') {
   const compiler = webpack(webpackConfig)
-
-  // Enable webpack-dev and webpack-hot middleware
   const { publicPath } = webpackConfig.output
 
   app.use(webpackDevMiddleware(compiler, publicPath))
   app.use(webpackHMRMiddleware(compiler))
-
-  // Serve static assets from ~/src/static since Webpack is unaware of
-  // these files. This middleware doesn't need to be enabled outside
-  // of development since this directory will be copied into ~/dist
-  // when the application is compiled.
-  app.use(convert(serve(paths.client('static'))))
-} else {
-  debug(
-    'Server is being run outside of live development mode. This starter kit '
-    + 'does not provide any production-ready server functionality. To learn '
-    + 'more about deployment strategies, check out the "deployment" section '
-    + 'in the README.'
-  )
-
-  // Serving ~/dist by default. Ideally these files should be served by
-  // the web server and not the app server, but this helps to demo the
-  // server in production.
-  app.use(convert(serve(paths.dist())))
+  app.use(serve('server/static'))
 }
 
 export default app

--- a/server/static/package.json
+++ b/server/static/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "bootstrap": "^3.3.7",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2"
+  }
+}


### PR DESCRIPTION
- Libs (React and Bootstrap) used by the local server are loaded from a seperate node_modules folder. This allows offline development and easy dependency update
- introduce npm setup script to to run both npm install