### PR TITLE
chore: webpack case-sensitive path plugin

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -2,6 +2,7 @@ import webpack from 'webpack'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 import config from '../config'
 import _debug from 'debug'
+import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin'
 
 const debug = _debug('app:webpack:config')
 const paths = config.utils_paths
@@ -81,6 +82,11 @@ if (__DEV__ || __STANDALONE__) {
       }
     })
   )
+}
+
+if (__DEV__) {
+  debug('Enable plugin for case-sensitive path check')
+  webpackConfig.plugins.push(new CaseSensitivePathsPlugin())
 
   debug('Enable plugins for live development (HMR, NoErrors).')
   webpackConfig.plugins.push(
@@ -108,37 +114,39 @@ if (__DEV__) {
   presets.push('react-hmre')
 }
 
-webpackConfig.module.loaders = [{
-  test: /\.(js|jsx)$/,
-  exclude: /node_modules/,
-  loader: 'babel',
-  query: {
-    cacheDirectory: true,
-    plugins: ['transform-runtime'],
-    presets: presets,
-    env: {
-      production: {
-        plugins: [
-          'transform-react-remove-prop-types',
-          'transform-react-constant-elements'
-        ]
-      },
-      test: {
-        plugins: [['istanbul', {
-          'exclude': [
-            '**/*/*.spec.js',
-            '**/tocco-ui/**/example.js',
-            '**/tocco-ui/dist'
+webpackConfig.module.loaders = [
+  {
+    test: /\.(js|jsx)$/,
+    exclude: /node_modules/,
+    loader: 'babel',
+    query: {
+      cacheDirectory: true,
+      plugins: ['transform-runtime'],
+      presets: presets,
+      env: {
+        production: {
+          plugins: [
+            'transform-react-remove-prop-types',
+            'transform-react-constant-elements'
           ]
-        }]]
+        },
+        test: {
+          plugins: [['istanbul', {
+            'exclude': [
+              '**/*/*.spec.js',
+              '**/tocco-ui/**/example.js',
+              '**/tocco-ui/dist'
+            ]
+          }]]
+        }
       }
     }
+  },
+  {
+    test: /\.json$/,
+    loader: 'json'
   }
-},
-{
-  test: /\.json$/,
-  loader: 'json'
-}]
+]
 
 webpackConfig.module.loaders.push(
   { test: /\.css$/, loader: 'style-loader!css-loader' },

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "babel-register": "^6.14.0",
     "babel-runtime": "^6.11.6",
     "better-npm-run": "0.0.11",
+    "case-sensitive-paths-webpack-plugin": "^1.1.4",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "chai-enzyme": "^0.5.1",


### PR DESCRIPTION
- plugin throws an error if case in import statement is incorrect. Important to avoid errors on case-insensitive operating systems like OSX
- some formatting in webpack.config.js