### PR TITLE
refactor(login): Change text resource selector to return text for key

### DIFF
--- a/packages/login/src/modules/sagas.js
+++ b/packages/login/src/modules/sagas.js
@@ -14,7 +14,7 @@ import {getResponse} from '../dev/loginResponseMocks'
 
 export const DEFAULT_TIMEOUT = 30
 
-export const textResourceSelector = state => state.intl.messages
+export const textResourceSelector = (state, key) => state.intl.messages[key] || key
 export const loginSelector = state => state.login
 
 export function doLoginRequest(data) {
@@ -58,18 +58,18 @@ export function* handlePasswordUpdateResponse() {
 }
 
 export function* handleOneTilLBlockResponse(body) {
-  const textResources = yield select(textResourceSelector)
-  yield put(setMessage(textResources['client.login.form.lastTry'], true))
+  const text = yield select(textResourceSelector, 'client.login.form.lastTry')
+  yield put(setMessage(text, true))
 }
 
 export function* handleBlockResponse(body) {
-  const textResources = yield select(textResourceSelector)
-  yield put(setMessage(textResources['client.login.form.blocked'], true))
+  const text = yield select(textResourceSelector, 'client.login.form.blocked')
+  yield put(setMessage(text, true))
 }
 
 export function* handleFailedResponse(body) {
-  const textResources = yield select(textResourceSelector)
-  yield put(setMessage(textResources['client.login.form.failed'], true))
+  const text = yield select(textResourceSelector, 'client.login.form.failed')
+  yield put(setMessage(text, true))
 }
 
 export function* handleSuccessfulLogin(body) {

--- a/packages/login/src/modules/sagas.spec.js
+++ b/packages/login/src/modules/sagas.spec.js
@@ -148,8 +148,8 @@ describe('login', () => {
       describe('handleOneTilLBlockResponse', () => {
         it('should dispatch action setMessage', () => {
           const gen = sagas.handleOneTilLBlockResponse({})
-          expect(gen.next().value).to.deep.equal(select(sagas.textResourceSelector))
-          expect(gen.next({'client.login.form.lastTry': 'msg'}).value).to.deep.equal(put(setMessage('msg', true)))
+          expect(gen.next().value).to.deep.equal(select(sagas.textResourceSelector, 'client.login.form.lastTry'))
+          expect(gen.next('msg').value).to.deep.equal(put(setMessage('msg', true)))
           expect(gen.next().done).to.deep.equal(true)
         })
       })
@@ -157,8 +157,8 @@ describe('login', () => {
       describe('handleBlockResponse', () => {
         it('should dispatch action setMessage', () => {
           const gen = sagas.handleBlockResponse({})
-          expect(gen.next().value).to.deep.equal(select(sagas.textResourceSelector))
-          expect(gen.next({'client.login.form.blocked': 'msg'}).value).to.deep.equal(put(setMessage('msg', true)))
+          expect(gen.next().value).to.deep.equal(select(sagas.textResourceSelector, 'client.login.form.blocked'))
+          expect(gen.next('msg').value).to.deep.equal(put(setMessage('msg', true)))
           expect(gen.next().done).to.deep.equal(true)
         })
       })
@@ -166,8 +166,8 @@ describe('login', () => {
       describe('handleFailedResponse', () => {
         it('should dispatch action setMessage', () => {
           const gen = sagas.handleFailedResponse({})
-          expect(gen.next().value).to.deep.equal(select(sagas.textResourceSelector))
-          expect(gen.next({'client.login.form.failed': 'msg'}).value).to.deep.equal(put(setMessage('msg', true)))
+          expect(gen.next().value).to.deep.equal(select(sagas.textResourceSelector, 'client.login.form.failed'))
+          expect(gen.next('msg').value).to.deep.equal(put(setMessage('msg', true)))
           expect(gen.next().done).to.deep.equal(true)
         })
       })


### PR DESCRIPTION
- If no text is found for the given key, the key is returned as fallback
- This also fixes a bug where no failure message was displayed if
  corresponding text resource was not found