### PR TITLE
refactor(login): Improve error handling in sagas

### DIFF
--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tocco-login",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "description": "Login dialog with password-update dialog that can run independently",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/login/src/dev/loginResponseMocks.js
+++ b/packages/login/src/dev/loginResponseMocks.js
@@ -1,55 +1,44 @@
 export function getResponse(data) {
-  const headers = {'Content-Type': 'application/json; charset=utf-8'}
-
-  let response
   const type = getResponseType(data)
   switch (type) {
     case 'success':
-      response = new Response('{"success":true}', {
-        headers
-      })
-      break
+      return {
+        success: true
+      }
     case 'two_factor':
-      response = new Response('{"TWOSTEPLOGIN":true,"success":false,"REQUESTEDCODE":"A8","timeout":30}', {
-        headers
-      })
-      break
+      return {
+        TWOSTEPLOGIN: true,
+        success: false,
+        REQUESTEDCODE: 'A8',
+        timeout: 30
+      }
     case 'reset_password':
-      response = new Response('{"RESET_PASSWORD_REQUIRED":true,"success":false,"principal_id":"12345","timeout":30}', {
-        headers
-      })
-      break
+      return {
+        RESET_PASSWORD_REQUIRED: true,
+        success: false,
+        principal_id: '12345',
+        timeout: 30
+      }
     case 'before_blocked':
-      response = new Response('{"ONE_TILL_BLOCK":true,"success":false}', {
-        headers,
-        ok: false,
-        status: 401,
-        statusText: 'Unauthorized'
-      })
-      break
+      return {
+        ONE_TILL_BLOCK: true,
+        success: false
+      }
     case 'blocked':
-      response = new Response('{"LOGIN_BLOCKED":true,"success":false}', {
-        headers,
-        ok: false,
-        status: 401,
-        statusText: 'Unauthorized'
-      })
-      break
+      return {
+        LOGIN_BLOCKED: true,
+        success: false
+      }
     default:
-      response = new Response('{"success":false}', {
-        headers,
-        ok: false,
-        status: 401,
-        statusText: 'Unauthorized'
-      })
+      return {
+        success: false
+      }
   }
-
-  return response
 }
 
 function getResponseType(data) {
   const mapCredentialsToResponses = require('./login_responses.json')
-  for (let value of mapCredentialsToResponses.credentials) {
+  for (const value of mapCredentialsToResponses.credentials) {
     if (data.username === value.username) {
       return value.response_type
     }

--- a/packages/login/src/modules/sagas.js
+++ b/packages/login/src/modules/sagas.js
@@ -17,15 +17,30 @@ export const DEFAULT_TIMEOUT = 30
 export const textResourceSelector = (state, key) => state.intl.messages[key] || key
 export const loginSelector = state => state.login
 
-export function doLoginRequest(data) {
-  return fetch(`${__BACKEND_URL__}/nice2/login`, getOptions(data))
+export function doRequest(url, options) {
+  return new Promise(resolve => {
+    fetch(url, options)
+      .then(resp => {
+        resp.json().then(json => resolve(json))
+      })
+      .catch(e => {
+        if (console && console.error) {
+          console.error('Failed to execute request', e)
+        }
+        resolve({success: false})
+      })
+  })
 }
 
-export function doSessionRequest() {
-  return fetch(`${__BACKEND_URL__}/nice2/session`, getOptions({}))
+export function* doLoginRequest(data) {
+  return yield call(doRequest, `${__BACKEND_URL__}/nice2/login`, getOptions(data))
 }
 
-function getOptions(data) {
+export function* doSessionRequest() {
+  return yield call(doRequest, `${__BACKEND_URL__}/nice2/session`, getOptions())
+}
+
+function getOptions(data = {}) {
   return {
     method: 'POST',
     headers: new Headers({
@@ -38,15 +53,8 @@ function getOptions(data) {
   }
 }
 
-function doDevRequest(data) {
-  console.log('DEV MODE: Would send following request in PROD MODE:', getOptions(data))
-  const response = getResponse(data)
-  console.log('DEV MODE: Response -> ', response)
-  return Promise.resolve(response)
-}
-
-export function* handleTwoStepLoginResponse(body) {
-  yield put(setRequestedCode(body.REQUESTEDCODE))
+export function* handleTwoStepLoginResponse(response) {
+  yield put(setRequestedCode(response.REQUESTEDCODE))
   yield put(changePage(Pages.TWOSTEPLOGIN))
 }
 
@@ -57,57 +65,49 @@ export function* handlePasswordUpdateResponse() {
   yield put(changePage(Pages.PASSWORD_UPDATE))
 }
 
-export function* handleOneTilLBlockResponse(body) {
+export function* handleOneTilLBlockResponse() {
   const text = yield select(textResourceSelector, 'client.login.form.lastTry')
   yield put(setMessage(text, true))
 }
 
-export function* handleBlockResponse(body) {
+export function* handleBlockResponse() {
   const text = yield select(textResourceSelector, 'client.login.form.blocked')
   yield put(setMessage(text, true))
 }
 
-export function* handleFailedResponse(body) {
+export function* handleFailedResponse() {
   const text = yield select(textResourceSelector, 'client.login.form.failed')
   yield put(setMessage(text, true))
 }
 
-export function* handleSuccessfulLogin(body) {
-  const timeout = body.timeout || DEFAULT_TIMEOUT
+export function* handleSuccessfulLogin(response) {
+  const timeout = response.timeout || DEFAULT_TIMEOUT
   yield call(ExternalEvents.invokeExternalEvent, 'loginSuccess', {timeout})
-}
-
-export function getBody(response) {
-  return response.json().then(json => (
-    json
-  ))
 }
 
 export function* loginSaga({payload}) {
   let response
   if (__DEV__) {
     yield delay(1000)
-    response = yield call(doDevRequest, payload)
+    response = getResponse(payload)
   } else {
     response = yield call(doLoginRequest, payload)
   }
 
-  const body = yield call(getBody, response)
-
-  if (body.success) {
-    yield call(handleSuccessfulLogin, body)
+  if (response.success) {
+    yield call(handleSuccessfulLogin, response)
   } else {
     yield put(changePage(Pages.LOGIN_FORM)) // in order to display possible error message
-    if (body.TWOSTEPLOGIN) {
-      yield call(handleTwoStepLoginResponse, body)
-    } else if (body.RESET_PASSWORD_REQUIRED) {
-      yield call(handlePasswordUpdateResponse, body)
-    } else if (body.ONE_TILL_BLOCK) {
-      yield call(handleOneTilLBlockResponse, body)
-    } else if (body.LOGIN_BLOCKED) {
-      yield call(handleBlockResponse, body)
+    if (response.TWOSTEPLOGIN) {
+      yield call(handleTwoStepLoginResponse, response)
+    } else if (response.RESET_PASSWORD_REQUIRED) {
+      yield call(handlePasswordUpdateResponse)
+    } else if (response.ONE_TILL_BLOCK) {
+      yield call(handleOneTilLBlockResponse)
+    } else if (response.LOGIN_BLOCKED) {
+      yield call(handleBlockResponse)
     } else {
-      yield call(handleFailedResponse, body)
+      yield call(handleFailedResponse)
     }
   }
 
@@ -121,10 +121,9 @@ export function* checkSessionSaga() {
   } else {
     response = yield call(doSessionRequest)
   }
-  const body = yield call(getBody, response)
 
-  if (body.success) {
-    yield call(handleSuccessfulLogin, body)
+  if (response.success) {
+    yield call(handleSuccessfulLogin, response)
   }
 }
 
@@ -134,4 +133,3 @@ export default function* mainSagas() {
     fork(takeLatest, actions.CHECK_SESSION, checkSessionSaga)
   ]
 }
-

--- a/packages/login/src/modules/sagas.spec.js
+++ b/packages/login/src/modules/sagas.spec.js
@@ -30,9 +30,8 @@ describe('login', () => {
         it('should handle successful login', () => {
           const gen = sagas.loginSaga({payload: {}})
           expect(gen.next().value).to.eql(call(sagas.doLoginRequest, {}))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.getBody, new Response()))
-          const body = {success: true}
-          expect(gen.next(body).value).to.eql(call(sagas.handleSuccessfulLogin, body))
+          const response = {success: true}
+          expect(gen.next(response).value).to.eql(call(sagas.handleSuccessfulLogin, response))
           expect(gen.next().value).to.eql(put(setPending(false)))
           expect(gen.next().done).to.deep.equal(true)
         })
@@ -40,10 +39,9 @@ describe('login', () => {
         it('should handle unsuccessful login', () => {
           const gen = sagas.loginSaga({payload: {}})
           expect(gen.next().value).to.eql(call(sagas.doLoginRequest, {}))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.getBody, new Response()))
-          const body = {success: false}
-          expect(gen.next(body).value).to.deep.equal(put(changePage(Pages.LOGIN_FORM)))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.handleFailedResponse, body))
+          const response = {success: false}
+          expect(gen.next(response).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
+          expect(gen.next().value).to.eql(call(sagas.handleFailedResponse))
           expect(gen.next().value).to.eql(put(setPending(false)))
           expect(gen.next().done).to.deep.equal(true)
         })
@@ -51,13 +49,12 @@ describe('login', () => {
         it('should handle two step response', () => {
           const gen = sagas.loginSaga({payload: {}})
           expect(gen.next().value).to.eql(call(sagas.doLoginRequest, {}))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.getBody, new Response()))
-          const body = {
+          const response = {
             success: false,
             TWOSTEPLOGIN: true
           }
-          expect(gen.next(body).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.handleTwoStepLoginResponse, body))
+          expect(gen.next(response).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
+          expect(gen.next().value).to.eql(call(sagas.handleTwoStepLoginResponse, response))
           expect(gen.next().value).to.eql(put(setPending(false)))
           expect(gen.next().done).to.eql(true)
         })
@@ -65,13 +62,12 @@ describe('login', () => {
         it('should handle password reset response', () => {
           const gen = sagas.loginSaga({payload: {}})
           expect(gen.next().value).to.eql(call(sagas.doLoginRequest, {}))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.getBody, new Response()))
-          const body = {
+          const response = {
             success: false,
             RESET_PASSWORD_REQUIRED: true
           }
-          expect(gen.next(body).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.handlePasswordUpdateResponse, body))
+          expect(gen.next(response).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
+          expect(gen.next().value).to.eql(call(sagas.handlePasswordUpdateResponse))
           expect(gen.next().value).to.eql(put(setPending(false)))
           expect(gen.next().done).to.eql(true)
         })
@@ -79,13 +75,12 @@ describe('login', () => {
         it('should handle one till block response', () => {
           const gen = sagas.loginSaga({payload: {}})
           expect(gen.next().value).to.eql(call(sagas.doLoginRequest, {}))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.getBody, new Response()))
-          const body = {
+          const response = {
             success: false,
             ONE_TILL_BLOCK: true
           }
-          expect(gen.next(body).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.handleOneTilLBlockResponse, body))
+          expect(gen.next(response).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
+          expect(gen.next().value).to.eql(call(sagas.handleOneTilLBlockResponse))
           expect(gen.next().value).to.eql(put(setPending(false)))
           expect(gen.next().done).to.eql(true)
         })
@@ -93,13 +88,12 @@ describe('login', () => {
         it('should handle login blocked response', () => {
           const gen = sagas.loginSaga({payload: {}})
           expect(gen.next().value).to.eql(call(sagas.doLoginRequest, {}))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.getBody, new Response()))
-          const body = {
+          const response = {
             success: false,
             LOGIN_BLOCKED: true
           }
-          expect(gen.next(body).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
-          expect(gen.next(new Response()).value).to.eql(call(sagas.handleBlockResponse, body))
+          expect(gen.next(response).value).to.eql(put(changePage(Pages.LOGIN_FORM)))
+          expect(gen.next().value).to.eql(call(sagas.handleBlockResponse))
           expect(gen.next().value).to.eql(put(setPending(false)))
           expect(gen.next().done).to.eql(true)
         })
@@ -176,33 +170,16 @@ describe('login', () => {
         it('should call handleSuccessfulLogin on success', () => {
           const gen = sagas.checkSessionSaga()
           expect(gen.next().value).to.deep.equal(call(sagas.doSessionRequest))
-          const response = {}
-          expect(gen.next(response).value).to.deep.equal(call(sagas.getBody, response))
-          const body = {success: true}
-          expect(gen.next(body).value).to.deep.equal(call(sagas.handleSuccessfulLogin, body))
+          const response = {success: true}
+          expect(gen.next(response).value).to.deep.equal(call(sagas.handleSuccessfulLogin, response))
           expect(gen.next().done).to.deep.equal(true)
         })
 
         it('should do nothing if not success', () => {
           const gen = sagas.checkSessionSaga()
           expect(gen.next().value).to.deep.equal(call(sagas.doSessionRequest))
-          const response = {}
-          expect(gen.next(response).value).to.deep.equal(call(sagas.getBody, response))
-          const body = {success: false}
-          expect(gen.next(body).done).to.deep.equal(true)
-        })
-      })
-
-      describe('getBody', () => {
-        it('should return body', done => {
-          const response = new Response('{"test":true}')
-          const promise = sagas.getBody(response)
-          promise.then(json => {
-            expect(json).to.deep.equal({
-              test: true
-            })
-            done()
-          })
+          const response = {success: false}
+          expect(gen.next(response).done).to.deep.equal(true)
         })
       })
     })


### PR DESCRIPTION
If fetch requests fail, errors are caught and logged and a generic failure
response is returned.
