### PR TITLE
refactor(merge): rename package and adjust text-resource name

### DIFF
--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tocco-action-merge",
-  "version": "0.1.2",
+  "name": "tocco-merge",
+  "version": "0.1.4",
   "description": "merge action",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/merge/src/components/MergeMatrix/table-components/HeaderRow.js
+++ b/packages/merge/src/components/MergeMatrix/table-components/HeaderRow.js
@@ -12,7 +12,7 @@ const HeaderRow = props => {
           const cls = isTargetEntity(entity.pk) ? 'merge-matrix-th-selected' : 'merge-matrix-th'
           const attributes = {}
           if (!isTargetEntity(entity.pk)) {
-            attributes.title = props.intl.formatMessage({id: 'client.entityoperation.action.merge.selectTargetTitle'})
+            attributes.title = props.intl.formatMessage({id: 'client.merge.selectTargetTitle'})
           }
 
           return (

--- a/packages/merge/src/components/MergeStrategy/MergeStrategy.js
+++ b/packages/merge/src/components/MergeStrategy/MergeStrategy.js
@@ -14,7 +14,7 @@ class MergeStrategy extends React.Component {
       <div>
         <form>
           <div>
-            <h4><FormattedMessage id="client.entityoperation.action.merge.copyRelationsTitle"/></h4>
+            <h4><FormattedMessage id="client.merge.copyRelationsTitle"/></h4>
             <div className="answer">
               <div onClick={() => this.props.changeStrategy('copyRelations', true)}>
                 <input
@@ -23,7 +23,7 @@ class MergeStrategy extends React.Component {
                   checked={this.props.strategies.copyRelations}
                   onChange={() => {}}
                 />
-                <span className="p-l-5"><FormattedMessage id="client.entityoperation.action.merge.yes"/></span>
+                <span className="p-l-5"><FormattedMessage id="client.merge.yes"/></span>
               </div>
               <div onClick={() => this.props.changeStrategy('copyRelations', false)}>
                 <input
@@ -32,12 +32,12 @@ class MergeStrategy extends React.Component {
                   checked={!this.props.strategies.copyRelations}
                   onChange={() => {}}
                 />
-                <span className="p-l-5"><FormattedMessage id="client.entityoperation.action.merge.no"/></span>
+                <span className="p-l-5"><FormattedMessage id="client.merge.no"/></span>
               </div>
             </div>
           </div>
           <div>
-            <h4><FormattedMessage id="client.entityoperation.action.merge.strategyTitle"/></h4>
+            <h4><FormattedMessage id="client.merge.strategyTitle"/></h4>
             <div className="answer">
               <select
                 className="form-control"
@@ -45,15 +45,15 @@ class MergeStrategy extends React.Component {
                 onChange={event => this.props.changeStrategy('sourceEntityAction', event.target.value)}
               >
                 <option value={SourceEntityAction.NO_ACTION}>
-                  {this.props.intl.formatMessage({id: 'client.entityoperation.action.merge.strategyNoAction'})}
+                  {this.props.intl.formatMessage({id: 'client.merge.strategyNoAction'})}
                 </option>
                 <option value={SourceEntityAction.DELETE} hidden>
-                  {this.props.intl.formatMessage({id: 'client.entityoperation.action.merge.strategyDelete'})}
+                  {this.props.intl.formatMessage({id: 'client.merge.strategyDelete'})}
                 </option>
                 {
                   (this.props.editOptions.length > 0
                     && <option value={SourceEntityAction.EDIT}>
-                      {this.props.intl.formatMessage({id: 'client.entityoperation.action.merge.strategyEdit'})}
+                      {this.props.intl.formatMessage({id: 'client.merge.strategyEdit'})}
                     </option>
                   )
                 }
@@ -61,7 +61,7 @@ class MergeStrategy extends React.Component {
               </select>
             </div>
             <div className={editClassNames}>
-              <h5><FormattedMessage id="client.entityoperation.action.merge.editTitle"/></h5>
+              <h5><FormattedMessage id="client.merge.editTitle"/></h5>
               <div className="answer">
                 {
                   this.props.editOptions.map((editOption, idx) => {

--- a/packages/merge/src/components/MergeStrategy/MergeStrategy.spec.js
+++ b/packages/merge/src/components/MergeStrategy/MergeStrategy.spec.js
@@ -30,11 +30,11 @@ describe('merge', () => {
           <IntlProvider
             locale={'en-US'}
             messages={{
-              'client.entityoperation.action.merge.yes': ' ',
-              'client.entityoperation.action.merge.no': ' ',
-              'client.entityoperation.action.merge.copyRelationsTitle': ' ',
-              'client.entityoperation.action.merge.editTitle': ' ',
-              'client.entityoperation.action.merge.strategyTitle': ' '
+              'client.merge.yes': ' ',
+              'client.merge.no': ' ',
+              'client.merge.copyRelationsTitle': ' ',
+              'client.merge.editTitle': ' ',
+              'client.merge.strategyTitle': ' '
             }}
           >
             <MergeStrategy

--- a/packages/merge/src/components/MergeWizard/MergeResponse.js
+++ b/packages/merge/src/components/MergeWizard/MergeResponse.js
@@ -10,9 +10,9 @@ export const EntityResponseTable = props => {
       <table className="table table-striped table-hover">
         <thead>
           <tr>
-            <th><FormattedMessage id="client.entityoperation.action.merge.entity"/></th>
-            <th><FormattedMessage id="client.entityoperation.action.merge.primaryKey"/></th>
-            <th><FormattedMessage id="client.entityoperation.action.merge.label"/></th>
+            <th><FormattedMessage id="client.merge.entity"/></th>
+            <th><FormattedMessage id="client.merge.primaryKey"/></th>
+            <th><FormattedMessage id="client.merge.label"/></th>
           </tr>
         </thead>
         <tbody>
@@ -42,26 +42,26 @@ class MergeResponse extends React.Component {
   render() {
     return (
       <div className="merge-response">
-        <h1><FormattedMessage id="client.entityoperation.action.merge.responseTitle"/></h1>
-        <span><FormattedMessage id="client.entityoperation.action.merge.responseDescription"/></span>
+        <h1><FormattedMessage id="client.merge.responseTitle"/></h1>
+        <span><FormattedMessage id="client.merge.responseDescription"/></span>
         <EntityResponseTable
-          title={this.props.intl.formatMessage({id: 'client.entityoperation.action.merge.notCopiedRelationsTitle'})}
+          title={this.props.intl.formatMessage({id: 'client.merge.notCopiedRelationsTitle'})}
           responseEntities={this.props.mergeResponse.notCopiedRelations}
         />
         <EntityResponseTable
-          title={this.props.intl.formatMessage({id: 'client.entityoperation.action.merge.notDeletedEntitiesTitle'})}
+          title={this.props.intl.formatMessage({id: 'client.merge.notDeletedEntitiesTitle'})}
           responseEntities={this.props.mergeResponse.notDeletedEntities}
         />
         {(this.props.mergeResponse.showPermissionMessage)
         && <div className="alert alert-info">
-          <FormattedMessage id="client.entityoperation.action.merge.missingReadPermissions"/>
+          <FormattedMessage id="client.merge.missingReadPermissions"/>
         </div>
         }
         <button
           className="btn btn-primary close-button"
           onClick={() => { ExternalEvents.invokeExternalEvent('close') }}
         >
-          <FormattedMessage id="client.entityoperation.action.merge.close"/>
+          <FormattedMessage id="client.merge.close"/>
         </button>
       </div>
     )

--- a/packages/merge/src/components/MergeWizard/MergeWizard.js
+++ b/packages/merge/src/components/MergeWizard/MergeWizard.js
@@ -10,7 +10,7 @@ import './styles.scss'
 
 class MergeStrategy extends React.Component {
   render() {
-    const saveButtonLabel = this.props.intl.formatMessage({id: 'client.entityoperation.action.merge.saveButton'})
+    const saveButtonLabel = this.props.intl.formatMessage({id: 'client.merge.saveButton'})
 
     if (!this.props.mergeResponse.merged) {
       return (

--- a/packages/merge/src/components/Wizard/Wizard.js
+++ b/packages/merge/src/components/Wizard/Wizard.js
@@ -69,7 +69,7 @@ export class Wizard extends React.Component {
               className="btn wizard-back-button"
               onClick={this.backClick}
             >
-              <FormattedMessage id="client.entityoperation.action.merge.back"/>
+              <FormattedMessage id="client.merge.back"/>
             </button>
           }
           {
@@ -79,7 +79,7 @@ export class Wizard extends React.Component {
               onClick={this.nextClick}
               disabled={!this.state.allowNext}
             >
-              <FormattedMessage id="client.entityoperation.action.merge.next"/>
+              <FormattedMessage id="client.merge.next"/>
             </button>
           }
           {

--- a/packages/merge/src/main.js
+++ b/packages/merge/src/main.js
@@ -41,7 +41,7 @@ const init = (id, input, externalEvents) => {
     dispatchInput(store)
 
     addLocaleData([...de, ...en, ...fr, ...it])
-    const initIntlPromise = Intl.initIntl(store, 'entityoperation.action.merge')
+    const initIntlPromise = Intl.initIntl(store, 'merge')
 
     const App = () => (
       <Provider store={store}>


### PR DESCRIPTION
- due to new convention, a package name should not include its usage. therefore 'action' prefix gets removed.
- bump merge to version 0.1.4