### PR TITLE
chore(tocco-client): fix relative backend url

### DIFF
--- a/config/_development.js
+++ b/config/_development.js
@@ -11,6 +11,6 @@ export default config => ({
     }
   },
   globals: Object.assign({}, config.globals, {
-    __BACKEND_URL__: JSON.stringify('http://:8080')
+    __BACKEND_URL__: "'http://' + window.location.hostname + ':8080'"
   })
 })


### PR DESCRIPTION
- 'http://8080' did not proper work as relative backend dev url. 'Fetch' was not able to parse such urls.
- JSON.stringify will not work with the new fix because the expression (window.location.hostname) would be evaluated during compile time