### PR TITLE
feat(tocco-ui): Add support for multiple cell values in `<Table>`

### DIFF
--- a/packages/tocco-ui/src/Table/Table.js
+++ b/packages/tocco-ui/src/Table/Table.js
@@ -10,12 +10,12 @@ import './styles.scss'
 const Table = props => {
   const columnDefinitions = sortBy(props.columnDefinitions, v => v.order)
 
-  const renderValue = (field, record) => {
+  const renderValue = (fields, record) => {
     if (props.cellRenderer) {
-      return props.cellRenderer(field, record)
+      return props.cellRenderer(fields, record)
     } else {
       return (
-        <span>{field.value.toString()}</span>
+        <span>{fields.map(field => field.value).join(', ')}</span>
       )
     }
   }
@@ -55,10 +55,12 @@ const Table = props => {
                 {
                   columnDefinitions.map((c, cidx) => {
                     const id = `${ridx}-${cidx}`
+                    const valueNames = Array.isArray(c.value) ? c.value : [c.value]
+                    const fields = valueNames.map(value => r[value])
                     return (
                       <td key={id}>
                         {
-                          renderValue(r[c.value], r)
+                          renderValue(fields, r)
                         }
                       </td>
                     )
@@ -77,12 +79,16 @@ const Table = props => {
 Table.propTypes = {
   /**
    * Specifies the columns that are displayed. An array of objects containing an optional label, the value which
-   * will be referenced on each record as well as an optional order number. Lower numbers are getting displayed first.
+   * will be referenced (single string or array of strings) on each record as well as an optional order number.
+   * Lower numbers are getting displayed first.
    */
   columnDefinitions: React.PropTypes.arrayOf(
     React.PropTypes.shape(
       {
-        value: React.PropTypes.string.isRequired,
+        value: React.PropTypes.oneOfType([
+          React.PropTypes.string,
+          React.PropTypes.arrayOf(React.PropTypes.string)
+        ]).isRequired,
         label: React.PropTypes.string,
         order: React.PropTypes.int
       }
@@ -96,8 +102,8 @@ Table.propTypes = {
     React.PropTypes.shape
   ).isRequired,
   /**
-   * A cell-renderer allows to render each cell content separately. Given the value as first argument and the whole
-   * record as second, the cell renderer function can return any kind of valid component.
+   * A cell-renderer allows to render each cell content separately. Given the field values as first argument
+   * and the whole record as second, the cell renderer function can return any kind of valid component.
    */
   cellRenderer: React.PropTypes.func,
   /**

--- a/packages/tocco-ui/src/Table/Table.spec.js
+++ b/packages/tocco-ui/src/Table/Table.spec.js
@@ -112,6 +112,16 @@ describe('tocco-ui', function() {
       expect(wrapper.contains('c3')).to.be.true
     })
 
+    it('should join multiple cell values', () => {
+      const record = {a: {value: 'a'}, b: {value: 'b'}}
+
+      const wrapper = shallow(
+        <Table records={[record]} columnDefinitions={[{value: ['a', 'b']}]}/>
+      )
+
+      expect(wrapper.contains('a, b')).to.be.true
+    })
+
     it('should add class attribute to table', () => {
       const wrapper = shallow(
         <Table className="table-striped abc" records={[]} columnDefinitions={[]}/>
@@ -142,8 +152,8 @@ describe('tocco-ui', function() {
       )
 
       expect(cellRenderer).to.have.calledTwice
-      expect(cellRenderer).to.have.been.calledWith(record.a, record)
-      expect(cellRenderer).to.have.been.calledWith(record.b, record)
+      expect(cellRenderer).to.have.been.calledWith([record.a], record)
+      expect(cellRenderer).to.have.been.calledWith([record.b], record)
     })
   })
 })

--- a/packages/tocco-ui/src/Table/example.js
+++ b/packages/tocco-ui/src/Table/example.js
@@ -19,6 +19,10 @@ export default () => {
       label: '#',
       value: 'user_nr',
       order: 0
+    },
+    {
+      label: 'Full name',
+      value: ['lastname', 'firstname']
     }
   ]
 
@@ -53,16 +57,12 @@ export default () => {
     }
   ]
 
-  const cellRenderer = field => {
-    if (field.type === 'counter') {
-      return (
-        <span style={{fontWeight: 'bold'}}>{field.value}</span>
-      )
-    }
-
-    return (
-      <span>{field.value}</span>
-    )
+  const cellRenderer = fields => {
+    const valueElements = fields.map(field =>
+      field.type === 'counter'
+       ? <div style={{fontWeight: 'bold'}}>{field.value}</div>
+       : <div>{field.value}</div>)
+    return <div>{valueElements}</div>
   }
 
   return (


### PR DESCRIPTION
A table cell can contain multiple field values. They are rendered as a comma
separated string (by default, but you can register your own renderer using the
`cellRenderer` prop.