### PR TITLE
chore: flow ignore node_modules folder

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,5 @@
-[libs]
+[ignore]
+.*node_modules.*
 
+[libs]
 flow/declarations


### PR DESCRIPTION
- otherwise various js files from there will throw a warning
 on npm run flow