### PR TITLE
refactor(tocco-ui): FormatedValue remove undefined checks

### DIFF
--- a/packages/tocco-ui/src/FormattedValue/FormattedValue.js
+++ b/packages/tocco-ui/src/FormattedValue/FormattedValue.js
@@ -8,7 +8,9 @@ import provider, {map as typeMap} from './typeFormatterProvider'
 const FormattedValue = props => {
   const isNotDefined = value => (value === undefined || value === null || value === '')
 
-  if (isNotDefined(props.value)) return <span/>
+  if (isNotDefined(props.value)) {
+    return <span/>
+  }
 
   return (
     <span>

--- a/packages/tocco-ui/src/FormattedValue/FormattedValue.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/FormattedValue.spec.js
@@ -15,5 +15,25 @@ describe('tocco-ui', function() {
       const wrapper = shallow(<FormattedValue type="date" value="1976-03-16T12:00:00.000Z"/>)
       expect(wrapper.find(DateFormatter)).to.have.length(1)
     })
+
+    it('should return an empty span on a undefined input', function() {
+      const wrapper = shallow(<FormattedValue type="string" value={undefined}/>)
+      expect(wrapper.html()).to.eql('<span></span>')
+    })
+
+    it('should return an empty span on empty input', function() {
+      const wrapper = shallow(<FormattedValue type="date" value=""/>)
+      expect(wrapper.html()).to.eql('<span></span>')
+    })
+
+    it('should return an empty span on input "null"', function() {
+      const wrapper = shallow(<FormattedValue type="something" value={null}/>)
+      expect(wrapper.html()).to.eql('<span></span>')
+    })
+
+    it('should not return an empty span on input false', function() {
+      const wrapper = shallow(<FormattedValue type="bool" value={false}/>)
+      expect(wrapper.html()).to.not.eql('<span></span>')
+    })
   })
 })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.js
@@ -1,10 +1,6 @@
 import React from 'react'
 
 const BooleanFormatter = props => {
-  if (typeof props.value === 'undefined') {
-    return <span/>
-  }
-
   const icon = props.value ? 'glyphicon-ok' : 'glyphicon-remove'
 
   return (

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.spec.js
@@ -18,13 +18,6 @@ describe('tocco-ui', function() {
         )
         expect(wrapper.html()).to.contains('glyphicon-remove')
       })
-
-      it('should not format undefined value', function() {
-        const wrapper = mount(
-          <BooleanFormatter/>
-        )
-        expect(wrapper.html()).to.equal('<span></span>')
-      })
     })
   })
 })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DecimalFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DecimalFormatter.spec.js
@@ -15,14 +15,20 @@ describe('tocco-ui', function() {
       })
 
       it('should format value', function() {
-        const wrapper = mount(<IntlProvider locale="en"><DecimalFormatter
-          value={1.3}/></IntlProvider>)
+        const wrapper = mount(
+          <IntlProvider locale="en">
+            <DecimalFormatter value={1.3}/>
+          </IntlProvider>
+        )
         expect(wrapper.text()).to.equal('1.30')
       })
 
       it('should format value accorind to locale', function() {
-        const wrapper = mount(<IntlProvider locale="de"><DecimalFormatter
-          value={1.3}/></IntlProvider>)
+        const wrapper = mount(
+          <IntlProvider locale="de">
+            <DecimalFormatter value={1.3}/>
+          </IntlProvider>
+        )
         expect(wrapper.text()).to.equal('1,30')
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
@@ -2,8 +2,7 @@ import React from 'react'
 import {FormattedDate} from 'react-intl'
 
 const DurationFormatter = props => {
-  const milliSeconds = parseInt(props.value) || 0
-
+  const milliSeconds = parseInt(props.value)
   const date = new Date(2000, 1, 1, 0, 0, 0, milliSeconds)
 
   return (

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/MoneyFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/MoneyFormatter.js
@@ -1,17 +1,13 @@
 import React from 'react'
 import {FormattedNumber} from 'react-intl'
 
-const MoneyFormatter = props => {
-  if (props.value) {
-    return (
-      <FormattedNumber
-        value={props.value}
-        style="decimal"
-        minimumFractionDigits={2}
-      />
-    )
-  }
-}
+const MoneyFormatter = props => (
+  <FormattedNumber
+    value={props.value}
+    style="decimal"
+    minimumFractionDigits={2}
+  />
+)
 
 MoneyFormatter.propTypes = {
   value: React.PropTypes.number

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/MoneyFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/MoneyFormatter.spec.js
@@ -14,23 +14,19 @@ describe('tocco-ui', function() {
         addLocaleData([...en, ...de])
       })
 
-      it('should format a money', function() {
+      it('should format a money amount', function() {
         const wrapper = mount(
           <IntlProvider locale="en">
-            <MoneyFormatter
-              value={1245.50}
-            />
+            <MoneyFormatter value={1245.50}/>
           </IntlProvider>
         )
         expect(wrapper.text()).to.equal('1,245.50')
       })
 
-      it('should format a money', function() {
+      it('should format a money amount regarding locale', function() {
         const wrapper = mount(
           <IntlProvider locale="de-CH">
-            <MoneyFormatter
-              value={1245.50}
-            />
+            <MoneyFormatter value={1245.50}/>
           </IntlProvider>
         )
         expect(wrapper.text()).to.equal('1\'245.50')

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/NumberFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/NumberFormatter.js
@@ -1,18 +1,13 @@
 import React from 'react'
 import {FormattedNumber} from 'react-intl'
 
-const NumberFormatter = props => {
-  const content = props.value
-  if (typeof content !== 'undefined' && content !== null) {
-    return (
-      <FormattedNumber
-        value={content}
-        style="decimal"
-        maximumFractionDigits={0}
-      />
-    )
-  }
-}
+const NumberFormatter = props => (
+  <FormattedNumber
+    value={props.value}
+    style="decimal"
+    maximumFractionDigits={0}
+  />
+)
 
 NumberFormatter.propTypes = {
   value: React.PropTypes.number

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/PercentFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/PercentFormatter.js
@@ -1,11 +1,9 @@
 import React from 'react'
 import DecimalFormatter from './DecimalFormatter'
 
-const PercentFormatter = props => {
-  return (
-    <span><DecimalFormatter value={props.value}/>%</span>
-  )
-}
+const PercentFormatter = props => (
+  <span><DecimalFormatter value={props.value}/>%</span>
+)
 
 PercentFormatter.propTypes = {
   value: React.PropTypes.number.isRequired

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/StringFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/StringFormatter.js
@@ -1,18 +1,11 @@
 import React from 'react'
 
-const StringFormatter = props => {
-  const content = props.value
-  if (typeof content === 'undefined' || content === null) {
-    return <span/>
-  }
-
-  return (
-    <span>{content}</span>
-  )
-}
+const StringFormatter = props => (
+  <span>{props.value.toString()}</span>
+)
 
 StringFormatter.propTypes = {
-  value: React.PropTypes.node
+  value: React.PropTypes.any
 }
 
 export default StringFormatter

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TextFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TextFormatter.js
@@ -1,21 +1,17 @@
 import React from 'react'
 
-const TextFormatter = props => {
-  let content = props.value || ''
-
-  return (
-    <span>
-      {
-        content.split('\\n').map((b, idx) => (
-          <div key={idx}>{b}</div>
-        ))
-      }
-    </span>
-  )
-}
+const TextFormatter = props => (
+  <span>
+    {
+      props.value.split('\\n').map((b, idx) => (
+        <div key={idx}>{b}</div>
+      ))
+    }
+  </span>
+)
 
 TextFormatter.propTypes = {
-  value: React.PropTypes.node
+  value: React.PropTypes.string
 }
 
 export default TextFormatter

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
@@ -26,14 +26,20 @@ describe('tocco-ui', function() {
       }
 
       it('should format value', function() {
-        const wrapper = mount(<IntlProvider locale="en"><TimeFormatter
-          value={timeValue}/></IntlProvider>)
+        const wrapper = mount(
+          <IntlProvider locale="en">
+            <TimeFormatter value={timeValue}/>
+          </IntlProvider>
+        )
         expect(wrapper.text().replace(leftToRightMark, '')).to.equal('11:15 PM')
       })
 
       it('should format value accorind to locale', function() {
-        const wrapper = mount(<IntlProvider locale="de"><TimeFormatter
-          value={timeValue}/></IntlProvider>)
+        const wrapper = mount(
+          <IntlProvider locale="de">
+            <TimeFormatter value={timeValue}/>
+          </IntlProvider>
+        )
         expect(wrapper.text().replace(leftToRightMark, '')).to.equal('23:15')
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/UrlFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/UrlFormatter.js
@@ -1,14 +1,8 @@
 import React from 'react'
 
-const UrlFormatter = props => {
-  if (typeof props.value === 'undefined' || props.value === '') {
-    return <span/>
-  }
-
-  return (
-    <span><a href={props.value}>{props.value}</a></span>
-  )
-}
+const UrlFormatter = props => (
+  <span><a href={props.value}>{props.value}</a></span>
+)
 
 UrlFormatter.propTypes = {
   value: React.PropTypes.string

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/UrlFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/UrlFormatter.spec.js
@@ -11,12 +11,6 @@ describe('tocco-ui', function() {
         expect(wrapper.find('a')).to.have.length(1)
         expect(wrapper.find('a')).to.have.attr('href', 'http://www.tocco.ch')
       })
-
-      it('should format value', function() {
-        const wrapper = mount(<UrlFormatter value=""/>)
-        expect(wrapper.find('span')).to.have.length(1)
-        expect(wrapper.find('a')).to.have.length(0)
-      })
     })
   })
 })


### PR DESCRIPTION
 - https://github.com/tocco/tocco-client/commit/81c943757d07da49263f7c72a8bf14c7751b830a
   since 'undefined' values getting handled in root component, the checks can be removed on type implementations