### PR TITLE
fix(tocco-ui): DateTimeEdit fix timezone problem

### DIFF
--- a/packages/tocco-ui/package.json
+++ b/packages/tocco-ui/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^15.2.1"
   },
   "devDependencies": {
-    "flatpickr": "^2.3.4",
+    "flatpickr": "^2.4.2",
     "react-select": "^1.0.0-rc.2",
     "tocco-theme": "0.1.0"
   }

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
@@ -43,8 +43,14 @@ class DateAbstract extends React.Component {
     }
   }
 
-  handleOnChange(selectedDates, dateStr) {
-    this.props.onChange(dateStr)
+  handleOnChange(selectedDates) {
+    if (!selectedDates || selectedDates.length === 0) {
+      this.props.onChange(null)
+    } else if (selectedDates.length === 1) {
+      this.props.onChange(selectedDates[0].toISOString())
+    } else {
+      throw new Error('EditableValue DateTime: unexpected length of input')
+    }
   }
 
   refMapper(ref) {


### PR DESCRIPTION
- A newer version of flatpickr handles timezone input in UTC (Z) format.
  Therefore the onChange event should send changed value also in utc.
- update flatpickr to newest version