### PR TITLE
fix(tocco-ui): fix a date formatter time zone issue

### DIFF
--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import {FormattedDate} from 'react-intl'
+import {convertDateToUTC} from '../util/DateUtils'
 
 const DateFormatter = props => {
   const timestamp = Date.parse(props.value)
+
   if (isNaN(timestamp)) {
     // eslint-disable-next-line no-console
     console.log('DateFormatter: Invalid date', props.value)
@@ -13,7 +15,7 @@ const DateFormatter = props => {
   if (props.value instanceof Date) {
     date = props.value
   } else {
-    date = new Date(new Date(timestamp).getTime() + new Date().getTimezoneOffset() * 60000)
+    date = convertDateToUTC(new Date(timestamp))
   }
 
   return (

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
@@ -9,12 +9,16 @@ const DateFormatter = props => {
     return <span/>
   }
 
-  const date = new Date(timestamp)
+  let date
+  if (props.value instanceof Date) {
+    date = props.value
+  } else {
+    date = new Date(new Date(timestamp).getTime() + new Date().getTimezoneOffset() * 60000)
+  }
 
   return (
     <FormattedDate
       value={date}
-      timeZone="UTC"
       year="numeric"
       month="numeric"
       day="numeric"

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.spec.js
@@ -15,20 +15,33 @@ describe('tocco-ui', function() {
       })
 
       const leftToRightMark = /\u200E/g // required for browser Edge
+      const zeros = /0/g // ms edge displayes dates with leading zeros (e.g. 09.09.2017)
 
-      it('should format value', function() {
+      it('should format value', () => {
         const wrapper = mount(<IntlProvider locale="en"><DateFormatter
           value="1976-11-16"/></IntlProvider>)
         expect(wrapper.text().replace(leftToRightMark, '')).to.equal('11/16/1976')
       })
 
-      it('should format value accorind to locale', function() {
+      it('should format value accorind to locale', () => {
         const wrapper = mount(<IntlProvider locale="de"><DateFormatter
           value="1976-11-16"/></IntlProvider>)
         expect(wrapper.text().replace(leftToRightMark, '')).to.equal('16.11.1976')
       })
 
-      it('should not format invalid date', function() {
+      it('should format value with ISO string', () => {
+        const wrapper = mount(<IntlProvider locale="de"><DateFormatter
+          value="1995-09-09T00:00:00.000Z"/></IntlProvider>)
+        expect(wrapper.text().replace(leftToRightMark, '').replace(zeros, '')).to.equal('9.9.1995')
+      })
+
+      it('should format value with Date object', () => {
+        const wrapper = mount(<IntlProvider locale="de"><DateFormatter
+          value={new Date(1995, 1, 9)}/></IntlProvider>)
+        expect(wrapper.text().replace(leftToRightMark, '').replace(zeros, '')).to.equal('9.2.1995')
+      })
+
+      it('should not format invalid date', () => {
         const wrapper = mount(<IntlProvider locale="de"><DateFormatter
           value="abc123"/></IntlProvider>)
         expect(wrapper.html()).to.equal('<span></span>')

--- a/packages/tocco-ui/src/FormattedValue/util/DateUtils.js
+++ b/packages/tocco-ui/src/FormattedValue/util/DateUtils.js
@@ -1,0 +1,7 @@
+/**
+ * Adds the timezone offset of the current environment to the passed date to get the date for the UTC timezone.
+ */
+export const convertDateToUTC = date => {
+  const timezoneOffset = new Date().getTimezoneOffset() * 60000
+  return new Date(date.getTime() + timezoneOffset)
+}

--- a/packages/tocco-ui/src/FormattedValue/util/DateUtils.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/util/DateUtils.spec.js
@@ -1,0 +1,14 @@
+import {convertDateToUTC} from './DateUtils'
+
+describe('tocco-ui', () => {
+  describe('FormattedValue', () => {
+    describe('DateUtils', () => {
+      it('should convert a date to the UTC timezone', () => {
+        const date = new Date('Tue Feb 28 2017 10:00:00 GMT+0100 (CET)')
+        const dateUTC = convertDateToUTC(date)
+        const localTimezoneOffset = new Date().getTimezoneOffset() * 60000
+        expect(dateUTC).to.be.eql(new Date(date.getTime() + localTimezoneOffset))
+      })
+    })
+  })
+})


### PR DESCRIPTION
Before the time zone was set to UTC fixed. This caused an issue because dates in js alsways
have a time and a time zone. Different browser handle the time zone differently. Some
use the UTC time zone and some use the local time zone (e.g. GMT +2)

Now the time zone is not set to UTC by default anymore. If a date object is passed to the
date formatter, it just will be passed. In this case the time zone handling does not matter.

If a string or a number is passed, the `Date.parse` function is used to parse the date and
the time zone offset will be added to the created date object.