### PR TITLE
Pr/fix dateformatter test saucelabs

### DIFF
--- a/packages/entity-browser/src/dev/entityFactory.js
+++ b/packages/entity-browser/src/dev/entityFactory.js
@@ -1,8 +1,14 @@
 const getRandomDate = (startYear, endYear) => {
   const start = new Date(startYear, 1, 1)
   const end = new Date(endYear, 1, 1)
+
   const date = new Date(+start + Math.random() * (end - start))
-  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+
+  const year = date.getFullYear()
+  const month = ('00' + (date.getMonth() + 1)).slice(-2)
+  const day = ('00' + date.getDate()).slice(-2)
+
+  return `${year}-${month}-${day}`
 }
 
 function getRandomInt(min, max) {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import {FormattedDate} from 'react-intl'
-import {parseLocalDate} from '../util/DateUtils'
+import {matchesIsoDate, parseIsoDate} from '../util/DateUtils'
 
 const DateFormatter = props => {
-  const localDate = parseLocalDate(props.value)
+  const localDate = parseIsoDate(props.value)
 
   if (!localDate) {
     return <span/>
@@ -21,7 +21,7 @@ const DateFormatter = props => {
 
 DateFormatter.propTypes = {
   value: (props, propName, componentName) => {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(props[propName])) {
+    if (!matchesIsoDate(props[propName])) {
       return new Error(`Invalid prop '${propName}' supplied to ${componentName}.`)
     }
   }

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
@@ -1,27 +1,17 @@
 import React from 'react'
 import {FormattedDate} from 'react-intl'
-import {convertDateToUTC} from '../util/DateUtils'
-
-/* eslint no-console: 0 */
+import {parseLocalDate} from '../util/DateUtils'
 
 const DateFormatter = props => {
-  const timestamp = Date.parse(props.value)
+  const localDate = parseLocalDate(props.value)
 
-  if (isNaN(timestamp)) {
+  if (!localDate) {
     return <span/>
-  }
-
-  console.log('props.value', props.value)
-  let date
-  if (props.value instanceof Date) {
-    date = props.value
-  } else {
-    date = convertDateToUTC(new Date(timestamp))
   }
 
   return (
     <FormattedDate
-      value={date}
+      value={localDate}
       year="numeric"
       month="numeric"
       day="numeric"
@@ -30,7 +20,11 @@ const DateFormatter = props => {
 }
 
 DateFormatter.propTypes = {
-  value: React.PropTypes.string.isRequired
+  value: (props, propName, componentName) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(props[propName])) {
+      return new Error(`Invalid prop '${propName}' supplied to ${componentName}.`)
+    }
+  }
 }
 
 export default DateFormatter

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.spec.js
@@ -15,39 +15,32 @@ describe('tocco-ui', function() {
       })
 
       const leftToRightMark = /\u200E/g // required for browser Edge
-      const zeros = /0/g // ms edge displayes dates with leading zeros (e.g. 09.09.2017)
 
-      /* Tests Failing on Saucelabs Safari
-       expected '15.11.1976' to equal '16.11.1976'
+      it('should format value', () => {
+        const wrapper = mount(
+          <IntlProvider locale="en">
+            <DateFormatter value="1976-11-16"/>
+          </IntlProvider>
+        )
 
-       it('should format value', () => {
-       const wrapper = mount(<IntlProvider locale="en"><DateFormatter
-       value="1976-11-16"/></IntlProvider>)
-       expect(wrapper.text().replace(leftToRightMark, '')).to.equal('11/16/1976')
-       })
-
-       it('should format value accorind to locale', () => {
-       const wrapper = mount(<IntlProvider locale="de"><DateFormatter
-       value="1976-11-16"/></IntlProvider>)
-       expect(wrapper.text().replace(leftToRightMark, '')).to.equal('16.11.1976')
-       })
-       */
-
-      it('should format value with ISO string', () => {
-        const wrapper = mount(<IntlProvider locale="de"><DateFormatter
-          value="1995-09-09T00:00:00.000Z"/></IntlProvider>)
-        expect(wrapper.text().replace(leftToRightMark, '').replace(zeros, '')).to.equal('9.9.1995')
+        expect(wrapper.text().replace(leftToRightMark, '')).to.equal('11/16/1976')
       })
 
-      it('should format value with Date object', () => {
-        const wrapper = mount(<IntlProvider locale="de"><DateFormatter
-          value={new Date(1995, 1, 9)}/></IntlProvider>)
-        expect(wrapper.text().replace(leftToRightMark, '').replace(zeros, '')).to.equal('9.2.1995')
+      it('should format value according to locale', () => {
+        const wrapper = mount(
+          <IntlProvider locale="de">
+            <DateFormatter value="1976-11-16"/>
+          </IntlProvider>
+        )
+        expect(wrapper.text().replace(leftToRightMark, '')).to.equal('16.11.1976')
       })
 
       it('should not format invalid date', () => {
-        const wrapper = mount(<IntlProvider locale="de"><DateFormatter
-          value="abc123"/></IntlProvider>)
+        const wrapper = mount(
+          <IntlProvider locale="de">
+            <DateFormatter value="abc123"/>
+          </IntlProvider>
+        )
         expect(wrapper.html()).to.equal('<span></span>')
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/util/DateUtils.js
+++ b/packages/tocco-ui/src/FormattedValue/util/DateUtils.js
@@ -1,7 +1,13 @@
-/**
- * Adds the timezone offset of the current environment to the passed date to get the date for the UTC timezone.
- */
-export const convertDateToUTC = date => {
-  const timezoneOffset = new Date().getTimezoneOffset() * 60000
-  return new Date(date.getTime() + timezoneOffset)
+export const parseLocalDate = s => {
+  if (!s || !/^\d{4}-\d{2}-\d{2}$/.test(s)) {
+    return null
+  }
+
+  const parts = s.split(/\D/)
+
+  const year = parseInt(parts[0])
+  const month = parseInt(parts[1]) - 1
+  const day = parseInt(parts[2])
+
+  return new Date(year, month, day)
 }

--- a/packages/tocco-ui/src/FormattedValue/util/DateUtils.js
+++ b/packages/tocco-ui/src/FormattedValue/util/DateUtils.js
@@ -1,9 +1,24 @@
-export const parseLocalDate = s => {
-  if (!s || !/^\d{4}-\d{2}-\d{2}$/.test(s)) {
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Tests if a date string matches the ISO date pattern (YYYY-MM-DD)
+ *
+ * @param dateString The date string to test.
+ */
+export const matchesIsoDate = dateString => ISO_DATE_PATTERN.test(dateString)
+
+/**
+ * Creates a Date object from a date string.
+ *
+ * @param isoDateString The ISO 8601 date string (must match YYYY-MM-DD)
+ * @returns {Date} the created Date object or null, if the given string doesn't match YYYY-MM-DD.
+ */
+export const parseIsoDate = isoDateString => {
+  if (!matchesIsoDate(isoDateString)) {
     return null
   }
 
-  const parts = s.split(/\D/)
+  const parts = isoDateString.split(/\D/)
 
   const year = parseInt(parts[0])
   const month = parseInt(parts[1]) - 1

--- a/packages/tocco-ui/src/FormattedValue/util/DateUtils.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/util/DateUtils.spec.js
@@ -1,13 +1,33 @@
-import {convertDateToUTC} from './DateUtils'
+import {parseLocalDate} from './DateUtils'
 
 describe('tocco-ui', () => {
   describe('FormattedValue', () => {
-    describe('DateUtils', () => {
-      it('should convert a date to the UTC timezone', () => {
-        const date = new Date('Tue Feb 28 2017 10:00:00 GMT+0100 (CET)')
-        const dateUTC = convertDateToUTC(date)
-        const localTimezoneOffset = new Date().getTimezoneOffset() * 60000
-        expect(dateUTC).to.be.eql(new Date(date.getTime() + localTimezoneOffset))
+    describe('util', () => {
+      describe('DateUtils', () => {
+        describe('parseLocalDate', () => {
+          it('should parse a valid local date string', () => {
+            const localDate = parseLocalDate('2017-03-27')
+
+            expect(localDate.getFullYear()).to.be.eql(2017)
+            expect(localDate.getMonth()).to.be.eql(2)
+            expect(localDate.getDate()).to.be.eql(27)
+
+            expect(localDate.getHours()).to.be.eql(0)
+            expect(localDate.getMinutes()).to.be.eql(0)
+            expect(localDate.getSeconds()).to.be.eql(0)
+            expect(localDate.getMilliseconds()).to.be.eql(0)
+          })
+
+          it('should return null if invalid date given', () => {
+            const localDate = parseLocalDate('invalid')
+            expect(localDate).to.be.null
+          })
+
+          it('should return null if no date given', () => {
+            const localDate = parseLocalDate(null)
+            expect(localDate).to.be.null
+          })
+        })
       })
     })
   })

--- a/packages/tocco-ui/src/FormattedValue/util/DateUtils.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/util/DateUtils.spec.js
@@ -1,31 +1,45 @@
-import {parseLocalDate} from './DateUtils'
+import {matchesIsoDate, parseIsoDate} from './DateUtils'
 
 describe('tocco-ui', () => {
   describe('FormattedValue', () => {
     describe('util', () => {
       describe('DateUtils', () => {
-        describe('parseLocalDate', () => {
-          it('should parse a valid local date string', () => {
-            const localDate = parseLocalDate('2017-03-27')
+        describe('matchesIsoDate', () => {
+          it('should return true if date string is valid', () => {
+            expect(matchesIsoDate('2017-03-27')).to.be.true
+          })
 
-            expect(localDate.getFullYear()).to.be.eql(2017)
-            expect(localDate.getMonth()).to.be.eql(2)
-            expect(localDate.getDate()).to.be.eql(27)
+          it('should return false if date string is invalid', () => {
+            expect(matchesIsoDate('invalid')).to.be.false
+          })
 
-            expect(localDate.getHours()).to.be.eql(0)
-            expect(localDate.getMinutes()).to.be.eql(0)
-            expect(localDate.getSeconds()).to.be.eql(0)
-            expect(localDate.getMilliseconds()).to.be.eql(0)
+          it('should return false if no date string given', () => {
+            expect(matchesIsoDate(null)).to.be.false
+          })
+        })
+
+        describe('parseIsoDate', () => {
+          it('should parse a valid date string', () => {
+            const date = parseIsoDate('2017-03-27')
+
+            expect(date.getFullYear()).to.be.eql(2017)
+            expect(date.getMonth()).to.be.eql(2)
+            expect(date.getDate()).to.be.eql(27)
+
+            expect(date.getHours()).to.be.eql(0)
+            expect(date.getMinutes()).to.be.eql(0)
+            expect(date.getSeconds()).to.be.eql(0)
+            expect(date.getMilliseconds()).to.be.eql(0)
           })
 
           it('should return null if invalid date given', () => {
-            const localDate = parseLocalDate('invalid')
-            expect(localDate).to.be.null
+            const date = parseIsoDate('invalid')
+            expect(date).to.be.null
           })
 
           it('should return null if no date given', () => {
-            const localDate = parseLocalDate(null)
-            expect(localDate).to.be.null
+            const date = parseIsoDate(null)
+            expect(date).to.be.null
           })
         })
       })


### PR DESCRIPTION
Also see:

http://stackoverflow.com/questions/33908299/javascript-parse-a-string-to-date-as-local-time-zone

"Parsing of date strings using the Date constructor or Date.parse (which are essentially the same thing) is strongly recommended against."