### PR TITLE
Pr/tocco ui/remote select properties

### DIFF
--- a/packages/entity-browser/src/components/FormField/formFieldUtil.js
+++ b/packages/entity-browser/src/components/FormField/formFieldUtil.js
@@ -81,6 +81,12 @@ const getOptions = (formField, modelField, util) => {
         // eslint-disable-next-line no-console
         console.log('click value', value)
       }
+
+      if (util.intl) {
+        options.searchPromptText = util.intl.formatMessage({id: 'client.component.remoteselect.searchPromptText'})
+        options.clearValueText = util.intl.formatMessage({id: 'client.component.remoteselect.clearValueText'})
+        options.clearAllText = util.intl.formatMessage({id: 'client.component.remoteselect.clearAllText'})
+      }
       break
   }
 

--- a/packages/entity-browser/src/components/FormField/formFieldUtil.spec.js
+++ b/packages/entity-browser/src/components/FormField/formFieldUtil.spec.js
@@ -1,0 +1,71 @@
+import {getEditableValueProps} from './formFieldUtil'
+
+describe('entity-browser', () => {
+  describe('components', () => {
+    describe('FormField', () => {
+      describe('formFieldUtil', () => {
+        it('should get editable value props for RemoteField', () => {
+          const formField = {
+            type: 'ch.tocco.nice2.model.form.components.simple.RemoteField'
+          }
+
+          const modelField = {
+            targetEntity: 'Dummy'
+          }
+
+          const formatMessage = sinon.spy()
+
+          const util = {
+            intl: {
+              formatMessage: formatMessage
+            }
+          }
+
+          const props = getEditableValueProps(formField, modelField, util)
+
+          const id1 = {id: 'client.component.remoteselect.searchPromptText'}
+          const id2 = {id: 'client.component.remoteselect.clearValueText'}
+          const id3 = {id: 'client.component.remoteselect.clearAllText'}
+
+          expect(formatMessage).to.have.been.calledWith(id1)
+          expect(formatMessage).to.have.been.calledWith(id2)
+          expect(formatMessage).to.have.been.calledWith(id3)
+
+          expect(typeof props.options.fetchOptions).to.be.eql('function')
+          expect(props.events).to.be.eql({})
+        })
+
+        it('should get editable value props for MultiRemoteField', () => {
+          const formField = {
+            type: 'ch.tocco.nice2.model.form.components.simple.MultiRemoteField'
+          }
+
+          const modelField = {
+            targetEntity: 'Dummy'
+          }
+
+          const formatMessage = sinon.spy()
+
+          const util = {
+            intl: {
+              formatMessage: formatMessage
+            }
+          }
+
+          const props = getEditableValueProps(formField, modelField, util)
+
+          const id1 = {id: 'client.component.remoteselect.searchPromptText'}
+          const id2 = {id: 'client.component.remoteselect.clearValueText'}
+          const id3 = {id: 'client.component.remoteselect.clearAllText'}
+
+          expect(formatMessage).to.have.been.calledWith(id1)
+          expect(formatMessage).to.have.been.calledWith(id2)
+          expect(formatMessage).to.have.been.calledWith(id3)
+
+          expect(typeof props.options.fetchOptions).to.be.eql('function')
+          expect(props.events).to.be.eql({})
+        })
+      })
+    })
+  })
+})

--- a/packages/entity-browser/src/dev/rest-responses/messages.json
+++ b/packages/entity-browser/src/dev/rest-responses/messages.json
@@ -18,5 +18,9 @@
   "client.entity-browser.saveSuccessfulTitle",
   "client.entity-browser.saveSuccessfulMessage",
   "client.entity-browser.lastSave",
-  "client.entity-browser.backToList"
+  "client.entity-browser.backToList",
+  "client.component.remoteselect.searchPromptText",
+  "client.component.remoteselect.clearValueText",
+  "client.component.remoteselect.clearAllText",
+  "client.component.remoteselect.noResultsText"
 ]

--- a/packages/entity-browser/src/routes/detail/components/DetailForm/DetailForm.js
+++ b/packages/entity-browser/src/routes/detail/components/DetailForm/DetailForm.js
@@ -29,7 +29,8 @@ export class DetailForm extends React.Component {
 
     const editableValueUtils = {
       relationEntities: this.props.relationEntities,
-      loadRelationEntity: this.props.loadRelationEntity
+      loadRelationEntity: this.props.loadRelationEntity,
+      intl: this.props.intl
     }
 
     return (

--- a/packages/tocco-ui/src/EditableValue/example.js
+++ b/packages/tocco-ui/src/EditableValue/example.js
@@ -153,7 +153,9 @@ class Example extends React.Component {
                   readOnly={this.state.readOnly}
                   value={this.state.values.remote}
                   options={{
-                    fetchOptions: this.fetchRemoteOptions
+                    fetchOptions: this.fetchRemoteOptions,
+                    searchPromptText: 'Type to search',
+                    clearValueText: 'Clear value'
                   }}
                 />
               </td>
@@ -167,7 +169,9 @@ class Example extends React.Component {
                   readOnly={this.state.readOnly}
                   value={this.state.values.multiRemote}
                   options={{
-                    fetchOptions: this.fetchRemoteOptions
+                    fetchOptions: this.fetchRemoteOptions,
+                    searchPromptText: 'Type to search',
+                    clearAllText: 'Clear all values'
                   }}
                 />
               </td>

--- a/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.js
@@ -20,8 +20,9 @@ class MultiRemoteSelect extends React.Component {
           labelKey="display"
           loadingPlaceholder="Laden"
           placeholder=""
-          searchPromptText="Tippen, um zu suchen"
-          noResultsText="-"
+          searchPromptText={this.props.options.searchPromptText}
+          clearAllText={this.props.options.clearAllText}
+          noResultsText={this.props.options.noResultsText}
           multi
           value={this.props.value}
           onChange={this.props.onChange}
@@ -47,7 +48,10 @@ MultiRemoteSelect.propTypes = {
   ),
   options: React.PropTypes.shape({
     fetchOptions: React.PropTypes.func,
-    valueClick: React.PropTypes.func
+    valueClick: React.PropTypes.func,
+    clearAllText: React.PropTypes.string,
+    searchPromptText: React.PropTypes.string,
+    noResultsText: React.PropTypes.string
   }),
   readOnly: React.PropTypes.bool
 }

--- a/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.spec.js
@@ -9,13 +9,23 @@ describe('tocco-ui', () => {
     describe('typeEditors', () => {
       describe('MultiRemoteSelect ', () => {
         it('should render a Async Select component', () => {
+          const options = {
+            clearAllText: 'CLEAR_ALL_TEXT',
+            searchPromptText: 'SEARCH_PROMPT_TEXT',
+            noResultsText: 'NO_RESULTS_TEXT'
+          }
+
           const wrapper = shallow(
             <MultiRemoteSelect
-              options={{}}
+              options={options}
               value={[{key: 2, display: 'Two'}]}
               onChange={() => {}}
             />)
+
           expect(wrapper.find(Select.Async)).to.have.length(1)
+          expect(wrapper.find(Select.Async).prop('clearAllText')).to.be.eql('CLEAR_ALL_TEXT')
+          expect(wrapper.find(Select.Async).prop('searchPromptText')).to.be.eql('SEARCH_PROMPT_TEXT')
+          expect(wrapper.find(Select.Async).prop('noResultsText')).to.be.eql('NO_RESULTS_TEXT')
         })
 
         it('should call onChange ', () => {

--- a/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
@@ -20,8 +20,9 @@ class RemoteSelect extends React.Component {
           labelKey="display"
           loadingPlaceholder="Laden"
           placeholder=""
-          searchPromptText="Tippen, um zu suchen"
-          noResultsText="-"
+          clearValueText={this.props.options.clearValueText}
+          searchPromptText={this.props.options.searchPromptText}
+          noResultsText={this.props.options.noResultsText}
           multi={false}
           value={this.props.value}
           onChange={this.props.onChange}
@@ -46,7 +47,10 @@ RemoteSelect.propTypes = {
     }),
   options: React.PropTypes.shape({
     fetchOptions: React.PropTypes.func,
-    valueClick: React.PropTypes.func
+    valueClick: React.PropTypes.func,
+    clearValueText: React.PropTypes.string,
+    searchPromptText: React.PropTypes.string,
+    noResultsText: React.PropTypes.string
   }),
   readOnly: React.PropTypes.bool
 }

--- a/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.spec.js
@@ -9,8 +9,23 @@ describe('tocco-ui', () => {
     describe('typeEditors', () => {
       describe('RemoteSelect ', () => {
         it('should render a Async Select component', () => {
-          const wrapper = shallow(<RemoteSelect options={{}} value={{key: 2, display: 'Two'}} onChange={() => {}}/>)
+          const options = {
+            clearValueText: 'CLEAR_VALUE_TEXT',
+            searchPromptText: 'SEARCH_PROMPT_TEXT',
+            noResultsText: 'NO_RESULTS_TEXT'
+          }
+
+          const wrapper = shallow(
+            <RemoteSelect
+              options={options}
+              value={{key: 2, display: 'Two'}}
+              onChange={() => {}}
+            />)
+
           expect(wrapper.find(Select.Async)).to.have.length(1)
+          expect(wrapper.find(Select.Async).prop('clearValueText')).to.be.eql('CLEAR_VALUE_TEXT')
+          expect(wrapper.find(Select.Async).prop('searchPromptText')).to.be.eql('SEARCH_PROMPT_TEXT')
+          expect(wrapper.find(Select.Async).prop('noResultsText')).to.be.eql('NO_RESULTS_TEXT')
         })
 
         it('should call onChange ', () => {


### PR DESCRIPTION
Add some properties to the remote select components to set customized text on the components.
The following four new properties have been added to the RemoteSelect and MultiRemoteSelect components:
- searchPromptText
- clearValueText
- clearAllText
- noResultsText

In the DetailForm component we use the intl.formatMessage function to provide localized strings.