### PR TITLE
fix(tocco-ui-showcase): Add `tocco-ui-theme` class again for showcase

### DIFF
--- a/packages/tocco-ui-showcase/src/components/ShowCaseApp.js
+++ b/packages/tocco-ui-showcase/src/components/ShowCaseApp.js
@@ -33,7 +33,7 @@ export default class ShowCaseApp extends React.Component {
   render() {
     return (
       <IntlProvider locale={this.state.locale}>
-        <div className="show-case-app">
+        <div className="show-case-app tocco-ui-theme">
           <div className="col title">
             <span>Tocco UI</span>
           </div>

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
@@ -31,6 +31,7 @@ class DateAbstract extends React.Component {
     }
 
     this.flatpickr = new Flatpickr(this.wrapper, options)
+    this.flatpickr.calendarContainer.classList.add('tocco-ui-theme')
   }
 
   componentWillReceiveProps(props) {

--- a/server/index.html
+++ b/server/index.html
@@ -13,7 +13,7 @@
   <script src="node_modules/react/dist/react.js"></script>
   <script src="node_modules/react-dom/dist/react-dom.js"></script>
 </head>
-<body>
+<body style="margin: 0;">
   <div id="root"></div>
 </body>
 </html>

--- a/server/standalone.html
+++ b/server/standalone.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.0/react.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.0/react-dom.js"></script>
 </head>
-<body>
+<body style="margin: 0;">
   <div id="root"></div>
 </body>
 </html>


### PR DESCRIPTION
The class has been removed in index.html and standalone.html in commit 0ae1cea.
That's okay, but we have to add it on the root of the showcase app, so that it
looks nice again.