### PR TITLE
fix(entity-list): Readd action `loadRelationEntity`

### DIFF
--- a/packages/entity-list/src/containers/SearchFormContainer.js
+++ b/packages/entity-list/src/containers/SearchFormContainer.js
@@ -1,11 +1,11 @@
 import {connect} from 'react-redux'
 import {injectIntl} from 'react-intl'
 import SearchForm from '../components/SearchForm'
-import {setSearchInput, reset, setShowExtendedSearchForm} from '../modules/searchForm/actions'
+import {setSearchInput, reset, setShowExtendedSearchForm, loadRelationEntity} from '../modules/searchForm/actions'
 
 const mapActionCreators = {
   setSearchInput,
-  loadRelationEntity: () => {},
+  loadRelationEntity,
   reset,
   setShowExtendedSearchForm
 }
@@ -13,7 +13,7 @@ const mapActionCreators = {
 const mapStateToProps = (state, props) => ({
   searchFormDefinition: state.searchForm.formDefinition,
   entityModel: state.list.entityModel,
-  relationEntities: state.input.relationEntities,
+  relationEntities: state.searchForm.relationEntities,
   searchInputs: state.searchForm.searchInputs,
   disableSimpleSearch: state.searchForm.disableSimpleSearch,
   simpleSearchFields: state.searchForm.simpleSearchFields,

--- a/packages/entity-list/src/modules/searchForm/actions.js
+++ b/packages/entity-list/src/modules/searchForm/actions.js
@@ -1,6 +1,8 @@
 export const INITIALIZE = 'searchForm/INITIALIZE'
 export const SET_FORM_DEFINITION = 'searchForm/SET_FORM_DEFINITION'
-export const SET_RELATION_ENTITIES = 'searchForm/SET_RELATION_ENTITIES'
+export const LOAD_RELATION_ENTITY = 'searchForm/LOAD_RELATION_ENTITY'
+export const SET_RELATION_ENTITY = 'searchForm/SET_RELATION_ENTITY'
+export const SET_RELATION_ENTITY_LOADED = 'searchForm/SET_RELATION_ENTITY_LOADED'
 export const SET_SEARCH_INPUT = 'searchForm/SET_SEARCH_INPUT'
 export const SEARCH_TERM_CHANGE = 'searchForm/SEARCH_TERM_CHANGE'
 export const RESET = 'searchForm/RESET'
@@ -17,6 +19,29 @@ export const setFormDefinition = formDefinition => ({
   type: SET_FORM_DEFINITION,
   payload: {
     formDefinition
+  }
+})
+
+export const loadRelationEntity = entityName => ({
+  type: LOAD_RELATION_ENTITY,
+  payload: {
+    entityName
+  }
+})
+
+export const setRelationEntityLoaded = entityName => ({
+  type: SET_RELATION_ENTITY_LOADED,
+  payload: {
+    entityName
+  }
+})
+
+export const setRelationEntity = (entityName, entities, reset = false) => ({
+  type: SET_RELATION_ENTITY,
+  payload: {
+    entityName,
+    entities,
+    reset
   }
 })
 

--- a/packages/entity-list/src/modules/searchForm/reducer.js
+++ b/packages/entity-list/src/modules/searchForm/reducer.js
@@ -55,6 +55,41 @@ const setSimpleSearchFields = (state, {payload}) => {
   return state
 }
 
+const setRelationEntity = (state, {payload}) => {
+  const relationEntities = {...state.relationEntities}
+
+  if (!relationEntities[payload.entityName]) {
+    relationEntities[payload.entityName] = {}
+  }
+
+  if (payload.reset) {
+    relationEntities[payload.entityName] = {}
+    relationEntities[payload.entityName].data = payload.entities
+  } else {
+    if (!relationEntities[payload.entityName].data) {
+      relationEntities[payload.entityName].data = []
+    }
+
+    payload.entities.forEach(entity => {
+      const idx = relationEntities[payload.entityName].data.findIndex(e => e.value === entity.value)
+      if (idx === -1) {
+        relationEntities[payload.entityName].data.push(entity)
+      }
+    })
+  }
+
+  return {...state, relationEntities}
+}
+
+const setRelationEntityLoaded = (state, {payload}) => {
+  const relationEntities = {...state.relationEntities}
+  if (!relationEntities[payload.entityName]) {
+    relationEntities[payload.entityName] = {}
+  }
+  relationEntities[payload.entityName].loaded = true
+  return {...state, relationEntities}
+}
+
 const ACTION_HANDLERS = {
   [actions.SET_SEARCH_INPUT]: setSearchInput,
   [actions.RESET]: reset,
@@ -62,7 +97,9 @@ const ACTION_HANDLERS = {
   [actions.SET_FORM_DEFINITION]: reducers.singleTransferReducer('formDefinition'),
   [actions.SET_SHOW_EXTENDED_SEARCH_FORM]: reducers.singleTransferReducer('showExtendedSearchForm'),
   [actions.SET_PRESELECTED_SEARCH_FIELDS]: setPreselectedSearchFields,
-  [actions.SET_DISABLE_SIMPLE_SEARCH]: reducers.singleTransferReducer('disableSimpleSearch')
+  [actions.SET_DISABLE_SIMPLE_SEARCH]: reducers.singleTransferReducer('disableSimpleSearch'),
+  [actions.SET_RELATION_ENTITY]: setRelationEntity,
+  [actions.SET_RELATION_ENTITY_LOADED]: setRelationEntityLoaded
 }
 
 const initialState = {
@@ -71,7 +108,8 @@ const initialState = {
   showExtendedSearchForm: false,
   simpleSearchFields: ['txtFulltext'],
   preselectedSearchFields: [],
-  disableSimpleSearch:false
+  disableSimpleSearch: false,
+  relationEntities: {}
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/entity-list/src/modules/searchForm/reducer.spec.js
+++ b/packages/entity-list/src/modules/searchForm/reducer.spec.js
@@ -7,7 +7,8 @@ const EXPECTED_INITIAL_STATE = {
   showExtendedSearchForm: false,
   simpleSearchFields: ['txtFulltext'],
   preselectedSearchFields: [],
-  disableSimpleSearch:false
+  disableSimpleSearch: false,
+  relationEntities: {}
 }
 
 describe('entity-list', () => {
@@ -54,6 +55,127 @@ describe('entity-list', () => {
 
           expect(stateNew.searchInputs).to.deep.equal({ID1: 'VALUE1', ID2: 'VALUE2'})
           expect(stateNew.preselectedSearchFields).to.deep.equal(preselectedSearchFields)
+        })
+
+        describe('setRelationEntity', () => {
+          it('should add new entities', () => {
+            const stateBefore = {
+              relationEntities: {}
+            }
+
+            const entities = [
+              {value: 1, label: 'User1'},
+              {value: 2, label: 'User2'}
+            ]
+
+            const expectedStateAfter = {
+              relationEntities: {
+                User: {
+                  data: entities
+                }
+              }
+            }
+            expect(reducer(stateBefore, actions.setRelationEntity('User', entities))).to.deep.equal(expectedStateAfter)
+          })
+
+          it('should add entities to existing and do not override', () => {
+            const stateBefore = {
+              relationEntities: {
+                User: {
+                  data: [
+                    {value: 1, label: 'User1'},
+                    {value: 2, label: 'User2'}
+                  ]
+                }
+              }
+            }
+
+            const entities = [
+              {value: 2, label: 'User2 new'},
+              {value: 3, label: 'User3'}
+            ]
+
+            const expectedStateAfter = {
+              relationEntities: {
+                User: {
+                  data: [
+                    {value: 1, label: 'User1'},
+                    {value: 2, label: 'User2'},
+                    {value: 3, label: 'User3'}
+                  ]
+                }
+              }
+            }
+            expect(reducer(stateBefore, actions.setRelationEntity('User', entities))).to.deep.equal(expectedStateAfter)
+          })
+
+          it('should add entities to existing and override with reset', () => {
+            const stateBefore = {
+              relationEntities: {
+                User: {
+                  data: [
+                    {value: 1, label: 'User1'},
+                    {value: 2, label: 'User2'}
+                  ]
+                }
+              }
+            }
+
+            const entities = [
+              {value: 2, label: 'User2 new'},
+              {value: 3, label: 'User3'}
+            ]
+
+            const expectedStateAfter = {
+              relationEntities: {
+                User: {
+                  data: [
+                    {value: 2, label: 'User2 new'},
+                    {value: 3, label: 'User3'}
+                  ]
+                }
+              }
+            }
+
+            expect(reducer(stateBefore, actions.setRelationEntity('User', entities, true)))
+              .to.deep.equal(expectedStateAfter)
+          })
+        })
+
+        describe('setRelationEntityLoaded', () => {
+          it('should set loaded', () => {
+            const stateBefore = {
+              relationEntities: {
+                User: {
+                  loaded: false
+                }
+              }
+            }
+
+            const expectedStateAfter = {
+              relationEntities: {
+                User: {
+                  loaded: true
+                }
+              }
+            }
+            expect(reducer(stateBefore, actions.setRelationEntityLoaded('User'))).to.deep.equal(expectedStateAfter)
+          })
+
+          it('should handle empty entity', () => {
+            const stateBefore = {
+              relationEntities: {}
+            }
+
+            const expectedStateAfter = {
+              relationEntities: {
+                User: {
+                  loaded: true
+                }
+              }
+            }
+            expect(reducer(stateBefore, actions.setRelationEntityLoaded('User'))).to.deep.equal(expectedStateAfter)
+          })
         })
       })
     })

--- a/packages/entity-list/src/modules/searchForm/sagas.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.js
@@ -3,6 +3,7 @@ import {delay} from 'redux-saga'
 import {call, put, fork, select, takeLatest} from 'redux-saga/effects'
 import * as actions from './actions'
 import {fetchForm, searchFormTransformer} from '../../util/api/forms'
+import {fetchEntities, selectEntitiesTransformer} from '../../util/api/entities'
 export const searchFormSelector = state => state.searchForm
 export const inputSelector = state => state.input
 
@@ -10,7 +11,8 @@ export default function* sagas() {
   yield [
     fork(takeLatest, actions.INITIALIZE, initialize),
     fork(takeLatest, actions.SET_SEARCH_INPUT, setSearchTerm),
-    fork(takeLatest, actions.RESET, setSearchTerm)
+    fork(takeLatest, actions.RESET, setSearchTerm),
+    fork(takeLatest, actions.LOAD_RELATION_ENTITY, loadRelationEntity)
   ]
 }
 
@@ -57,4 +59,14 @@ export function* setSearchTerm() {
   yield call(delay, 400)
   const {searchValues} = yield select(searchFormSelector)
   yield put(actions.searchTermChange(searchValues))
+}
+
+export function* loadRelationEntity({payload}) {
+  const {entityName} = payload
+  const {relationEntities} = yield select(searchFormSelector)
+  if (!relationEntities[entityName] || !relationEntities[entityName].loaded) {
+    const entities = yield call(fetchEntities, entityName, {}, selectEntitiesTransformer)
+    yield put(actions.setRelationEntity(entityName, entities, true))
+    yield put(actions.setRelationEntityLoaded(entityName))
+  }
 }


### PR DESCRIPTION
Before the entity list has become a separate package, this action (and the
reducer and the sagas) were part of the parent module "entity-browser" and we
didn't have to implement it in the list by ourselves.