### PR TITLE
feat(tocco-util): Introduce "shared" saga to fire an external event

### DIFF
--- a/packages/entity-list/README.md
+++ b/packages/entity-list/README.md
@@ -1,1 +1,11 @@
 # Entity List
+
+## Embedding
+
+React-registry name: `entity-list`
+
+### Events
+
+| Name          | Payload                       | Description
+|---------------|-------------------------------|-------------
+| `onRowClick`  | `id` (The id of the record)   | This event is fired when a list row is clicked

--- a/packages/entity-list/src/containers/ListViewContainer.js
+++ b/packages/entity-list/src/containers/ListViewContainer.js
@@ -2,12 +2,14 @@ import {connect} from 'react-redux'
 import {injectIntl} from 'react-intl'
 import ListView from '../components/ListView'
 import {initialize, changePage, setOrderBy, refresh} from '../modules/list/actions'
+import {externalEvents} from 'tocco-util'
 
 const mapActionCreators = {
   initialize,
   changePage,
   setOrderBy,
-  refresh
+  refresh,
+  onRowClick: id => externalEvents.fireExternalEvent('onRowClick', { id })
 }
 
 const mapStateToProps = (state, props) => {

--- a/packages/tocco-util/src/externalEvents/externalEvents.js
+++ b/packages/tocco-util/src/externalEvents/externalEvents.js
@@ -1,5 +1,17 @@
 import consoleLogger from '../consoleLogger'
+import {call} from 'redux-saga/effects'
+
 let events = {}
+
+export const FIRE_EXTERNAL_EVENT = 'FIRE_EXTERNAL_EVENT'
+
+export const fireExternalEvent = (name, payload) => ({
+  type: FIRE_EXTERNAL_EVENT,
+  payload: {
+    name,
+    payload
+  }
+})
 
 export const registerEvents = externalEvents => {
   events = {...events, ...externalEvents}
@@ -14,6 +26,11 @@ export const invokeExternalEvent = (eventName, ...args) => {
   if (events[eventName]) {
     events[eventName](...args)
   }
+}
+
+export function* fireExternalEventSaga(action) {
+  const {name, payload} = action.payload
+  yield call(invokeExternalEvent, name, payload)
 }
 
 export const getEvents = () => {

--- a/packages/tocco-util/src/externalEvents/externalEvents.spec.js
+++ b/packages/tocco-util/src/externalEvents/externalEvents.spec.js
@@ -1,29 +1,68 @@
-import {registerEvents, getEvents, invokeExternalEvent} from './externalEvents'
+import * as externalEvents from './externalEvents'
+import {call} from 'redux-saga/effects'
 
 describe('tocco-util', () => {
-  describe('ExternalEvents', () => {
-    it('should register event handlers', () => {
-      registerEvents({success: () => {}})
-      expect(getEvents()).to.deep.equal(['success'])
+  describe('externalEvents', () => {
+    describe('fireExternalEvent', () => {
+      it('should create a FIRE_EXTERNAL_EVENT action', () => {
+        const eventName = 'success'
+        const payload = {
+          prop1: 'value1',
+          prop2: 'value2'
+        }
+
+        const action = externalEvents.fireExternalEvent(eventName, payload)
+
+        expect(action).to.deep.equal({
+          type: externalEvents.FIRE_EXTERNAL_EVENT,
+          payload: {
+            name: eventName,
+            payload
+          }
+        })
+      })
     })
 
-    it('should invoke event handler', () => {
-      const handler = sinon.spy()
-      registerEvents({success: handler})
-      invokeExternalEvent('success')
-      expect(handler).to.have.property('callCount', 1)
+    describe('registerEvents', () => {
+      it('should register event handlers', () => {
+        externalEvents.registerEvents({success: () => {}})
+        expect(externalEvents.getEvents()).to.deep.equal(['success'])
+      })
     })
 
-    it('should pass arguments to event handler', () => {
-      const handler = sinon.spy()
-      registerEvents({success: handler})
-      invokeExternalEvent('success', 'arg1', 'arg2', 'arg3')
-      expect(handler).to.have.been.calledWith('arg1', 'arg2', 'arg3')
+    describe('invokeExternalEvent', () => {
+      it('should invoke event handler', () => {
+        const handler = sinon.spy()
+        externalEvents.registerEvents({success: handler})
+        externalEvents.invokeExternalEvent('success')
+        expect(handler).to.have.property('callCount', 1)
+      })
+
+      it('should pass arguments to event handler', () => {
+        const handler = sinon.spy()
+        externalEvents.registerEvents({success: handler})
+        externalEvents.invokeExternalEvent('success', 'arg1', 'arg2', 'arg3')
+        expect(handler).to.have.been.calledWith('arg1', 'arg2', 'arg3')
+      })
+
+      it('should ignore unknown events', done => {
+        externalEvents.invokeExternalEvent('unknown')
+        done()
+      })
     })
 
-    it('should ignore unknown events', done => {
-      invokeExternalEvent('unknown')
-      done()
+    describe('fireExternalEventSaga', () => {
+      it('should call invokeExternalEvent', () => {
+        const eventName = 'success'
+        const payload = {
+          prop1: 'value1',
+          prop2: 'value2'
+        }
+        const action = externalEvents.fireExternalEvent(eventName, payload)
+        const generator = externalEvents.fireExternalEventSaga(action)
+        expect(generator.next().value).to.deep.equal(call(externalEvents.invokeExternalEvent, eventName, payload))
+        expect(generator.next().done).to.equal(true)
+      })
     })
   })
 })

--- a/packages/tocco-util/src/externalEvents/index.js
+++ b/packages/tocco-util/src/externalEvents/index.js
@@ -1,2 +1,17 @@
-import {registerEvents, getEvents, invokeExternalEvent} from './externalEvents'
-export default {registerEvents, getEvents, invokeExternalEvent}
+import {
+  registerEvents,
+  getEvents,
+  invokeExternalEvent,
+  FIRE_EXTERNAL_EVENT,
+  fireExternalEvent,
+  fireExternalEventSaga
+} from './externalEvents'
+
+export default {
+  registerEvents,
+  getEvents,
+  invokeExternalEvent,
+  FIRE_EXTERNAL_EVENT,
+  fireExternalEvent,
+  fireExternalEventSaga
+}


### PR DESCRIPTION
Simply dispatch a `fireExternalEvent` action (action creator located in the
`externalEvents` module of the `tocco-util` package) and the saga (which will
always be registered if the store got created using storeFactory#createStore())
will invoke the event listeners.

Example:

```
import {externalEvents} from 'tocco-util'

store.dispatch(externalEvents.fireExternalEvent('myExternalEvent', myEventPayload))
```