### PR TITLE
fix(entity-browser): Fix back button for related entity detail view

### DIFF
--- a/packages/entity-browser/src/dev/rest-responses/messages.json
+++ b/packages/entity-browser/src/dev/rest-responses/messages.json
@@ -18,7 +18,7 @@
   "client.entity-browser.saveSuccessfulTitle",
   "client.entity-browser.saveSuccessfulMessage",
   "client.entity-browser.lastSave",
-  "client.entity-browser.backToList",
+  "client.entity-browser.back",
   "client.entity-browser.confirmTouchedFormLeave",
   "client.entity-browser.confirmationOk",
   "client.entity-browser.confirmationCancel",

--- a/packages/entity-browser/src/routes/detail/components/DetailForm/DetailForm.js
+++ b/packages/entity-browser/src/routes/detail/components/DetailForm/DetailForm.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {reduxForm, Field} from 'redux-form'
 import {intlShape, FormattedRelative, FormattedMessage} from 'react-intl'
-import {Link, Prompt} from 'react-router-dom'
+import {Prompt} from 'react-router-dom'
 import {Button, LayoutBox} from 'tocco-ui'
 
 import ReduxFormFieldAdapter from '../ReduxFormFieldAdapter'
@@ -116,7 +116,6 @@ export class DetailForm extends React.Component {
         <LayoutBox alignment="horizontal">
           <LayoutBox alignment="vertical">
             {!props.valid && props.anyTouched && <ErrorBox formErrors={props.formErrors} showErrors={this.showErrors}/>}
-            <Link className="btn btn-primary" to="/"><FormattedMessage id={`client.entity-browser.backToList`}/></Link>
             <Button
               type="submit"
               label={this.msg('client.entity-browser.save')}

--- a/packages/entity-browser/src/routes/detail/components/DetailView/DetailView.js
+++ b/packages/entity-browser/src/routes/detail/components/DetailView/DetailView.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {intlShape} from 'react-intl'
+import {Button} from 'tocco-ui'
 
 import DetailForm from '../DetailForm'
 import syncValidation from '../../../../util/detailView/syncValidation'
@@ -21,6 +22,10 @@ class DetailView extends React.Component {
     })
   }
 
+  handleGoBack = () => {
+    this.props.router.push(this.props.parentUrl)
+  }
+
   getSyncValidation = () => {
     if (!this.validateSingleton) {
       this.validateSingleton = syncValidation(this.props.entityModel, this.props.intl)
@@ -28,11 +33,18 @@ class DetailView extends React.Component {
     return this.validateSingleton
   }
 
+  msg = id => this.props.intl.formatMessage({id})
+
   render() {
     const props = this.props
 
     return (
       <div className="detail-view">
+        <Button
+          type="button"
+          label={this.msg('client.entity-browser.back')}
+          onClick={this.handleGoBack}
+        />
         {props.formInitialValues
         && <DetailForm
           validate={this.getSyncValidation()}
@@ -48,6 +60,7 @@ class DetailView extends React.Component {
           entityModel={props.entityModel}
           intl={props.intl}
           lastSave={props.lastSave}
+          goBack={this.handleGoBack}
         />
         }
       </div>
@@ -99,5 +112,10 @@ DetailView.propTypes = {
       )
     })
   }).isRequired,
-  lastSave: React.PropTypes.number
+  lastSave: React.PropTypes.number,
+  parentUrl: React.PropTypes.string
+}
+
+DetailView.defaultProps = {
+  parentUrl: '/'
 }

--- a/packages/entity-browser/src/routes/detail/components/DetailView/DetailView.spec.js
+++ b/packages/entity-browser/src/routes/detail/components/DetailView/DetailView.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import DetailView from './DetailView'
 import {shallow} from 'enzyme'
+import {IntlStub} from 'tocco-test-util'
 
 const EMPTY_FUNC = () => {
 }
@@ -18,6 +19,7 @@ describe('entity-browser', () => {
         }
 
         const wrapper = shallow(<DetailView
+          intl={IntlStub}
           router={routerProp}
           loadDetailView={EMPTY_FUNC}
           formDefinition={{children: []}}

--- a/packages/entity-browser/src/routes/detail/containers/DetailViewContainer.js
+++ b/packages/entity-browser/src/routes/detail/containers/DetailViewContainer.js
@@ -28,7 +28,7 @@ const getFormGeneralErros = formName =>
   )
 
 const mapStateToProps = (state, props) => {
-  const {modelPaths, entityId} = parseUrl(props.router.match.url)
+  const {modelPaths, entityId, parentUrl} = parseUrl(props.router.match.url)
   return {
     formDefinition: state.detail.formDefinition,
     entity: state.detail.entity,
@@ -44,7 +44,8 @@ const mapStateToProps = (state, props) => {
       _error: getFormGeneralErros('detailForm')(state)
     },
     formInitialValues: getFormInitialValues('detailForm')(state),
-    lastSave: state.detail.lastSave
+    lastSave: state.detail.lastSave,
+    parentUrl
   }
 }
 

--- a/packages/entity-browser/src/util/detailView/parseUrl.js
+++ b/packages/entity-browser/src/util/detailView/parseUrl.js
@@ -8,8 +8,9 @@ const parseUrl = url => {
   }
 
   const entityId = parts[parts.length - 1]
+  const parentUrl = '/' + parts.slice(0, -2).join('/')
 
-  return {modelPaths, entityId}
+  return {modelPaths, entityId, parentUrl}
 }
 
 export default parseUrl

--- a/packages/entity-browser/src/util/detailView/parseUrl.spec.js
+++ b/packages/entity-browser/src/util/detailView/parseUrl.spec.js
@@ -11,7 +11,8 @@ describe('entity-browser', () => {
 
           const expectedResult = {
             modelPaths: [],
-            entityId: '2'
+            entityId: '2',
+            parentUrl: '/'
           }
 
           expect(result).to.eql(expectedResult)
@@ -24,7 +25,8 @@ describe('entity-browser', () => {
 
           const expectedResult = {
             modelPaths: ['relDummySubGrid'],
-            entityId: '3'
+            entityId: '3',
+            parentUrl: '/detail/2'
           }
 
           expect(result).to.eql(expectedResult)
@@ -37,7 +39,8 @@ describe('entity-browser', () => {
 
           const expectedResult = {
             modelPaths: ['relFoo', 'relBar', 'relFooBar'],
-            entityId: '5'
+            entityId: '5',
+            parentUrl: '/detail/2/relFoo/3/relBar/4'
           }
 
           expect(result).to.eql(expectedResult)


### PR DESCRIPTION
Before, the back button always switched to the list (path '/'). This is not
desired on the detail view of a related entity -> in this case, we want to
return to the parent detail view.

Additionally, the back button has been moved to the top of the detail view.