### PR TITLE
fix(entity-list): getSearchInputsForRequest not from model

### DIFF
--- a/packages/entity-browser/src/routes/list/modules/sagas.js
+++ b/packages/entity-browser/src/routes/list/modules/sagas.js
@@ -1,11 +1,10 @@
-import {call, put, fork, select, spawn, takeEvery, takeLatest, take} from 'redux-saga/effects'
+import {call, put, fork, select, spawn, takeEvery, takeLatest} from 'redux-saga/effects'
 import * as actions from './actions'
 import * as searchFormActions from './searchForm/actions'
 import {getSearchInputsForRequest} from '../../../util/searchInputs'
 import {fetchForm, columnDefinitionTransformer, getFieldsOfColumnDefinition} from '../../../util/api/forms'
 import {fetchEntityCount, fetchEntities, entitiesListTransformer} from '../../../util/api/entities'
 import _clone from 'lodash/clone'
-import {INITIALIZED} from '../../entity-browser/modules/actions'
 
 export const entityBrowserSelector = state => state.entityBrowser
 export const listSelector = state => state.list
@@ -20,17 +19,6 @@ export default function* sagas() {
     fork(takeEvery, actions.RESET_DATA_SET, resetDataSet),
     fork(takeLatest, actions.REFRESH, refresh)
   ]
-}
-
-export function* getEntityModel() {
-  let entityBrowser = yield select(entityBrowserSelector)
-  if (!entityBrowser.initialized) {
-    yield take(INITIALIZED)
-  }
-
-  entityBrowser = yield select(entityBrowserSelector)
-
-  return entityBrowser.entityModel
 }
 
 export function* initialize() {
@@ -66,15 +54,12 @@ export function* getSearchInputs() {
   let {searchInputs} = yield select(searchFormSelector)
   searchInputs = yield call(_clone, searchInputs)
 
-  const entityModel = yield call(getEntityModel)
-
   if (searchInputs && searchInputs.txtFulltext) {
     searchInputs._search = searchInputs.txtFulltext
     delete searchInputs.txtFulltext
   }
 
-  const result = yield call(getSearchInputsForRequest, searchInputs, entityModel)
-  return result
+  return yield call(getSearchInputsForRequest, searchInputs)
 }
 
 export function* fetchEntitiesAndAddToStore(page) {

--- a/packages/entity-browser/src/routes/list/modules/sagas.spec.js
+++ b/packages/entity-browser/src/routes/list/modules/sagas.spec.js
@@ -198,13 +198,11 @@ describe('entity-browser', () => {
         describe('getSearchInputs saga', () => {
           it('should get searchInputs', () => {
             const searchInputs = {}
-            const entityModel = {}
 
             const gen = sagas.getSearchInputs()
             expect(gen.next().value).to.eql(select(sagas.searchFormSelector))
             expect(gen.next({searchInputs}).value).to.eql(call(_clone, {}))
-            expect(gen.next(searchInputs).value).to.eql(call(sagas.getEntityModel))
-            expect(gen.next(entityModel).value).to.eql(call(getSearchInputsForRequest, searchInputs, entityModel))
+            expect(gen.next(searchInputs).value).to.eql(call(getSearchInputsForRequest, searchInputs))
             expect(gen.next().done).to.be.true
           })
         })

--- a/packages/entity-browser/src/util/searchInputs.js
+++ b/packages/entity-browser/src/util/searchInputs.js
@@ -1,16 +1,19 @@
-export const getSearchInputsForRequest = (searchInputs, entityModel) => {
-  const result = {}
-  Object.keys(searchInputs).forEach(f => {
-    if (entityModel[f] && entityModel[f].type === 'relation') {
-      if (entityModel[f].multi) {
-        result[`${f}.pk`] = searchInputs[f].map(o => o.key)
-      } else {
-        result[`${f}.pk`] = searchInputs[f].key
-      }
+import _forOwn from 'lodash/forOwn'
+import _isObject from 'lodash/isObject'
+
+export const getSearchInputsForRequest = searchInputs => {
+  let result = {}
+
+  _forOwn(searchInputs, (value, name) => {
+    if (Array.isArray(value)) {
+      result[`${name}.pk`] = value.map(v => v.key)
+    } else if (_isObject(value)) {
+      result[`${name}.pk`] = value.key
     } else {
-      result[f] = searchInputs[f]
+      result[name] = value
     }
-  })
+  }
+  )
 
   return result
 }

--- a/packages/entity-browser/src/util/searchInputs.spec.js
+++ b/packages/entity-browser/src/util/searchInputs.spec.js
@@ -11,27 +11,13 @@ describe('entity-browser', () => {
             field: 'some input'
           }
 
-          const entityModel = {
-            relMulti_entity: {
-              type: 'relation',
-              multi: true
-            },
-            relSingle_entity: {
-              type: 'relation',
-              multi: false
-            },
-            field: {
-              type: 'not_a_relation'
-            }
-          }
-
           const expectedResult = {
             'relMulti_entity.pk': ['1', '2'],
             'relSingle_entity.pk': '1',
             field: 'some input'
           }
 
-          const result = getSearchInputsForRequest(input, entityModel)
+          const result = getSearchInputsForRequest(input)
 
           expect(result).to.deep.eql(expectedResult)
         })

--- a/packages/entity-list/src/util/searchInputs.js
+++ b/packages/entity-list/src/util/searchInputs.js
@@ -1,16 +1,19 @@
-export const getSearchInputsForRequest = (searchInputs, entityModel) => {
-  const result = {}
-  Object.keys(searchInputs).forEach(f => {
-    if (entityModel[f] && entityModel[f].type === 'relation') {
-      if (entityModel[f].multi) {
-        result[`${f}.pk`] = searchInputs[f].map(o => o.key)
-      } else {
-        result[`${f}.pk`] = searchInputs[f].key
-      }
+import _forOwn from 'lodash/forOwn'
+import _isObject from 'lodash/isObject'
+
+export const getSearchInputsForRequest = searchInputs => {
+  let result = {}
+
+  _forOwn(searchInputs, (value, name) => {
+    if (Array.isArray(value)) {
+      result[`${name}.pk`] = value.map(v => v.key)
+    } else if (_isObject(value)) {
+      result[`${name}.pk`] = value.key
     } else {
-      result[f] = searchInputs[f]
+      result[name] = value
     }
-  })
+  }
+  )
 
   return result
 }

--- a/packages/entity-list/src/util/searchInputs.spec.js
+++ b/packages/entity-list/src/util/searchInputs.spec.js
@@ -11,27 +11,13 @@ describe('entity-browser', () => {
             field: 'some input'
           }
 
-          const entityModel = {
-            relMulti_entity: {
-              type: 'relation',
-              multi: true
-            },
-            relSingle_entity: {
-              type: 'relation',
-              multi: false
-            },
-            field: {
-              type: 'not_a_relation'
-            }
-          }
-
           const expectedResult = {
             'relMulti_entity.pk': ['1', '2'],
             'relSingle_entity.pk': '1',
             field: 'some input'
           }
 
-          const result = getSearchInputsForRequest(input, entityModel)
+          const result = getSearchInputsForRequest(input)
 
           expect(result).to.deep.eql(expectedResult)
         })


### PR DESCRIPTION
- Searchfield relation type multi should not be retrieved from model
  because a single relation probably gets displayed as multi-select or
  as string (fulltext) in searchForm. Getting information form
  searchFormDefinition also doesn't work because of hidden input search
  values which are not represented in definition.