### PR TITLE
Search forms for sub grids

### DIFF
--- a/packages/entity-browser/src/dev/fetchMocks.js
+++ b/packages/entity-browser/src/dev/fetchMocks.js
@@ -42,6 +42,10 @@ export default function setupFetchMock(fetchMock) {
     require('./rest-responses/form_user_detail_relDummySubGrid_list.json')
   )
   fetchMock.get(
+    new RegExp('^.*?/nice2/rest/forms/UserSearch_detail_relDummySubGrid_search$'),
+    require('./rest-responses/form_user_detail_relDummySubGrid_search.json')
+  )
+  fetchMock.get(
     new RegExp('^.*?/nice2/rest/forms/UserSearch_Dummy_entity_detail$'),
     require('./rest-responses/form_dummy_entity_detail.json')
   )

--- a/packages/entity-browser/src/dev/rest-responses/form_user_detail.json
+++ b/packages/entity-browser/src/dev/rest-responses/form_user_detail.json
@@ -112,7 +112,16 @@
                     "children": [ ],
                     "label": "Dauer",
                     "useLabel": "YES"
-                  },
+                  }
+                ],
+                "label": "Form Stuff",
+                "useLabel": "YES"
+              },
+              {
+                "name": "dummy_subgrid",
+                "type": "ch.tocco.nice2.model.form.components.layout.VerticalBox",
+                "displayType": "EDITABLE",
+                "children": [
                   {
                     "name": "relDummySubGrid",
                     "type": "ch.tocco.nice2.model.form.components.table.Table",
@@ -122,7 +131,7 @@
                     "useLabel": "HIDE"
                   }
                 ],
-                "label": "Form Stuff",
+                "label": "Sub Grid",
                 "useLabel": "YES"
               }
             ]

--- a/packages/entity-browser/src/dev/rest-responses/form_user_detail_relDummySubGrid_search.json
+++ b/packages/entity-browser/src/dev/rest-responses/form_user_detail_relDummySubGrid_search.json
@@ -1,0 +1,49 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://test.tocco.ch/nice2/rest/forms/UserSearch_detail_relDummySubGrid_search"
+    }
+  },
+  "form": {
+    "name": "UserSearch_detail_relDummySubGrid_search",
+    "type": "ch.tocco.nice2.model.form.components.Form",
+    "displayType": "EDITABLE",
+    "children": [
+      {
+        "name": "box1",
+        "type": "ch.tocco.nice2.model.form.components.layout.VerticalBox",
+        "displayType": "EDITABLE",
+        "children": [
+          {
+            "name": "txtFulltext",
+            "type": "ch.tocco.nice2.model.form.components.simple.TextField",
+            "displayType": "EDITABLE",
+            "children": [],
+            "label": "Entity",
+            "useLabel": "YES"
+          },
+          {
+            "name": "label",
+            "type": "ch.tocco.nice2.model.form.components.simple.TextField",
+            "displayType": "EDITABLE",
+            "children": [],
+            "label": "Bezeichnung",
+            "useLabel": "YES"
+          },
+          {
+            "name": "active",
+            "type": "ch.tocco.nice2.model.form.components.simple.Checkbox",
+            "displayType": "EDITABLE",
+            "children": [ ],
+            "label": "Aktiv",
+            "useLabel": "YES"
+          }
+        ],
+        "label": null,
+        "useLabel": "NO"
+      }
+    ],
+    "label": "##forms.UserSearch_detail_relDummySubGrid_search:de_CH:nice2.optional.usersearch",
+    "useLabel": "YES"
+  }
+}

--- a/packages/entity-browser/src/routes/detail/components/SubGrid/SubGrid.js
+++ b/packages/entity-browser/src/routes/detail/components/SubGrid/SubGrid.js
@@ -9,7 +9,7 @@ const SubGrid = props => {
         entityName={props.modelField.targetEntity}
         formBase={`${props.detailFormName}_${props.gridName}`}
         limit={5}
-        showSearchForm={false}
+        showSearchForm={true}
         preselectedSearchFields={[{
           id: props.modelField.reverseRelationName,
           value: {key: props.entityKey},

--- a/packages/entity-list/src/components/SearchForm/SearchForm.js
+++ b/packages/entity-list/src/components/SearchForm/SearchForm.js
@@ -16,6 +16,7 @@ class SearchForm extends React.Component {
 
   handleSubmit = e => {
     e.preventDefault()
+    e.stopPropagation()
     this.props.setSearchInput()
   }
 
@@ -37,6 +38,11 @@ class SearchForm extends React.Component {
 
   render() {
     const props = this.props
+
+    if (props.searchFormDefinition.length === 0) {
+      return null
+    }
+
     return (
       <form onSubmit={this.handleSubmit} className="form-horizontal">
         {

--- a/packages/entity-list/src/components/SearchForm/SearchForm.spec.js
+++ b/packages/entity-list/src/components/SearchForm/SearchForm.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {IntlStub} from 'tocco-test-util'
 import SearchForm from './'
-import {mount} from 'enzyme'
+import {mount, shallow} from 'enzyme'
 import {Button, FormField} from 'tocco-ui'
 
 const EMPTY_FUNC = () => {}
@@ -9,6 +9,29 @@ const EMPTY_FUNC = () => {}
 describe('entity-browser', () => {
   describe('components', () => {
     describe('SearchForm', () => {
+      it('should render nothing if searchFormDefinition empty', () => {
+        const entityModel = require('../../dev/test-data/userModel.json')
+        const searchFormDefinition = []
+
+        const wrapper = shallow(
+          <SearchForm
+            initialize={EMPTY_FUNC}
+            entityModel={entityModel}
+            searchFormDefinition={searchFormDefinition}
+            setSearchInput={EMPTY_FUNC}
+            relationEntities={{}}
+            searchInputs={{}}
+            reset={EMPTY_FUNC}
+            intl={IntlStub}
+            simpleSearchFields={[]}
+            disableSimpleSearch
+            preselectedSearchFields={[]}
+          />
+        )
+
+        expect(wrapper.type()).to.be.null
+      })
+
       it('should render needed components', () => {
         const entityModel = require('../../dev/test-data/userModel.json')
         const searchFormDefinition = require('../../dev/test-data/searchFormDefinition.json')

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -7,8 +7,8 @@ const IGNORED_FIELD_TYPES = [
 const defaultFormTransformer = json => (json.form)
 
 export function fetchForm(formName, transformer = defaultFormTransformer) {
-  return request(`forms/${formName}`)
-    .then(resp => resp.body)
+  return request(`forms/${formName}`, undefined, undefined, undefined, undefined, [404])
+    .then(resp => resp.body || {})
     .then(json => transformer(json))
 }
 
@@ -32,6 +32,11 @@ export const columnDefinitionTransformer = json => {
 
 export const searchFormTransformer = json => {
   const {form} = json
+
+  if (!form) {
+    return []
+  }
+
   const fields = form.children[0].children
 
   return fields
@@ -51,6 +56,7 @@ export const getFieldsOfColumnDefinition = columnDefinition => {
   columnDefinition
     .filter(column => !column.values.some(field => IGNORED_FIELD_TYPES.includes(field.type)))
     .forEach(column => {
+      fields = fields.concat(column.values.map(field => field.name))
       fields = fields.concat(column.values.map(field => field.name))
     })
 

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -57,7 +57,6 @@ export const getFieldsOfColumnDefinition = columnDefinition => {
     .filter(column => !column.values.some(field => IGNORED_FIELD_TYPES.includes(field.type)))
     .forEach(column => {
       fields = fields.concat(column.values.map(field => field.name))
-      fields = fields.concat(column.values.map(field => field.name))
     })
 
   return fields

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -26,6 +26,11 @@ describe('entity-browser', () => {
             ]
             expect(result).to.eql(expectedResult)
           })
+
+          it('should return an empty array if form is missing', () => {
+            const result = forms.searchFormTransformer({})
+            expect(result).to.eql([])
+          })
         })
 
         describe('columnDefinitionTransformer', () => {
@@ -85,6 +90,19 @@ describe('entity-browser', () => {
               expect(fetchMock.calls().matched).to.have.length(1)
               const lastCallUrl = fetchMock.lastCall()[0]
               expect(lastCallUrl).to.eql('/nice2/rest/forms/User_search')
+            })
+          })
+
+          it('should ignore 404 errors', () => {
+            const body = new Blob(['{}'], {type: 'application/json'})
+            const mockedResponse = new Response(body, {'status': 404})
+
+            fetchMock.get('*', mockedResponse)
+
+            const transformer = json => json.form || 'no form'
+
+            return forms.fetchForm('User_search', transformer).then(res => {
+              expect(res).to.eql('no form')
             })
           })
         })

--- a/packages/tocco-util/src/rest/rest.js
+++ b/packages/tocco-util/src/rest/rest.js
@@ -16,8 +16,10 @@ export const getParameterString = params => {
   return ''
 }
 
-const handleError = (response, acceptedErrorCodes) => {
-  if (!response.ok && !acceptedErrorCodes.includes(response.body.errorCode)) {
+const handleError = (response, acceptedErrorCodes, acceptedStatusCodes) => {
+  if (!response.ok
+    && !acceptedStatusCodes.includes(response.status)
+    && !acceptedErrorCodes.includes(response.body.errorCode)) {
     throw new Error(response.statusText)
   }
 
@@ -41,7 +43,7 @@ export const setNullBusinessUnit = value => {
   nullBusinessUnit = value
 }
 
-export const request = (resource, params, method = 'GET', body, acceptedErrorCodes = []) => {
+export const request = (resource, params, method = 'GET', body, acceptedErrorCodes = [], acceptedStatusCodes = []) => {
   const headers = {
     'Content-Type': 'application/json'
   }
@@ -65,7 +67,7 @@ export const request = (resource, params, method = 'GET', body, acceptedErrorCod
   const url = `${__BACKEND_URL__}/nice2/rest/${resource}${paramString}`
   return fetch(url, options)
     .then(response => (extractBody(response)))
-    .then(response => (handleError(response, acceptedErrorCodes)))
+    .then(response => (handleError(response, acceptedErrorCodes, acceptedStatusCodes)))
     .catch(error => {
       error.message = `REST request error: ${error.message} \n url: ${url}, options: ${JSON.stringify(options)}`
       throw error

--- a/packages/tocco-util/src/rest/rest.spec.js
+++ b/packages/tocco-util/src/rest/rest.spec.js
@@ -130,6 +130,34 @@ describe('tocco-util', () => {
         const lastCall = fetchMock.lastCall()[0]
         expect(lastCall).to.eql('/nice2/rest/Entities/Contact?_search=test&xyz=abc')
       })
+
+      it('should return with accepted status code', done => {
+        const statusCode = 400
+
+        const body = new Blob(['{}'], {type: 'application/json'})
+        const mockedResponse = new Response(body, {'status': statusCode})
+
+        fetchMock.get('*', mockedResponse)
+        const resource = 'Entities/Contact'
+        request(resource, undefined, undefined, undefined, undefined, [400]).then(response => {
+          expect(response.status).to.eql(statusCode)
+          expect(response.body).to.eql({})
+          done()
+        })
+      })
+
+      it('should trow exception on unaccepted status code', done => {
+        const statusCode = 400
+
+        const body = new Blob(['{}'], {type: 'application/json'})
+        const mockedResponse = new Response(body, {'status': statusCode})
+
+        fetchMock.get('*', mockedResponse)
+        const resource = 'Entities/Contact'
+        request(resource, undefined, undefined, undefined, undefined, []).catch(() => {
+          done()
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Example code to load a form and accept a 404 status code (form not found):
```
request(`forms/${formName}`, undefined, undefined, undefined, undefined, [404])
```