### PR TITLE
feat(entity-list): integrate react-bootstrap-table

### DIFF
--- a/packages/entity-list/package.json
+++ b/packages/entity-list/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "react-bootstrap-table": "^4.0.0-beta.2",
     "tocco-test-util": "^0.1.0",
     "tocco-theme": "^0.1.2",
     "tocco-ui": "^0.1.1",

--- a/packages/entity-list/src/components/ListView/ListView.js
+++ b/packages/entity-list/src/components/ListView/ListView.js
@@ -71,7 +71,7 @@ class ListView extends React.Component {
           loadingText={this.msg('client.entity-list.loadingText')}
         >
           <BootstrapTable
-            remote={true}
+            remote
             data={props.entities}
             pagination={ showPagination }
             fetchInfo={{dataTotalSize: props.entityCount}}
@@ -81,14 +81,14 @@ class ListView extends React.Component {
             striped
             hover
           >
-            <TableHeaderColumn dataField="__key" isKey={true} hidden>Key</TableHeaderColumn>
+            <TableHeaderColumn dataField="__key" isKey hidden>Key</TableHeaderColumn>
             {
               props.columnDefinitions.map((column, idx) => (
                 <TableHeaderColumn
                   key={idx}
                   dataFormat={this.cellFormatter}
+                  dataSort
                   dataField={column.child.name}
-                  dataSort={true}
                 >
                   {column.label}
                 </TableHeaderColumn>

--- a/packages/entity-list/src/components/ListView/ListView.scss
+++ b/packages/entity-list/src/components/ListView/ListView.scss
@@ -1,16 +1,12 @@
-.entity-browser {
-  .list-view {
-    .refresh-button {
-      margin-left: 1.42rem;
-    }
+.react-bs-table {
+  .table {
+    margin-bottom: 0;
   }
 }
 
-.list-view-navigation {
-  @include clearfix();
-
-  .tocco-pagination {
-    float: left;
-    margin-right: $tocco-pagination-dividing-space;
+.break-word {
+  > td {
+    white-space: normal;
+    word-wrap: break-word;
   }
 }

--- a/packages/entity-list/src/components/ListView/ListView.spec.js
+++ b/packages/entity-list/src/components/ListView/ListView.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ListView from './ListView'
-import {Pagination, Table} from 'tocco-ui'
+import {BootstrapTable} from 'react-bootstrap-table'
 import {IntlStub} from 'tocco-test-util'
 import {shallow} from 'enzyme'
 
@@ -21,95 +21,9 @@ const defaultProps = {
 describe('entity-list', () => {
   describe('components', () => {
     describe('ListView', () => {
-      it('should render', () => {
+      it('should render bootstrap table', () => {
         const wrapper = shallow(<ListView {...defaultProps}/>)
-
-        expect(wrapper.find(Table)).to.have.length(1)
-        expect(wrapper.find(Pagination)).to.have.length(1)
-      })
-
-      it('should call changePage', () => {
-        const changePage = sinon.spy()
-
-        const wrapper = shallow(<ListView
-          {...defaultProps}
-          changePage={changePage}
-        />)
-
-        wrapper.find(Pagination).simulate('pageChange')
-        expect(changePage).to.have.calledOnce
-      })
-
-      it('should pass properties to the Table component', () => {
-        const entities = [{id: 1, values:{}}, {id: 2, values:{}}]
-        const orderBy = {
-          name: 'name',
-          direction: 'asc'
-        }
-        const columnDefinitions = [{values: [{name: 'my'}]}]
-        const inProgress = true
-        const orderByChange = sinon.spy()
-
-        const wrapper = shallow(<ListView
-          {...defaultProps}
-          entities={entities}
-          orderBy={orderBy}
-          columnDefinitions={columnDefinitions}
-          inProgress={inProgress}
-          setOrderBy={orderByChange}
-        />)
-
-        expect(wrapper.find(Table).props().records).to.eql(entities)
-        expect(wrapper.find(Table).props().orderBy).to.eql(orderBy)
-        expect(wrapper.find(Table).props().columnDefinitions).to.eql(columnDefinitions)
-        expect(wrapper.find(Table).props().loading).to.eql(inProgress)
-        wrapper.find(Table).simulate('orderByChange')
-        expect(orderByChange).to.have.calledOnce
-      })
-
-      it('should handle currentPage', () => {
-        const currentPage = 100
-
-        const wrapper = shallow(<ListView
-          {...defaultProps}
-          currentPage={currentPage}
-        />)
-
-        expect(wrapper.find(Pagination).props().currentPage).to.eql(currentPage)
-      })
-
-      it('should handle limit', () => {
-        const limit = 100
-
-        const wrapper = shallow(<ListView
-          {...defaultProps}
-          limit={limit}
-        />)
-
-        expect(wrapper.find(Pagination).props().recordsPerPage).to.eql(limit)
-      })
-
-      it('should handle entityCount', () => {
-        const entityCount = 1234
-
-        const wrapper = shallow(<ListView
-          {...defaultProps}
-          entityCount={entityCount}
-        />)
-
-        expect(wrapper.find(Pagination).props().totalRecords).to.eql(entityCount)
-      })
-
-      it('should call refresh', () => {
-        const spy = sinon.spy()
-
-        const wrapper = shallow(<ListView
-          {...defaultProps}
-          refresh={spy}
-        />)
-
-        wrapper.find('.refresh-button').simulate('click')
-        expect(spy).to.have.calledOnce
+        expect(wrapper.find(BootstrapTable)).to.have.length(1)
       })
     })
   })

--- a/packages/entity-list/src/dev/textResources.json
+++ b/packages/entity-list/src/dev/textResources.json
@@ -6,5 +6,12 @@
   "client.entity-list.reset",
   "client.entity-list.refresh",
   "client.entity-list.loadingText",
-  "client.entity-list.extendedSearch"
+  "client.entity-list.extendedSearch",
+  "client.entity-list.dataLoading",
+  "client.entity-list.noData",
+  "client.entity-list.total",
+  "client.entity-list.nextPageTitle",
+  "client.entity-list.prePageTitle",
+  "client.entity-list.firstPageTitle",
+  "client.entity-list.lastPageTitle"
 ]

--- a/packages/entity-list/src/util/api/entities.js
+++ b/packages/entity-list/src/util/api/entities.js
@@ -26,27 +26,26 @@ export function fetchModel(entityName, transformer = defaultModelTransformer) {
 export const entitiesListTransformer = json => {
   return json.data.map(entity => {
     const result = {
-      id: entity.key,
-      values: {}
+      __key: entity.key
     }
 
     const paths = entity.paths
     for (const path in paths) {
       const type = paths[path].type
       if (type === 'field') {
-        result.values[path] = paths[path].value
+        result[path] = paths[path].value
       } else if (type === 'entity') {
-        result.values[path] = {
+        result[path] = {
           type: 'string',
           value: paths[path].value ? paths[path].value.display : ''
         }
       } else if (type === 'entity-list') {
-        result.values[path] = {
+        result[path] = {
           type: 'string',
           value: paths[path].value ? paths[path].value.map(v => v.display).join(', ') : ''
         }
       } else if (type === 'display-expression') {
-        result.values[path] = {
+        result[path] = {
           type: 'html',
           value: paths[path].value
         }

--- a/packages/entity-list/src/util/api/entities.spec.js
+++ b/packages/entity-list/src/util/api/entities.spec.js
@@ -78,7 +78,8 @@ describe('entity-list', () => {
                       }]
                     }
                   }
-                }, {
+                },
+                {
                   paths: {
                     firstname: {
                       type: 'field',
@@ -116,16 +117,39 @@ describe('entity-list', () => {
 
             expect(transformedResult).to.be.a('array')
             expect(transformedResult).to.have.length(2)
-            expect(transformedResult[0].values).to.have.property('firstname')
-            expect(transformedResult[0].values).to.have.property('relGender')
-            expect(transformedResult[0].values.firstname).to.eql({type: 'string', value: 'Jon'})
-            expect(transformedResult[0].values.relGender).to.eql({type: 'string', value: 'Male'})
-            expect(transformedResult[0].values.titles).to.eql({type: 'string', value: 'Dr., Bundesrat'})
 
-            expect(transformedResult[1].values).to.have.property('firstname')
-            expect(transformedResult[1].values).to.have.property('relGender')
-            expect(transformedResult[1].values.firstname).to.eql({type: 'string', value: 'Klaus'})
-            expect(transformedResult[1].values.titles).to.eql({type: 'string', value: 'Dr., Prof'})
+            expect(transformedResult[0]).to.have.property('firstname')
+            expect(transformedResult[0]).to.have.property('relGender')
+            expect(transformedResult[0].firstname).to.eql({type: 'string', value: 'Jon'})
+            expect(transformedResult[0].relGender).to.eql({type: 'string', value: 'Male'})
+            expect(transformedResult[0].titles).to.eql({type: 'string', value: 'Dr., Bundesrat'})
+
+            expect(transformedResult[1]).to.have.property('firstname')
+            expect(transformedResult[1]).to.have.property('relGender')
+            expect(transformedResult[1].firstname).to.eql({type: 'string', value: 'Klaus'})
+            expect(transformedResult[1].titles).to.eql({type: 'string', value: 'Dr., Prof'})
+          })
+
+          it('should add __key to entity', () => {
+            const fetchResult = {
+              data: [
+                {
+                  key: 1,
+                  paths: {}
+                }, {
+                  key: 22,
+                  paths: {}
+                }
+              ]
+            }
+
+            const transformedResult = entities.entitiesListTransformer(fetchResult)
+
+            expect(transformedResult[0]).to.have.property('__key')
+            expect(transformedResult[0].__key).to.eql(1)
+
+            expect(transformedResult[1]).to.have.property('__key')
+            expect(transformedResult[1].__key).to.eql(22)
           })
 
           it('should handle path type display-expression', () => {
@@ -156,18 +180,19 @@ describe('entity-list', () => {
             expect(transformedResult).to.be.a('array')
             expect(transformedResult).to.have.length(2)
 
-            expect(transformedResult[0].values).to.have.property('title')
-            expect(transformedResult[0].values.title).to.eql({type: 'html', value: '<p>TEST 1</p>'})
+            expect(transformedResult[0]).to.have.property('title')
+            expect(transformedResult[0].title).to.eql({type: 'html', value: '<p>TEST 1</p>'})
 
-            expect(transformedResult[1].values).to.have.property('title')
-            expect(transformedResult[1].values.title).to.eql({type: 'html', value: '<p>TEST 2</p>'})
+            expect(transformedResult[1]).to.have.property('title')
+            expect(transformedResult[1].title).to.eql({type: 'html', value: '<p>TEST 2</p>'})
           })
         })
 
         describe('fetchModel', () => {
           it('should call fetch', () => {
             fetchMock.get('*', {})
-            return entities.fetchModel('User', () => {}).then(() => {
+            return entities.fetchModel('User', () => {
+            }).then(() => {
               expect(fetchMock.calls().matched).to.have.length(1)
               const lastCallUrl = fetchMock.lastCall()[0]
               expect(lastCallUrl).to.eql('/nice2/rest/entities/User/model')

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -19,15 +19,20 @@ export const columnDefinitionTransformer = json => {
   const columns = form.children.find(child => child.type === tableType)
     .children.filter(column => column.displayType !== 'HIDDEN')
 
-  const isDisplayableType = child => {
+  const isDisplayableChild = child => {
     return child.type !== 'ch.tocco.nice2.model.form.components.action.Action'
       && !child.name.startsWith('custom:')
+      && child.displayType !== 'HIDDEN'
   }
 
-  return columns.map(c => ({
-    label: c.label,
-    values: c.children.filter(isDisplayableType).map(child => ({name: child.name, type: child.type}))
-  }))
+  return columns.map(c => (
+    {
+      name: c.name,
+      label: c.label,
+      useLabel: c.useLabel,
+      child: c.children.filter(isDisplayableChild)[0]
+    }
+  ))
 }
 
 export const searchFormTransformer = json => {
@@ -50,14 +55,8 @@ export const searchFormTransformer = json => {
     }))
 }
 
-export const getFieldsOfColumnDefinition = columnDefinition => {
-  let fields = []
-
+export const getFieldsOfColumnDefinition = columnDefinition => (
   columnDefinition
-    .filter(column => !column.values.some(field => IGNORED_FIELD_TYPES.includes(field.type)))
-    .forEach(column => {
-      fields = fields.concat(column.values.map(field => field.name))
-    })
-
-  return fields
-}
+    .filter(column => !IGNORED_FIELD_TYPES.includes(column.child))
+    .map(column => column.child.name)
+)

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -34,7 +34,10 @@ describe('entity-list', () => {
         })
 
         describe('columnDefinitionTransformer', () => {
-          it('should return an array of label and list of fields', () => {
+          it('should return an array of columns with child (field)', () => {
+            const field1 = {name: 'name1', type: 'type', displayType: 'EDITABLE', label: 'label'}
+            const field2 = {name: 'name2', type: 'type', displayType: 'EDITABLE', label: 'label'}
+
             const fetchResult = {
               form: {
                 children: [{
@@ -43,29 +46,16 @@ describe('entity-list', () => {
                   children: [
                     {
                       displayType: 'EDITABLE',
+                      name: 'lb1',
                       label: 'label1',
-                      children: [{name: 'name1', type: 'type', displayType: 'EDITABLE', label: 'label'}]
+                      useLabel: true,
+                      children: [field1]
                     }, {
-                      displayType: 'HIDDEN',
+                      displayType: 'EDITABLE',
+                      name: 'lb2',
                       label: 'label2',
-                      children: [{name: 'name2', type: 'type', displayType: 'HIDDEN', label: 'label'}]
-                    }, {
-                      displayType: 'EDITABLE',
-                      label: 'label3',
-                      children: [{name: 'custom:name3', type: 'type', displayType: 'EDITABLE', label: 'label'}]
-                    }, {
-                      displayType: 'EDITABLE',
-                      label: 'label4',
-                      children: [{
-                        name: 'name4',
-                        type: 'ch.tocco.nice2.model.form.components.action.Action',
-                        displayType: 'EDITABLE',
-                        label: 'label'
-                      }]
-                    }, {
-                      displayType: 'EDITABLE',
-                      label: 'label5',
-                      children: [{name: 'name5', type: 'type', displayType: 'EDITABLE', label: 'label'}]
+                      useLabel: false,
+                      children: [field2]
                     }
                   ]
                 }]
@@ -74,11 +64,54 @@ describe('entity-list', () => {
             const result = forms.columnDefinitionTransformer(fetchResult)
 
             const expectedColumnDefinition = [
-              {label: 'label1', values: [{name: 'name1', type: 'type'}]},
-              {label: 'label3', values: []},
-              {label: 'label4', values: []},
-              {label: 'label5', values: [{name: 'name5', type: 'type'}]}
+              {label: 'label1', useLabel: true, name: 'lb1', child: field1},
+              {label: 'label2', useLabel: false, name: 'lb2', child: field2}
             ]
+
+            expect(result).to.eql(expectedColumnDefinition)
+          })
+
+          it('should ignore HIDDEN columns and hidden fields', () => {
+            const field1 = {name: 'name1', type: 'type', displayType: 'EDITABLE', label: 'label'}
+            const field2Hidden = {name: 'name2', type: 'type', displayType: 'HIDDEN', label: 'label'}
+
+            const fetchResult = {
+              form: {
+                children: [{
+                  name: 'table',
+                  type: 'ch.tocco.nice2.model.form.components.table.Table',
+                  children: [
+                    {
+                      displayType: 'EDITABLE',
+                      name: 'lb1',
+                      label: 'label1',
+                      useLabel: true,
+                      children: [field1]
+                    }, {
+                      displayType: 'EDITABLE',
+                      name: 'lb2',
+                      label: 'label2',
+                      useLabel: false,
+                      children: [field2Hidden]
+                    },
+                    {
+                      displayType: 'HIDDEN',
+                      name: 'lb3',
+                      label: 'label3',
+                      useLabel: false,
+                      children: [field1]
+                    }
+                  ]
+                }]
+              }
+            }
+            const result = forms.columnDefinitionTransformer(fetchResult)
+
+            const expectedColumnDefinition = [
+              {label: 'label1', useLabel: true, name: 'lb1', child: field1},
+              {label: 'label2', useLabel: false, name: 'lb2', child: undefined}
+            ]
+
             expect(result).to.eql(expectedColumnDefinition)
           })
         })


### PR DESCRIPTION
- replace tocco-ui table and pagination with react-bootstrap-table
- hide pagination if no more than one page exists
- add __key attribute to entity and story fields directly in object and not in an attribute values (entities.js).
  This change was needed to add mandatory key columns to react bootstrap table
- Columndefinition: Only regard first field in columns. To add two fields into one column, freemarker is required.
  This change made handling with react-bootstrap-table easier and does not require a hack.