### PR TITLE
fix(entity-detail): Fix support for remote entities (RemoteSelect)

### DIFF
--- a/packages/entity-detail/src/containers/DetailViewContainer.js
+++ b/packages/entity-detail/src/containers/DetailViewContainer.js
@@ -8,9 +8,13 @@ import {
   getFormAsyncErrors,
   getFormSubmitErrors
 } from 'redux-form'
-
-import {loadDetailView, unloadDetailView, submitForm, loadRelationEntity} from '../modules/entityDetail/actions'
-// import {loadRemoteEntity} from '../../entity-browser/modules/actions' // TODO
+import {
+  loadDetailView,
+  unloadDetailView,
+  submitForm,
+  loadRelationEntity,
+  loadRemoteEntity
+} from '../modules/entityDetail/actions'
 import DetailView from '../components/DetailView/DetailView'
 import {logError} from 'tocco-util/src/errorLogging'
 
@@ -19,7 +23,7 @@ const mapActionCreators = {
   unloadDetailView,
   submitForm,
   loadRelationEntity,
-  loadRemoteEntity: () => {}, // TODO
+  loadRemoteEntity,
   logError
 }
 
@@ -33,7 +37,7 @@ const mapStateToProps = (state, props) => {
     formDefinition: state.entityDetail.formDefinition,
     entity: state.entityDetail.entity,
     relationEntities: state.entityDetail.relationEntities,
-    remoteEntities: {}, // TODO
+    remoteEntities: state.entityDetail.remoteEntities,
     entityModel: state.entityDetail.entityModel,
     entityId: state.input.entityId,
     formValues: getFormValues('detailForm')(state),

--- a/packages/entity-detail/src/modules/entityDetail/actions.js
+++ b/packages/entity-detail/src/modules/entityDetail/actions.js
@@ -5,9 +5,12 @@ export const SUBMIT_FORM = 'entityDetail/SUBMIT_FORM'
 export const SET_LAST_SAVE = 'entityDetail/SET_LAST_SAVE'
 export const SET_ENTITY_MODEL = 'entityDetail/SET_ENTITY_MODEL'
 export const UNLOAD_DETAIL_VIEW = 'entityDetail/UNLOAD_DETAIL_VIEW'
-export const LOAD_RELATION_ENTITY = 'entityBrowser/LOAD_RELATION_ENTITY'
-export const SET_RELATION_ENTITY = 'entityBrowser/SET_RELATION_ENTITY'
-export const SET_RELATION_ENTITY_LOADED = 'entityBrowser/SET_RELATION_ENTITY_LOADED'
+export const LOAD_RELATION_ENTITY = 'entityDetail/LOAD_RELATION_ENTITY'
+export const SET_RELATION_ENTITY = 'entityDetail/SET_RELATION_ENTITY'
+export const SET_RELATION_ENTITY_LOADED = 'entityDetail/SET_RELATION_ENTITY_LOADED'
+export const LOAD_REMOTE_ENTITY = 'entityDetail/LOAD_REMOTE_ENTITY'
+export const SET_REMOTE_ENTITY = 'entityDetail/SET_REMOTE_ENTITY'
+export const SET_REMOTE_ENTITY_LOADING = 'entityDetail/SET_REMOTE_ENTITY_LOADING'
 
 export const setFormDefinition = formDefinition => ({
   type: SET_FORM_DEFINITION,
@@ -73,5 +76,29 @@ export const setRelationEntity = (entityName, entities, reset = false) => ({
     entityName,
     entities,
     reset
+  }
+})
+
+export const loadRemoteEntity = (field, entityName, searchTerm) => ({
+  type: LOAD_REMOTE_ENTITY,
+  payload: {
+    field,
+    entityName,
+    searchTerm
+  }
+})
+
+export const setRemoteEntity = (field, entities) => ({
+  type: SET_REMOTE_ENTITY,
+  payload: {
+    field,
+    entities
+  }
+})
+
+export const setRemoteEntityLoading = field => ({
+  type: SET_REMOTE_ENTITY_LOADING,
+  payload: {
+    field
   }
 })

--- a/packages/entity-detail/src/modules/entityDetail/reducer.js
+++ b/packages/entity-detail/src/modules/entityDetail/reducer.js
@@ -36,20 +36,51 @@ const setRelationEntityLoaded = (state, {payload}) => {
   return {...state, relationEntities}
 }
 
+const setRemoteEntity = (state, {payload}) => {
+  const {field, entities} = payload
+  return {
+    ...state,
+    remoteEntities: {
+      ...state.remoteEntities,
+      [field]: {
+        loading: false,
+        entities
+      }
+    }
+  }
+}
+
+const setRemoteEntityLoading = (state, {payload}) => {
+  const {field} = payload
+  return {
+    ...state,
+    remoteEntities: {
+      ...state.remoteEntities,
+      [field]: {
+        loading: true,
+        entities: []
+      }
+    }
+  }
+}
+
 const ACTION_HANDLERS = {
   [actions.SET_FORM_DEFINITION]: reducers.singleTransferReducer('formDefinition'),
   [actions.SET_ENTITY]: reducers.singleTransferReducer('entity'),
   [actions.SET_LAST_SAVE]: reducers.singleTransferReducer('lastSave'),
   [actions.SET_ENTITY_MODEL]: reducers.singleTransferReducer('entityModel'),
   [actions.SET_RELATION_ENTITY]: setRelationEntity,
-  [actions.SET_RELATION_ENTITY_LOADED]: setRelationEntityLoaded
+  [actions.SET_RELATION_ENTITY_LOADED]: setRelationEntityLoaded,
+  [actions.SET_REMOTE_ENTITY]: setRemoteEntity,
+  [actions.SET_REMOTE_ENTITY_LOADING]: setRemoteEntityLoading
 }
 
 const initialState = {
   formDefinition: {},
   entity: {},
   entityModel: {},
-  relationEntities: {}
+  relationEntities: {},
+  remoteEntities: {}
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/entity-detail/src/modules/entityDetail/reducer.spec.js
+++ b/packages/entity-detail/src/modules/entityDetail/reducer.spec.js
@@ -5,7 +5,8 @@ const EXPECTED_INITIAL_STATE = {
   formDefinition: {},
   entity: {},
   entityModel: {},
-  relationEntities: {}
+  relationEntities: {},
+  remoteEntities: {}
 }
 
 describe('entity-detail', () => {
@@ -145,6 +146,71 @@ describe('entity-detail', () => {
               }
             }
             expect(reducer(stateBefore, actions.setRelationEntityLoaded('User'))).to.deep.equal(expectedStateAfter)
+          })
+        })
+
+        describe('setRemoteEntity', () => {
+          it('should set entities with loaded flag', () => {
+            const stateBefore = {
+              remoteEntities: {
+                relUser: {
+                  entities: []
+                }
+              }
+            }
+
+            const fieldName = 'relUser2'
+            const remoteEntities = [
+              {key: 1, label: 'One'},
+              {key: 2, label: 'Two'}
+            ]
+
+            const expectedStateAfter = {
+              remoteEntities: {
+                relUser: {
+                  entities: []
+                },
+                [fieldName]: {
+                  entities: remoteEntities,
+                  loading: false
+                }
+              }
+            }
+
+            expect(reducer(stateBefore, actions.setRemoteEntity(fieldName, remoteEntities)))
+              .to.deep.equal(expectedStateAfter)
+          })
+
+          describe('setRemoteEntityLoading', () => {
+            it('should set loading flag', () => {
+              const stateBefore = {
+                remoteEntities: {
+                  relUser: {
+                    entities: []
+                  },
+                  relUser2: {
+                    entities: [],
+                    loading: false
+                  }
+                }
+              }
+
+              const fieldName = 'relUser2'
+
+              const expectedStateAfter = {
+                remoteEntities: {
+                  relUser: {
+                    entities: []
+                  },
+                  [fieldName]: {
+                    entities: [],
+                    loading: true
+                  }
+                }
+              }
+
+              expect(reducer(stateBefore, actions.setRemoteEntityLoading(fieldName))).to.deep.equal(expectedStateAfter)
+            })
           })
         })
       })

--- a/packages/entity-detail/src/util/api/entities.js
+++ b/packages/entity-detail/src/util/api/entities.js
@@ -55,14 +55,18 @@ function buildParams({
   page = undefined,
   orderBy = {},
   limit = undefined,
-  fields = [],
+  paths = [],
+  fields = undefined,
+  relations = undefined,
   searchFilters = [],
   searchInputs = {},
   formName = undefined
 } = {}) {
   const params = {
     '_sort': Object.keys(orderBy || {}).length === 2 ? `${orderBy.name} ${orderBy.direction}` : undefined,
-    '_paths': fields.join(','),
+    '_paths': paths.join(','),
+    '_fields': fields && fields.length === 0 ? '!' : fields ? fields.join(',') : null,
+    '_relations': relations && relations.length === 0 ? '!' : relations ? relations.join(',') : null,
     '_form': formName,
     '_filter': searchFilters.join(','),
     ...searchInputs

--- a/packages/entity-detail/src/util/api/entities.spec.js
+++ b/packages/entity-detail/src/util/api/entities.spec.js
@@ -14,17 +14,35 @@ describe('entity-detail', () => {
           it('should call fetch', () => {
             fetchMock.get('*', {data: [{fields: {a: 'a'}}]})
 
-            const fields = ['f1', 'f2']
+            const paths = ['f1', 'f2']
             return entities.fetchEntities('User', {
               page: 2,
               orderBy: 'firstname',
               limit: 20,
-              fields: fields,
+              paths: paths,
               searchInputs: {_search: 'test'}
             }).then(() => {
               expect(fetchMock.calls().matched).to.have.length(1)
               const lastCall = fetchMock.lastCall()[0]
               expect(lastCall).to.eql('/nice2/rest/entities/User?_limit=20&_offset=20&_paths=f1%2Cf2&_search=test')
+            })
+          })
+
+          it('should set exclamation mark for fields and relations if explicitly empty', () => {
+            fetchMock.get('*', {data: [{fields: {a: 'a'}}]})
+
+            return entities.fetchEntities('User', {
+              page: 2,
+              orderBy: 'firstname',
+              limit: 20,
+              fields: [],
+              relations: [],
+              searchInputs: {_search: 'test'}
+            }).then(() => {
+              expect(fetchMock.calls().matched).to.have.length(1)
+              const lastCall = fetchMock.lastCall()[0]
+              expect(lastCall)
+                .to.eql('/nice2/rest/entities/User?_fields=!&_limit=20&_offset=20&_relations=!&_search=test')
             })
           })
         })

--- a/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
@@ -39,13 +39,15 @@ class RemoteSelect extends React.Component {
 
 RemoteSelect.propTypes = {
   onChange: React.PropTypes.func,
-  value: React.PropTypes.shape(
-    {
+  value: React.PropTypes.oneOfType([
+    React.PropTypes.shape({
       key: React.PropTypes.oneOfType([
         React.PropTypes.string,
         React.PropTypes.number
       ])
     }),
+    React.PropTypes.string // empty string coming from Redux Form if value null
+  ]),
   options: React.PropTypes.shape({
     options: React.PropTypes.array,
     fetchOptions: React.PropTypes.func,


### PR DESCRIPTION
Changes applied compared to entity-browser:

- `loadRemoteEntity` saga has to be registered with `takeEvery` effect
  instead of `takeLatest`, because it might be triggered for several select
  boxes in parallel (they must not cancel each other).
  - Both "relation entities" and "remote entities" should be loaded without
    fields and without relations (query params: _fields=!&_relations=!), since
    we only need the key and the display value to display. It might be much
    faster this way.