### PR TITLE
feat(entity-detail): Introduce external event `onTouchedChange`

### DIFF
--- a/packages/entity-detail/README.md
+++ b/packages/entity-detail/README.md
@@ -13,3 +13,4 @@
 | Name                | Payload                                                                                                            | Description
 |---------------------|--------------------------------------------------------------------------------------------------------------------|-------------
 | `onSubGridRowClick` | `id` (id of the clicked record), `gridName` (name of the sub grid), `relationName` (name of the sub grid relation) | This event is fired when a row of a sub grid is clicked
+| `onTouchedChange`   | `touched` (boolean flag which indicates if the form is touched)                                                    | This event is fired when the touched state changes

--- a/packages/entity-detail/src/components/DetailForm/DetailForm.js
+++ b/packages/entity-detail/src/components/DetailForm/DetailForm.js
@@ -16,6 +16,7 @@ export class DetailForm extends React.Component {
 
   componentWillReceiveProps(props) {
     this.formBuilder = this.createFormBuilder(props)
+    this.props.fireTouched(props.anyTouched)
   }
 
   createFormBuilder = props => {
@@ -164,7 +165,8 @@ DetailForm.propTypes = {
       React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object])))
   ),
   valid: React.PropTypes.bool,
-  lastSave: React.PropTypes.number
+  lastSave: React.PropTypes.number,
+  fireTouched: React.PropTypes.func.isRequired
 }
 
 export default reduxForm({

--- a/packages/entity-detail/src/components/DetailForm/DetailForm.spec.js
+++ b/packages/entity-detail/src/components/DetailForm/DetailForm.spec.js
@@ -102,6 +102,7 @@ describe('entity-detail', () => {
                 form="detailForm"
                 intl={IntlStub}
                 touch={EMPTY_FUNC}
+                fireTouched={EMPTY_FUNC}
               />
             </MemoryRouter>
           </Provider>

--- a/packages/entity-detail/src/components/DetailView/DetailView.js
+++ b/packages/entity-detail/src/components/DetailView/DetailView.js
@@ -74,6 +74,7 @@ class DetailView extends React.Component {
             intl={props.intl}
             lastSave={props.lastSave}
             goBack={this.handleGoBack}
+            fireTouched={props.fireTouched}
           />
         </LoadMask>
       </div>
@@ -127,7 +128,8 @@ DetailView.propTypes = {
   }).isRequired,
   showBackButton: React.PropTypes.bool,
   lastSave: React.PropTypes.number,
-  parentUrl: React.PropTypes.string
+  parentUrl: React.PropTypes.string,
+  fireTouched: React.PropTypes.func.isRequired
 }
 
 DetailView.defaultProps = {

--- a/packages/entity-detail/src/components/DetailView/DetailView.spec.js
+++ b/packages/entity-detail/src/components/DetailView/DetailView.spec.js
@@ -38,6 +38,7 @@ describe('entity-detail', () => {
           submitForm={EMPTY_FUNC}
           logError={EMPTY_FUNC}
           showBackButton
+          fireTouched={EMPTY_FUNC}
         />)
 
         expect(wrapper.find('.detail-view')).to.have.length(1)
@@ -72,6 +73,7 @@ describe('entity-detail', () => {
           submitForm={EMPTY_FUNC}
           logError={EMPTY_FUNC}
           showBackButton={false}
+          fireTouched={EMPTY_FUNC}
         />)
 
         expect(wrapper.find(Button)).to.have.length(0)

--- a/packages/entity-detail/src/containers/DetailViewContainer.js
+++ b/packages/entity-detail/src/containers/DetailViewContainer.js
@@ -13,7 +13,8 @@ import {
   unloadDetailView,
   submitForm,
   loadRelationEntity,
-  loadRemoteEntity
+  loadRemoteEntity,
+  fireTouched
 } from '../modules/entityDetail/actions'
 import DetailView from '../components/DetailView/DetailView'
 import {logError} from 'tocco-util/src/errorLogging'
@@ -24,7 +25,8 @@ const mapActionCreators = {
   submitForm,
   loadRelationEntity,
   loadRemoteEntity,
-  logError
+  logError,
+  fireTouched
 }
 
 const getFormGeneralErros = formName =>

--- a/packages/entity-detail/src/modules/entityDetail/actions.js
+++ b/packages/entity-detail/src/modules/entityDetail/actions.js
@@ -11,6 +11,8 @@ export const SET_RELATION_ENTITY_LOADED = 'entityDetail/SET_RELATION_ENTITY_LOAD
 export const LOAD_REMOTE_ENTITY = 'entityDetail/LOAD_REMOTE_ENTITY'
 export const SET_REMOTE_ENTITY = 'entityDetail/SET_REMOTE_ENTITY'
 export const SET_REMOTE_ENTITY_LOADING = 'entityDetail/SET_REMOTE_ENTITY_LOADING'
+export const FIRE_TOUCHED = 'entityDetail/FIRE_TOUCHED'
+export const SET_TOUCHED = 'entityDetail/SET_TOUCHED'
 
 export const setFormDefinition = formDefinition => ({
   type: SET_FORM_DEFINITION,
@@ -100,5 +102,19 @@ export const setRemoteEntityLoading = field => ({
   type: SET_REMOTE_ENTITY_LOADING,
   payload: {
     field
+  }
+})
+
+export const fireTouched = touched => ({
+  type: FIRE_TOUCHED,
+  payload: {
+    touched
+  }
+})
+
+export const setTouched = touched => ({
+  type: SET_TOUCHED,
+  payload: {
+    touched
   }
 })

--- a/packages/entity-detail/src/modules/entityDetail/reducer.js
+++ b/packages/entity-detail/src/modules/entityDetail/reducer.js
@@ -72,7 +72,8 @@ const ACTION_HANDLERS = {
   [actions.SET_RELATION_ENTITY]: setRelationEntity,
   [actions.SET_RELATION_ENTITY_LOADED]: setRelationEntityLoaded,
   [actions.SET_REMOTE_ENTITY]: setRemoteEntity,
-  [actions.SET_REMOTE_ENTITY_LOADING]: setRemoteEntityLoading
+  [actions.SET_REMOTE_ENTITY_LOADING]: setRemoteEntityLoading,
+  [actions.SET_TOUCHED]: reducers.singleTransferReducer('touched')
 }
 
 const initialState = {
@@ -80,7 +81,8 @@ const initialState = {
   entity: {},
   entityModel: {},
   relationEntities: {},
-  remoteEntities: {}
+  remoteEntities: {},
+  touched: false
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/entity-detail/src/modules/entityDetail/reducer.spec.js
+++ b/packages/entity-detail/src/modules/entityDetail/reducer.spec.js
@@ -6,7 +6,8 @@ const EXPECTED_INITIAL_STATE = {
   entity: {},
   entityModel: {},
   relationEntities: {},
-  remoteEntities: {}
+  remoteEntities: {},
+  touched: false
 }
 
 describe('entity-detail', () => {
@@ -211,6 +212,21 @@ describe('entity-detail', () => {
 
               expect(reducer(stateBefore, actions.setRemoteEntityLoading(fieldName))).to.deep.equal(expectedStateAfter)
             })
+          })
+        })
+
+        describe('SET_TOUCHED', () => {
+          it('should handle SET_TOUCHED', () => {
+            const stateBefore = {
+              otherProp: 'foo',
+              touched: false
+            }
+
+            const expectedStateAfter = {
+              otherProp: 'foo',
+              touched: true
+            }
+            expect(reducer(stateBefore, actions.setTouched(true))).to.deep.equal(expectedStateAfter)
           })
         })
       })


### PR DESCRIPTION
Can be used in the parent component to display a confirmation message
if user navigates away from the detail view, but has unsaved changes.