### PR TITLE
refactor(entity-util): formField readonly clean up

### DIFF
--- a/packages/entity-detail/src/components/ReduxFormFieldAdapter/ReduxFormFieldAdapter.js
+++ b/packages/entity-detail/src/components/ReduxFormFieldAdapter/ReduxFormFieldAdapter.js
@@ -30,7 +30,7 @@ const ReduxFormFieldAdapter = props => {
     value: input.value,
     dirty,
     touched,
-    readOnly: submitting,
+    submitting,
     events,
     error,
     onChange: input.onChange,

--- a/packages/tocco-util/src/formField/formField.js
+++ b/packages/tocco-util/src/formField/formField.js
@@ -17,16 +17,16 @@ export const formFieldFactory = (mapping, data, resources = {}) => {
       events,
       error,
       utils,
-      readOnly
+      submitting
     } = data
 
-    const readOnlyFinally = (
+    const readOnly = (
       formDefinitionField.displayType === 'READONLY'
-      || readOnly === true
+      || submitting
       || !_get(entityField, 'value.writable', true)
     )
 
-    const mandatory = _get(modelField, `validation.mandatory`, false)
+    const mandatory = _get(modelField, `validation.mandatory`, false) && !readOnly
 
     const valueField = valueFieldFactory(
       mapping,
@@ -36,7 +36,7 @@ export const formFieldFactory = (mapping, data, resources = {}) => {
         id,
         value,
         onChange,
-        readOnly: readOnlyFinally,
+        readOnly,
         mandatory
       },
       events,
@@ -48,7 +48,7 @@ export const formFieldFactory = (mapping, data, resources = {}) => {
         key={id}
         id={id}
         label={formDefinitionField.label}
-        mandatory={!readOnlyFinally && mandatory}
+        mandatory={mandatory}
         mandatoryTitle={resources.mandatoryTitle}
         error={error}
         touched={touched}


### PR DESCRIPTION
- pass submitting to formfield and handle readonly there.
  This change helps to make code simpler.