### PR TITLE
chore(tocco-client): switch license to AGPLv3+ (adding the +)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     }
   },
   "author": "Tocco AG",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0+",
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2"


### PR DESCRIPTION
Omitting the + means we can't upgrade to a new version of the
license should the copyright holder of any commit ever be any
other party than Tocco. Also, we really want to be able to
upgrade in case the license turns out to be flawed, legally
unenforceable or if legal circumstances change.

note: SPDX allows a + suffix to indicate "or any later version"