### PR TITLE
feat(tocco-util): Add REST request functions as sagas

### DIFF
--- a/packages/tocco-util/src/rest/index.js
+++ b/packages/tocco-util/src/rest/index.js
@@ -1,3 +1,3 @@
-import {request, getRequest, setNullBusinessUnit} from './rest'
+import {request, requestSaga, getRequest, getRequestSaga, setNullBusinessUnit} from './rest'
 
-export {request, getRequest, setNullBusinessUnit}
+export {request, requestSaga, getRequest, getRequestSaga, setNullBusinessUnit}


### PR DESCRIPTION
- New functions/generators `requestSaga` (for function `request`)
  and `getRequestSaga` (for function `getRequest`).
- Advantage of sagas instead of normal functions: we can put
  redux actions or call other sagas (will be used for client question
  stuff, which will be handled directly in the REST utils).
- Old functions `request` and `getRequest` are deprecated and
  should not be used anymore.