### PR TITLE
fix: Include `entity-detail` fetch mocks in `entity-browser`

### DIFF
--- a/packages/entity-browser/src/main.js
+++ b/packages/entity-browser/src/main.js
@@ -91,6 +91,9 @@ const initApp = (id, input, events, publicPath) => {
       const listFetchMocks = require('tocco-entity-list/src/dev/fetchMocks')
       listFetchMocks(fetchMock)
 
+      const detailFetchMocks = require('tocco-entity-detail/src/dev/fetchMocks')
+      detailFetchMocks(fetchMock)
+
       fetchMock.spy()
     }
 


### PR DESCRIPTION
This way we don't have to define the fetch mock in both modules (for example
the text resources of the `entity-detail` module)