### PR TITLE
refactor: Replace deprecated function `request` with `simpleRequest`

### DIFF
--- a/packages/entity-detail/src/util/detailView/asyncValidation.js
+++ b/packages/entity-detail/src/util/detailView/asyncValidation.js
@@ -1,5 +1,5 @@
 import {SubmissionError} from 'redux-form'
-import {request} from 'tocco-util/src/rest'
+import {simpleRequest} from 'tocco-util/src/rest'
 import {formValuesToEntity, validationErrorToFormError, getDirtyFields} from './reduxForm'
 
 export class AsyncValidationException {
@@ -17,7 +17,12 @@ const hasError = errors => (
 const validateRequest = (values, initialValues) => {
   const dirtyFields = getDirtyFields(initialValues, values)
   const entity = formValuesToEntity(values, dirtyFields)
-  return request(`entities/${entity.model}/${entity.key}`, {_validate: true}, 'PATCH', entity)
+  const options = {
+    queryParams: {_validate: true},
+    method: 'PATCH',
+    body: entity
+  }
+  return simpleRequest(`entities/${entity.model}/${entity.key}`, options)
     .then(resp => resp.body)
     .then(body => {
       if (body.valid) {

--- a/packages/tocco-util/src/rest/index.js
+++ b/packages/tocco-util/src/rest/index.js
@@ -1,17 +1,13 @@
 import {
-  request,
   requestSaga,
-  getRequest,
-  getRequestSaga,
-  setNullBusinessUnit
+  setNullBusinessUnit,
+  simpleRequest
 } from './rest'
 import ClientQuestionCancelledException from './ClientQuestionCancelledException'
 
 export {
-  request,
   requestSaga,
-  getRequest,
-  getRequestSaga,
   setNullBusinessUnit,
+  simpleRequest,
   ClientQuestionCancelledException
 }

--- a/packages/tocco-util/src/rest/request.js
+++ b/packages/tocco-util/src/rest/request.js
@@ -1,4 +1,4 @@
-const handleError = (response, acceptedErrorCodes, acceptedStatusCodes) => {
+const handleError = (response, acceptedErrorCodes = [], acceptedStatusCodes = []) => {
   if (!response.ok
     && !acceptedStatusCodes.includes(response.status)
     && !acceptedErrorCodes.includes(response.body.errorCode)) {

--- a/packages/tocco-util/src/rest/rest.js
+++ b/packages/tocco-util/src/rest/rest.js
@@ -20,32 +20,10 @@ export const getParameterString = params => {
   return ''
 }
 
-/**
- * @deprecated #requestSaga should be used, since it allows to put actions or to call other sagas
- */
-export const getRequest = (resource, params, acceptedErrorCodes = []) => {
-  return request(resource, params, 'GET', undefined, acceptedErrorCodes)
-}
-
 let nullBusinessUnit = false
 
 export const setNullBusinessUnit = value => {
   nullBusinessUnit = value
-}
-
-/**
- * @deprecated #requestSaga should be used, since it allows to put actions or to call other sagas
- */
-export const request = (resource, queryParams, method, body, acceptedErrorCodes = [], acceptedStatusCodes = []) => {
-  const options = {
-    queryParams,
-    method,
-    body,
-    acceptedErrorCodes,
-    acceptedStatusCodes
-  }
-  const requestData = prepareRequest(resource, options)
-  return sendRequest(requestData.url, requestData.options, options.acceptedErrorCodes, options.acceptedStatusCodes)
 }
 
 /**
@@ -71,6 +49,29 @@ export function* requestSaga(resource, options = {}) {
   )
   response = yield call(handleClientQuestion, response, requestData, options)
   return response
+}
+
+/**
+ * Send a simple REST request.
+ *
+ * Caution: Only prefer this function over `requestSaga`, if you can't
+ * use the saga. Note that this simple request function does not support
+ * things like client questions.
+ *
+ * @param resource {String} The URL to fetch.
+ * @param options {Object} An object which can contain the following options:
+ * - queryParams {Object}
+ * - method {String}
+ * - body {Object}
+ * - acceptedErrorCodes {Array}
+ * - acceptedStatusCodes {Array}
+ * - backendUrl {String}
+ *
+ * @see requestSaga
+ */
+export const simpleRequest = (resource, options = {}) => {
+  const requestData = prepareRequest(resource, options)
+  return sendRequest(requestData.url, requestData.options, options.acceptedErrorCodes, options.acceptedStatusCodes)
 }
 
 export function prepareRequest(resource, options = {}) {

--- a/packages/tocco-util/src/rest/rest.spec.js
+++ b/packages/tocco-util/src/rest/rest.spec.js
@@ -1,7 +1,7 @@
 import {call} from 'redux-saga/effects'
 import {
   getParameterString,
-  request,
+  simpleRequest,
   requestSaga,
   setNullBusinessUnit,
   prepareRequest
@@ -59,7 +59,7 @@ describe('tocco-util', () => {
       })
     })
 
-    describe('request', () => {
+    describe('simpleRequest', () => {
       beforeEach(() => {
         fetchMock.reset()
         fetchMock.restore()
@@ -80,7 +80,10 @@ describe('tocco-util', () => {
 
         fetchMock.get('*', mockedResponse)
         const resource = 'entities/Contact'
-        request(resource, {}, 'GET', {}, ['SAVE_FAILED']).then(response => {
+        const options = {
+          acceptedErrorCodes: ['SAVE_FAILED']
+        }
+        simpleRequest(resource, options).then(response => {
           expect(response.status).to.eql(statusCode)
           expect(response.body).to.eql(bodyObj)
           done()
@@ -98,7 +101,7 @@ describe('tocco-util', () => {
 
         fetchMock.get('*', mockedResponse)
         const resource = 'entities/Contact'
-        request(resource, {}, 'GET', {}, []).catch(() => {
+        simpleRequest(resource).catch(() => {
           done()
         })
       })
@@ -106,7 +109,7 @@ describe('tocco-util', () => {
       it('should set content type header', () => {
         fetchMock.get('*', {})
 
-        request('', {}, 'GET', {}, [])
+        simpleRequest('')
 
         const headers = fetchMock.lastOptions().headers
         expect(headers.get('randomxyxc')).to.be.null
@@ -116,12 +119,12 @@ describe('tocco-util', () => {
       it('should set null business unit header', () => {
         fetchMock.get('*', {})
 
-        request('', {}, 'GET', {}, [])
+        simpleRequest('')
         const headers = fetchMock.lastOptions().headers
         expect(headers.get('x-business-unit')).to.be.null
 
         setNullBusinessUnit(true)
-        request('', {}, 'GET', {}, [])
+        simpleRequest('')
         setNullBusinessUnit(false)
 
         const headers2 = fetchMock.lastOptions().headers
@@ -131,11 +134,13 @@ describe('tocco-util', () => {
       it('should use ordered params', () => {
         fetchMock.get('*', {})
         const resource = 'entities/Contact'
-        const params = {
-          _search: 'test',
-          xyz: 'abc'
+        const options = {
+          queryParams: {
+            _search: 'test',
+            xyz: 'abc'
+          }
         }
-        request(resource, params)
+        simpleRequest(resource, options)
 
         const lastCall = fetchMock.lastCall()[0]
         expect(lastCall).to.eql('/nice2/rest/entities/Contact?_search=test&xyz=abc')
@@ -149,7 +154,9 @@ describe('tocco-util', () => {
 
         fetchMock.get('*', mockedResponse)
         const resource = 'entities/Contact'
-        request(resource, undefined, undefined, undefined, undefined, [400]).then(response => {
+        simpleRequest(resource, {
+          acceptedStatusCodes: [400]
+        }).then(response => {
           expect(response.status).to.eql(statusCode)
           expect(response.body).to.eql({})
           done()
@@ -164,7 +171,7 @@ describe('tocco-util', () => {
 
         fetchMock.get('*', mockedResponse)
         const resource = 'entities/Contact'
-        request(resource, undefined, undefined, undefined, undefined, []).catch(() => {
+        simpleRequest(resource).catch(() => {
           done()
         })
       })


### PR DESCRIPTION
This function returns a promise and can be used outside of sagas.
Please note that in contrast to `requestSaga` it does not support
client questions. Whenever possible, `requestSaga` should be used.