### PR TITLE
refactor(entity-detail): rewrite getDirtyFields

### DIFF
--- a/packages/entity-detail/src/util/detailView/reduxForm.js
+++ b/packages/entity-detail/src/util/detailView/reduxForm.js
@@ -1,4 +1,4 @@
-import _reduce from 'lodash/reduce'
+import _forOwn from 'lodash/forOwn'
 import _isEqual from 'lodash/isEqual'
 
 import {generalErrorField} from './formErrors'
@@ -64,10 +64,14 @@ export const entityToFormValues = entity => {
   return result
 }
 
-export const getDirtyFields = (initialValues, values) => (
-  _reduce(
-    initialValues,
-    (result, value, key) => _isEqual(value, values[key]) ? result : result.concat(key),
-    []
-  )
-)
+export const getDirtyFields = (initialValues, values) => {
+  const dirtyFields = []
+
+  _forOwn(initialValues, (value, key) => {
+    if (!_isEqual(value, values[key])) {
+      dirtyFields.push(key)
+    }
+  })
+
+  return dirtyFields
+}


### PR DESCRIPTION
when loaded in nice2 context, getDirtyFields always returned an empty array.
It seems like the reduce function from lodash internally uses a function, that behaves differently when running in nice2 context.
Probably a polyfill overwrites a functionality.
It couldn't be analyzed what exactly caused this so in a simple workaround the whole method got rewritten to work without _reduce

Signed-off-by: Daniel Keller <dkeller@tocco.ch>