### PR TITLE
refactor(entity-list): preselectedSearchFields input not mandatory

### DIFF
--- a/packages/entity-list/src/components/SearchForm/SearchForm.js
+++ b/packages/entity-list/src/components/SearchForm/SearchForm.js
@@ -56,6 +56,9 @@ class SearchForm extends React.Component {
   msg = id => (this.props.intl.formatMessage({id}))
 
   isHidden = name => {
+    if (!this.props.preselectedSearchFields) {
+      return false
+    }
     const field = this.props.preselectedSearchFields.find(f => f.id === name)
     return field && field.hidden
   }
@@ -147,7 +150,7 @@ SearchForm.propTypes = {
       id: React.PropTypes.string.isRequired,
       hidden: React.PropTypes.bool
     })
-  ).isRequired
+  )
 }
 
 export default reduxForm({


### PR DESCRIPTION
- otherwise there will be an error, if an empty array is not set in input