### PR TITLE
refactor(entity-list): fix sequence problem

### DIFF
--- a/packages/entity-list/src/input.js
+++ b/packages/entity-list/src/input.js
@@ -11,7 +11,8 @@ export const getDispatchActions = input => {
   const actions = [
     setEntityName(input.entityName),
     setListFormName(`${input.formBase}_list`),
-    setSearchFormName(`${input.formBase}_search`)
+    setSearchFormName(`${input.formBase}_search`),
+    setPreselectedSearchFields(input.preselectedSearchFields || [])
   ]
 
   if (input.limit) {
@@ -28,10 +29,6 @@ export const getDispatchActions = input => {
 
   if (typeof input.disableSimpleSearch === 'boolean') {
     actions.push(setDisableSimpleSearch(input.disableSimpleSearch))
-  }
-
-  if (input.preselectedSearchFields) {
-    actions.push(setPreselectedSearchFields(input.preselectedSearchFields))
   }
 
   if (input.simpleSearchFields) {

--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -1,24 +1,20 @@
+import _isEmpty from 'lodash/isEmpty'
 import {call, put, fork, select, spawn, takeEvery, takeLatest, all} from 'redux-saga/effects'
 import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
-import {getSearchInputsForRequest} from '../../util/searchInputs'
+import {getSearchInputs} from '../searchForm/sagas'
 import {fetchForm, columnDefinitionTransformer, getFieldsOfColumnDefinition} from '../../util/api/forms'
 import {fetchEntityCount, fetchEntities, entitiesListTransformer, fetchModel} from '../../util/api/entities'
-import _clone from 'lodash/clone'
-import _isEmpty from 'lodash/isEmpty'
-import {getFormValues, reset} from 'redux-form'
 
 export const inputSelector = state => state.input
 export const entityListSelector = state => state.entityList
 export const listSelector = state => state.list
-export const searchValuesSelector = getFormValues('searchForm')
 
 export default function* sagas() {
   yield all([
     fork(takeLatest, actions.INITIALIZE, initialize),
     fork(takeLatest, actions.CHANGE_PAGE, changePage),
     fork(takeLatest, searchFormActions.EXECUTE_SEARCH, resetDataSet),
-    fork(takeLatest, searchFormActions.RESET_SEARCH, resetSearch),
     fork(takeEvery, actions.SET_ORDER_BY, resetDataSet),
     fork(takeEvery, actions.RESET_DATA_SET, resetDataSet),
     fork(takeLatest, actions.REFRESH, refresh)
@@ -59,21 +55,6 @@ export function* changePage({payload}) {
   yield put(actions.setCurrentPage(page))
   yield call(requestEntities, page)
   yield put(actions.setInProgress(false))
-}
-
-export function* getSearchInputs() {
-  const searchInputs = yield select(searchValuesSelector)
-
-  const clonedSearchInputs = _clone(searchInputs)
-  const {entityModel} = yield select(listSelector)
-
-  if (searchInputs && searchInputs.txtFulltext) {
-    clonedSearchInputs._search = searchInputs.txtFulltext
-    delete clonedSearchInputs.txtFulltext
-  }
-
-  const result = yield call(getSearchInputsForRequest, clonedSearchInputs, entityModel)
-  return result
 }
 
 export function* fetchEntitiesAndAddToStore(page) {
@@ -157,9 +138,4 @@ export function* resetDataSet() {
 
   yield call(changePage, {payload: {page: 1}})
   yield put(actions.setInProgress(false))
-}
-
-export function* resetSearch() {
-  yield put(reset('searchForm'))
-  yield call(resetDataSet)
 }

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -1,9 +1,8 @@
 import {put, select, call, fork, spawn, takeLatest, takeEvery, all} from 'redux-saga/effects'
-import {reset} from 'redux-form'
 import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
+import {getSearchInputs} from '../searchForm/sagas'
 import rootSaga, * as sagas from './sagas'
-import {getSearchInputsForRequest} from '../../util/searchInputs'
 import {fetchForm, columnDefinitionTransformer} from '../../util/api/forms'
 import {fetchEntityCount, fetchEntities, entitiesListTransformer, fetchModel} from '../../util/api/entities'
 
@@ -28,7 +27,6 @@ describe('entity-list', () => {
               fork(takeLatest, actions.INITIALIZE, sagas.initialize),
               fork(takeLatest, actions.CHANGE_PAGE, sagas.changePage),
               fork(takeLatest, searchFormActions.EXECUTE_SEARCH, sagas.resetDataSet),
-              fork(takeLatest, searchFormActions.RESET_SEARCH, sagas.resetSearch),
               fork(takeEvery, actions.SET_ORDER_BY, sagas.resetDataSet),
               fork(takeEvery, actions.RESET_DATA_SET, sagas.resetDataSet),
               fork(takeLatest, actions.REFRESH, sagas.refresh)
@@ -107,7 +105,7 @@ describe('entity-list', () => {
             const gen = sagas.fetchEntitiesAndAddToStore(1)
             expect(gen.next().value).to.eql(select(sagas.inputSelector))
             expect(gen.next(input).value).to.eql(select(sagas.listSelector))
-            expect(gen.next(listViewState).value).to.eql(call(sagas.getSearchInputs))
+            expect(gen.next(listViewState).value).to.eql(call(getSearchInputs))
             expect(gen.next(searchInputs).value).to.eql(
               call(fetchEntities, input.entityName, fetchParams, entitiesListTransformer)
             )
@@ -178,7 +176,7 @@ describe('entity-list', () => {
 
             expect(gen.next().value).to.eql(put(actions.setInProgress(true)))
             expect(gen.next().value).to.eql(select(sagas.inputSelector))
-            expect(gen.next({entityName, searchFilters, formBase}).value).to.eql(call(sagas.getSearchInputs))
+            expect(gen.next({entityName, searchFilters, formBase}).value).to.eql(call(getSearchInputs))
             expect(gen.next(searchInputs).value).to.eql(call(fetchEntityCount, entityName, fetchParams))
             expect(gen.next(entityCount).value).to.eql(put(actions.setEntityCount(entityCount)))
             expect(gen.next().value).to.eql(put(actions.clearEntityStore()))
@@ -200,18 +198,6 @@ describe('entity-list', () => {
             expect(gen.next(state).value).to.eql(put(actions.clearEntityStore(entities)))
             expect(gen.next(state).value).to.eql(call(sagas.requestEntities, page))
             expect(gen.next().value).to.eql(put(actions.setInProgress(false)))
-            expect(gen.next().done).to.be.true
-          })
-        })
-
-        describe('getSearchInputs saga', () => {
-          it('should get searchInputs', () => {
-            const entityModel = {}
-            const searchValues = {}
-            const gen = sagas.getSearchInputs()
-            expect(gen.next().value).to.eql(select(sagas.searchValuesSelector))
-            expect(gen.next(searchValues).value).to.eql(select(sagas.listSelector))
-            expect(gen.next({entityModel}).value).to.eql(call(getSearchInputsForRequest, searchValues, entityModel))
             expect(gen.next().done).to.be.true
           })
         })
@@ -258,15 +244,6 @@ describe('entity-list', () => {
             }
 
             const gen = sagas.loadEntityModel(entityName, entityModel)
-            expect(gen.next().done).to.be.true
-          })
-        })
-
-        describe('resetSearch saga', () => {
-          it('should reset the form and trigger a search', () => {
-            const gen = sagas.resetSearch()
-            expect(gen.next().value).to.eql(put(reset('searchForm')))
-            expect(gen.next().value).to.eql(call(sagas.resetDataSet))
             expect(gen.next().done).to.be.true
           })
         })

--- a/packages/entity-list/src/modules/searchForm/actions.js
+++ b/packages/entity-list/src/modules/searchForm/actions.js
@@ -12,6 +12,7 @@ export const SET_PRESELECTED_SEARCH_FIELDS = 'searchForm/SET_PRESELECTED_SEARCH_
 export const SET_DISABLE_SIMPLE_SEARCH = 'searchForm/SET_DISABLE_SIMPLE_SEARCH'
 export const SET_SEARCH_FORM_NAME = 'searchForm/SET_SEARCH_FORM_NAME'
 export const SUBMIT_SEARCH_FORM = 'searchForm/SUBMIT_SEARCH_FORM'
+export const SET_VALUES_INITIALIZED = 'searchForm/SET_VALUES_INITIALIZED'
 
 export const setInitialized = (initialized = true) => ({
   type: SET_INITIALIZED,
@@ -99,4 +100,11 @@ export const setSearchFormName = searchFormName => ({
 
 export const submitSearchForm = () => ({
   type: SUBMIT_SEARCH_FORM
+})
+
+export const setValuesInitialized = valuesInitialized => ({
+  type: SET_VALUES_INITIALIZED,
+  payload: {
+    valuesInitialized
+  }
 })

--- a/packages/entity-list/src/modules/searchForm/reducer.js
+++ b/packages/entity-list/src/modules/searchForm/reducer.js
@@ -61,7 +61,8 @@ const ACTION_HANDLERS = {
   [actions.SET_SHOW_EXTENDED_SEARCH_FORM]: reducers.singleTransferReducer('showExtendedSearchForm'),
   [actions.SET_DISABLE_SIMPLE_SEARCH]: reducers.singleTransferReducer('disableSimpleSearch'),
   [actions.SET_RELATION_ENTITY]: setRelationEntity,
-  [actions.SET_RELATION_ENTITY_LOADED]: setRelationEntityLoaded
+  [actions.SET_RELATION_ENTITY_LOADED]: setRelationEntityLoaded,
+  [actions.SET_VALUES_INITIALIZED]: reducers.singleTransferReducer('valuesInitialized')
 }
 
 const initialState = {
@@ -71,7 +72,8 @@ const initialState = {
   showExtendedSearchForm: false,
   simpleSearchFields: ['txtFulltext'],
   disableSimpleSearch: false,
-  relationEntities: {}
+  relationEntities: {},
+  valuesInitialized: false
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/entity-list/src/modules/searchForm/reducer.spec.js
+++ b/packages/entity-list/src/modules/searchForm/reducer.spec.js
@@ -8,7 +8,8 @@ const EXPECTED_INITIAL_STATE = {
   showExtendedSearchForm: false,
   simpleSearchFields: ['txtFulltext'],
   disableSimpleSearch: false,
-  relationEntities: {}
+  relationEntities: {},
+  valuesInitialized: false
 }
 
 describe('entity-list', () => {


### PR DESCRIPTION
- before this change it could have happened, that the list loads it data
  without the preselected search fields being set.
- move reset saga to search module since the button is there