### PR TITLE
fix(tocco-ui): Use date only instead of date with time in DateEdit

### DIFF
--- a/packages/tocco-ui/src/EditableValue/specUtils.js
+++ b/packages/tocco-ui/src/EditableValue/specUtils.js
@@ -1,0 +1,23 @@
+/**
+ * Returns the expected date according to the current timezone (helps to write date tests
+ * which run in all time zones).
+ *
+ * Example:
+ *
+ * ```
+ * // -> expectedDate is `2017-08-20` if the current time zone is somewhere on the western side of the GMT+2 time zone
+ * //    (`-120` -> current time zone minus 120 minutes is GMT)
+ * // -> expectedDate is '2017-08-21' if the current time zone is GMT+2 or on the eastern side of it
+ * const expectedDate = getExpectedDate('2017-08-20', '2017-08-21', -120)
+ * ```
+ *
+ * @param westernDate The date which is expected if the current time zone is on the western side of the threshold
+ * @param easternDate The date which is expected if the current time zone is on the eastern side of the threshold
+ * (or same)
+ * @param thresholdOffset The time zone where to split east and west (`-120` = GMT+2. See #getTimezoneOffset())
+ * @returns the `westernDate` or `easternDate` depending on the current time zone.
+ */
+export const getExpectedDate = (westernDate, easternDate, thresholdOffset) => {
+  const timeZoneOffset = new Date().getTimezoneOffset()
+  return timeZoneOffset <= thresholdOffset ? easternDate : westernDate
+}

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateEdit.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import DateAbstract from './DateAbstract'
-import {atMostOne} from '../utils'
+import {atMostOne, toLocalDateString} from '../utils'
 
 const DateEdit = props => {
   const options = {
@@ -9,7 +9,11 @@ const DateEdit = props => {
     ...props.options
   }
 
-  const handleChange = dates => props.onChange(atMostOne(dates))
+  const handleChange = dates => {
+    const dateTime = atMostOne(dates)
+    const date = dateTime ? toLocalDateString(dateTime) : null
+    props.onChange(date)
+  }
 
   return (
     <DateAbstract value={[props.value]} onChange={handleChange} options={options} readOnly={props.readOnly}/>

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateEdit.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateEdit.spec.js
@@ -3,6 +3,7 @@ import {shallow} from 'enzyme'
 
 import DateEdit from './DateEdit'
 import DateAbstract from './DateAbstract'
+import {getExpectedDate} from '../specUtils'
 
 const EMPTY_FUNC = () => {
 }
@@ -21,9 +22,10 @@ describe('tocco-ui', () => {
           const dateAbstract = wrapper.find(DateAbstract)
           expect(dateAbstract).to.have.length(1)
 
-          dateAbstract.simulate('change', ['2017-04-13'])
+          dateAbstract.simulate('change', ['2017-04-12T22:00:00.000Z'])
 
-          expect(onChange).to.be.calledWith('2017-04-13')
+          const expectedDate = getExpectedDate('2017-04-12', '2017-04-13', -120)
+          expect(onChange).to.be.calledWith(expectedDate)
         })
 
         it('should throw an exception if multiple dates received from date picker', () => {
@@ -34,8 +36,8 @@ describe('tocco-ui', () => {
           const dateAbstract = wrapper.find(DateAbstract)
           expect(dateAbstract).to.have.length(1)
 
-          expect(() => dateAbstract.simulate('change', ['2017-04-13', '2017-04-14']))
-            .to.throw('Expected at most one item in array: 2017-04-13, 2017-04-14')
+          expect(() => dateAbstract.simulate('change', ['2017-04-12T22:00:00.000Z', '2017-04-13T22:00:00.000Z']))
+            .to.throw('Expected at most one item in array: 2017-04-12T22:00:00.000Z, 2017-04-13T22:00:00.000Z')
         })
       })
     })

--- a/packages/tocco-ui/src/EditableValue/utils.js
+++ b/packages/tocco-ui/src/EditableValue/utils.js
@@ -7,3 +7,27 @@ export const atMostOne = array => {
     throw new Error(`Expected at most one item in array: ${array.join(', ')}`)
   }
 }
+
+/**
+ * Get a date value as `YYYY-MM-DD` string representation.
+ *
+ * @param date Anything that the `Date` constructor accepts as single argument
+ * @returns {string} The given date in format `YYYY-MM-DD`
+ */
+export const toLocalDateString = date => {
+  if (date == null) {
+    return null
+  }
+
+  const dateObj = new Date(date)
+
+  const year = dateObj.getFullYear()
+  const month = dateObj.getMonth() + 1 // getMonth() is zero-based
+  const day = dateObj.getDate()
+
+  return [
+    year,
+    (month > 9 ? '' : '0') + month,
+    (day > 9 ? '' : '0') + day
+  ].join('-')
+}

--- a/packages/tocco-ui/src/EditableValue/utils.spec.js
+++ b/packages/tocco-ui/src/EditableValue/utils.spec.js
@@ -1,4 +1,5 @@
-import {atMostOne} from './utils'
+import {atMostOne, toLocalDateString} from './utils'
+import {getExpectedDate} from './specUtils'
 
 describe('tocco-ui', () => {
   describe('EditableValue', () => {
@@ -18,6 +19,27 @@ describe('tocco-ui', () => {
 
         it('should throw an error if array with multiple items given', () => {
           expect(() => atMostOne(['item1', 'item2'])).to.throw('Expected at most one item in array: item1, item2')
+        })
+      })
+
+      describe('toLocalDateString', () => {
+        it('should return null if null given', () => {
+          expect(toLocalDateString(null)).to.be.null
+        })
+
+        it('should return null if undefined given', () => {
+          expect(toLocalDateString(undefined)).to.be.null
+        })
+
+        it('should return first date if 0 given', () => {
+          const expectedDate = getExpectedDate('1969-12-31', '1970-01-01', 0)
+          expect(toLocalDateString(0)).to.eql(expectedDate)
+        })
+
+        it('should return the local date if a UTC date time string is given', () => {
+          const localDateString = toLocalDateString('2017-08-20T22:00:00.000Z')
+          const expectedDate = getExpectedDate('2017-08-20', '2017-08-21', -120)
+          expect(localDateString).to.eql(expectedDate)
         })
       })
     })


### PR DESCRIPTION
AbstractDate returns an array of ISO date-time strings in UTC.
We need to convert the string into a local date (without time)
in the current time zone (example if we're currently in the
GMT+2 time zone: '2017-04-12T22:00:00.000Z' -> '2017-04-13')