### PR TITLE
feat(entity-list): Refresh the current page on mount if initialized

### DIFF
--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -34,6 +34,8 @@ export function* initialize() {
       call(loadTableDefinition, columnDefinition, formBase)
     ])
     yield call(resetDataSet)
+  } else {
+    yield call(refresh)
   }
 
   yield put(actions.setInProgress(false))

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -41,19 +41,38 @@ describe('entity-list', () => {
             const formBase = 'Base_form'
             const columnDefinition = []
             const entityModel = {}
+            const initialized = false
 
             const gen = sagas.initialize()
             expect(gen.next().value).to.eql(put(actions.setInProgress(true)))
             expect(gen.next().value).to.eql(select(sagas.entityListSelector))
             expect(gen.next({entityName}).value).to.eql(select(sagas.inputSelector))
             expect(gen.next({formBase}).value).to.eql(select(sagas.listSelector))
-            const nextValue = gen.next({columnDefinition, entityModel}).value
+            const nextValue = gen.next({columnDefinition, entityModel, initialized}).value
             expect(nextValue).to.eql(all([
               call(sagas.loadEntityModel, entityName, entityModel),
               call(sagas.loadTableDefinition, columnDefinition, formBase)
             ]))
 
             expect(gen.next().value).to.eql(call(sagas.resetDataSet))
+            expect(gen.next().value).to.eql(put(actions.setInProgress(false)))
+            expect(gen.next().value).to.eql(put(actions.setInitialized()))
+            expect(gen.next().done).to.be.true
+          })
+
+          it('should refresh the current page if already initialized', () => {
+            const entityName = 'Test_entity'
+            const formBase = 'Base_form'
+            const columnDefinition = []
+            const entityModel = {}
+            const initialized = true
+
+            const gen = sagas.initialize()
+            expect(gen.next().value).to.eql(put(actions.setInProgress(true)))
+            expect(gen.next().value).to.eql(select(sagas.entityListSelector))
+            expect(gen.next({entityName}).value).to.eql(select(sagas.inputSelector))
+            expect(gen.next({formBase}).value).to.eql(select(sagas.listSelector))
+            expect(gen.next({columnDefinition, entityModel, initialized}).value).to.eql(call(sagas.refresh))
             expect(gen.next().value).to.eql(put(actions.setInProgress(false)))
             expect(gen.next().value).to.eql(put(actions.setInitialized()))
             expect(gen.next().done).to.be.true


### PR DESCRIPTION
The `initialize` saga is called when the list view is mounted.

In case it's already initialized, we should still refresh the current
page, since the displayed data might be outdated now (example: user
switches from the list view to the detail view of an entity, updates
the entity and returns back to the list -> list is now outdated and
should be refreshed).