### PR TITLE
refactor(tocco-ui): show pending indicator

### DIFF
--- a/packages/tocco-ui/src/Button/Button.js
+++ b/packages/tocco-ui/src/Button/Button.js
@@ -24,8 +24,7 @@ const Button = props => {
       disabled={props.disabled}
       type={props.type ? props.type : 'button'}
     >
-      {props.icon
-      && <i className={classNames('glyphicon', props.icon)}/>} {props.label || ''}
+      <i className={classNames('glyphicon', props.icon)}/> {props.label || ''}
     </button>)
 }
 

--- a/packages/tocco-ui/src/Button/Button.spec.js
+++ b/packages/tocco-ui/src/Button/Button.spec.js
@@ -88,15 +88,10 @@ describe('tocco-ui', function() {
     })
 
     it('should show icon', () => {
-      let wrapper = shallow(
+      const wrapper = shallow(
         <Button icon="icon"/>
       )
       expect(wrapper.find('i').hasClass('icon')).to.equal(true)
-
-      wrapper = shallow(
-        <Button/>
-      )
-      expect(wrapper.find('i')).to.have.length(0)
     })
 
     it('should set default type to button', () => {

--- a/packages/tocco-ui/src/Button/example.js
+++ b/packages/tocco-ui/src/Button/example.js
@@ -8,17 +8,18 @@ export default () => {
     <div>
       {/* start example */}
       <Button
-        label="Save"
+        label="Primary"
         primary
+      />
+      <Button
+        icon="glyphicon-heart"
         type="submit"
       />
-
       <Button
         label="Pending"
         pending
         onClick={() => alert('do something')}
       />
-
       <Button
         label="Disabled"
         disabled


### PR DESCRIPTION
- without this change, the pending icon only was shown, if an icon was
  set on button
- improve example