### PR TITLE
chore: set flexible package version for local packages

### DIFF
--- a/packages/entity-browser/package.json
+++ b/packages/entity-browser/package.json
@@ -25,11 +25,11 @@
     }
   },
   "devDependencies": {
-    "tocco-entity-detail": "0.1.9",
-    "tocco-entity-list": "0.1.9",
-    "tocco-test-util": "0.1.2",
-    "tocco-theme": "0.1.8",
-    "tocco-ui": "0.1.5",
-    "tocco-util": "0.1.6"
+    "tocco-entity-detail": ">0.1.0",
+    "tocco-entity-list": ">0.1.0",
+    "tocco-test-util": ">0.1.0",
+    "tocco-theme": ">0.1.0",
+    "tocco-ui": ">0.1.0",
+    "tocco-util": ">0.1.0"
   }
 }

--- a/packages/entity-detail/package.json
+++ b/packages/entity-detail/package.json
@@ -25,10 +25,10 @@
     }
   },
   "devDependencies": {
-    "tocco-entity-list": "0.1.9",
-    "tocco-test-util": "0.1.2",
-    "tocco-theme": "0.1.8",
-    "tocco-ui": "0.1.5",
-    "tocco-util": "0.1.6"
+    "tocco-entity-list": ">0.1.0",
+    "tocco-test-util": ">0.1.0",
+    "tocco-theme": ">0.1.0",
+    "tocco-ui": ">0.1.0",
+    "tocco-util": ">0.1.0"
   }
 }

--- a/packages/entity-list/package.json
+++ b/packages/entity-list/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "react-bootstrap-table": "^4.0.0-beta.2",
-    "tocco-test-util": "0.1.2",
-    "tocco-theme": "0.1.8",
-    "tocco-ui": "0.1.5",
-    "tocco-util": "0.1.6"
+    "tocco-test-util": ">0.1.0",
+    "tocco-theme": ">0.1.0",
+    "tocco-ui": ">0.1.0",
+    "tocco-util": ">0.1.0"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -25,9 +25,9 @@
     }
   },
   "devDependencies": {
-    "tocco-test-util": "0.1.2",
-    "tocco-theme": "0.1.8",
-    "tocco-ui": "0.1.5",
-    "tocco-util": "0.1.6"
+    "tocco-test-util": ">0.1.0",
+    "tocco-theme": ">0.1.0",
+    "tocco-ui": ">0.1.0",
+    "tocco-util": ">0.1.0"
   }
 }

--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -25,9 +25,9 @@
     }
   },
   "devDependencies": {
-    "tocco-test-util": "0.1.2",
-    "tocco-theme": "0.1.8",
-    "tocco-ui": "0.1.5",
-    "tocco-util": "0.1.6"
+    "tocco-test-util": ">0.1.0",
+    "tocco-theme": ">0.1.0",
+    "tocco-ui": ">0.1.0",
+    "tocco-util": ">0.1.0"
   }
 }

--- a/packages/tocco-ui-showcase/package.json
+++ b/packages/tocco-ui-showcase/package.json
@@ -34,7 +34,7 @@
     "react-docgen": "^2.12.1",
     "react-highlight": "^0.9.0",
     "react-scrollspy": "^2.5.0",
-    "tocco-theme": "0.1.8",
-    "tocco-util": "0.1.6"
+    "tocco-theme": ">0.1.0",
+    "tocco-util": ">0.1.0"
   }
 }

--- a/packages/tocco-ui-showcase/yarn.lock
+++ b/packages/tocco-ui-showcase/yarn.lock
@@ -228,14 +228,6 @@ source-map@~0.5.0:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-tocco-theme@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/tocco-theme/-/tocco-theme-0.1.4.tgz#1053f8387f57acfa6b8e18a832e45a5d5fb20061"
-
-tocco-util@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/tocco-util/-/tocco-util-0.1.5.tgz#5ff3269388648d3d6f0f2a3e456b642f8c3f6731"
-
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"

--- a/packages/tocco-util/package.json
+++ b/packages/tocco-util/package.json
@@ -4,7 +4,7 @@
   "description": "tocco util",
   "main": "src/main.js",
   "devDependencies": {
-    "tocco-test-util": "0.1.2",
-    "tocco-ui": "0.1.5"
+    "tocco-test-util": ">0.1.0",
+    "tocco-ui": ">0.1.0"
   }
 }

--- a/plop/templates/package/package.json
+++ b/plop/templates/package/package.json
@@ -26,9 +26,9 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "tocco-test-util": "0.1.2",
-    "tocco-theme": "0.1.4",
-    "tocco-ui": "0.1.4",
-    "tocco-util": "0.1.5"
+    "tocco-test-util": ">0.1.0",
+    "tocco-theme": ">0.1.0",
+    "tocco-ui": ">0.1.0",
+    "tocco-util": ">0.1.0"
   }
 }


### PR DESCRIPTION
- with >0.1.0 lerna bootstrap always looking for the newest version (local).
  If a packages gets updated, one doen't have to update each package.json