### PR TITLE
fix(entity-browser): dispatching input & history configurable

### DIFF
--- a/packages/entity-browser/README.md
+++ b/packages/entity-browser/README.md
@@ -20,6 +20,7 @@ React-registry name: `entity-browser`
 | `initialKey`           |           | If set, the entity browser will start on the detail page of the entity with the specified key instead of showing a list.
 | `nullBusinessUnit`     |           | If true, all REST-request have the null business unit header (X-Business-Unit: __n-u-l-l__)
 | `showCreateButton`     |           | (Temporary) Flag to show/hide a create button in list view
+| `memoryHistory`        |           | By default, a url based history is used. In case of embedding for example, this will not work
 
 ### Events
 

--- a/packages/entity-browser/src/input.js
+++ b/packages/entity-browser/src/input.js
@@ -1,5 +1,0 @@
-import {setAppId} from './routes/entity-browser/modules/actions'
-
-export const getDispatchActions = input => ([
-  setAppId(input.id || new Date().getTime())
-])

--- a/packages/entity-browser/src/routes/entity-browser/route.js
+++ b/packages/entity-browser/src/routes/entity-browser/route.js
@@ -1,21 +1,26 @@
 import EntityBrowser from './components/EntityBrowser'
 
 import entityBrowser from './modules'
-import {setEntityName, setFormBase} from './modules/actions'
+import {setEntityName, setFormBase, setAppId} from './modules/actions'
 
 const inputDispatches = [
   {
-    field: 'entityName',
-    action: setEntityName,
+    key: 'entityName',
+    actionCreator: setEntityName,
     mandatory: true
   },
   {
-    field: 'entityName',
-    action: setFormBase
+    key: 'entityName',
+    actionCreator: setFormBase
   },
   {
-    field: 'formBase',
-    action: setFormBase
+    key: 'formBase',
+    actionCreator: setFormBase
+  },
+  {
+    key: 'id',
+    defaultValue: new Date().valueOf(),
+    actionCreator: setAppId
   }
 ]
 

--- a/packages/tocco-util/src/route/input.js
+++ b/packages/tocco-util/src/route/input.js
@@ -1,8 +1,11 @@
 import consoleLogger from '../consoleLogger'
 
-export const dispatchInput = (store, input, key, actionCreator, mandatory = false, logger = consoleLogger.logError) => {
-  if (input.hasOwnProperty(key)) {
-    const action = actionCreator(input[key])
+export const dispatchInput = (store,
+  input,
+  {key, actionCreator, mandatory = false, defaultValue},
+  logger = consoleLogger.logError) => {
+  if (input.hasOwnProperty(key) || defaultValue) {
+    const action = actionCreator(input[key] || defaultValue)
     store.dispatch(action)
   } else if (mandatory === true) {
     logger(`EntityBrowser: Mandatory field '${key}' not set in input`)

--- a/packages/tocco-util/src/route/input.spec.js
+++ b/packages/tocco-util/src/route/input.spec.js
@@ -22,7 +22,7 @@ describe('tocco-util', () => {
 
           store.dispatch.once().withExactArgs(actionCreator('User'))
 
-          dispatchInput(store, input, 'entityName', actionCreator)
+          dispatchInput(store, input, {key: 'entityName', actionCreator})
 
           store.dispatch.verify()
         })
@@ -37,7 +37,7 @@ describe('tocco-util', () => {
 
           store.dispatch.never()
 
-          dispatchInput(store, input, 'entityName', actionCreator)
+          dispatchInput(store, input, {key: 'entityName', actionCreator})
 
           store.dispatch.verify()
         })
@@ -55,7 +55,22 @@ describe('tocco-util', () => {
           const logger = sinon.mock()
           logger.once().withExactArgs("EntityBrowser: Mandatory field 'entityName' not set in input")
 
-          dispatchInput(store, input, 'entityName', actionCreator, true, logger)
+          dispatchInput(store, input, {key: 'entityName', actionCreator, mandatory: true}, logger)
+
+          store.dispatch.verify()
+        })
+
+        it('should dispatch defaultValues', () => {
+          const input = { // no `entityName` property
+          }
+
+          const store = {
+            dispatch: sinon.mock()
+          }
+
+          const defaultValue = 'test'
+          store.dispatch.once().withExactArgs(actionCreator(defaultValue))
+          dispatchInput(store, input, {key: 'entityName', actionCreator, mandatory: true, defaultValue})
 
           store.dispatch.verify()
         })

--- a/packages/tocco-util/src/route/route.js
+++ b/packages/tocco-util/src/route/route.js
@@ -21,7 +21,11 @@ export const loadRoute = (store, input, importRouteDependencies, path) => props 
 
         if (route.inputDispatches) {
           route.inputDispatches.forEach(inputDispatch => {
-            dispatchInput(store, input, inputDispatch.field, inputDispatch.action, inputDispatch.mandatory)
+            dispatchInput(
+              store,
+              input,
+              inputDispatch
+            )
           })
         }
 


### PR DESCRIPTION
- previous input dispatching did not effect the app since it got
  overwritten by the route. instead the way the route dispatches the input
  got optimized and default values are now possible.
- introduce new input "memoryHistory". When true, a memory based history is used. This
  should be set if the application run in an environment where the url cannot be used
  as history. e.g. when included as tab in nice2