### PR TITLE
refactor: text-resource cleanup

### DIFF
--- a/packages/entity-detail/src/dev/textResources.json
+++ b/packages/entity-detail/src/dev/textResources.json
@@ -13,7 +13,5 @@
   "client.entity-detail.saveSuccessfulMessage",
   "client.entity-detail.createSuccessfulTitle",
   "client.entity-detail.createSuccessfulMessage",
-  "client.entity-detail.validationError",
-  "client.entity-detail.uploadFailedTitle",
-  "client.entity-detail.uploadFailedMessage"
+  "client.entity-detail.validationError"
 ]

--- a/packages/entity-detail/src/modules/entityDetail/sagas.js
+++ b/packages/entity-detail/src/modules/entityDetail/sagas.js
@@ -215,8 +215,8 @@ export function* uploadDocument({payload}) {
     // timestamp is needed as workaround, so that Upload component rerenders
     yield put(changeFormValue(FORM_ID, field, {id: null, timestamp: Date.now()}))
     yield put(errorLogging.logError(
-      'client.entity-detail.uploadFailedTitle',
-      'client.entity-detail.uploadFailedMessage',
+      'client.component.form.uploadFailedTitle',
+      'client.component.form.uploadFailedMessage',
       error
     ))
   }

--- a/packages/tocco-ui/src/FormField/FormField.js
+++ b/packages/tocco-ui/src/FormField/FormField.js
@@ -25,7 +25,7 @@ const FormField = props => {
       'sr-only': !props.label
     })
 
-  const labelAlt = `${props.label} ${props.mandatory ? props.mandatoryTitle : ''}`
+  const labelAlt = `${props.label}${props.mandatory ? `, ${props.mandatoryTitle}` : ''}`
 
   const editableValueWrapperClass = classNames({
     'col-sm-9': props.label,
@@ -34,7 +34,7 @@ const FormField = props => {
 
   return (
     <div className={fromGroupClass}>
-      <label className={labelClass} htmlFor={props.id} alt={labelAlt}>
+      <label className={labelClass} htmlFor={props.id} alt={labelAlt} title={labelAlt}>
         {props.label}
       </label>
       <div className={editableValueWrapperClass}>
@@ -46,7 +46,7 @@ const FormField = props => {
 }
 
 FormField.defaultProps = {
-  mandatoryTitle: 'is a mandatory field'
+  mandatoryTitle: 'mandatory'
 }
 
 FormField.propTypes = {

--- a/packages/tocco-util/src/actions/modules/actionHandlers/simpleAction.js
+++ b/packages/tocco-util/src/actions/modules/actionHandlers/simpleAction.js
@@ -19,7 +19,7 @@ export function* invokeRequest(definition, entity, ids, params) {
     const success = response.body.success === true
 
     const type = success ? 'success' : 'warning'
-    const title = response.body.message || 'client.component.actions.successTitle'
+    const title = response.body.message || 'client.component.actions.successDefault'
     const icon = success ? 'check' : 'exclamation'
 
     yield put(notifier.info(type, title, null, icon))

--- a/packages/tocco-util/src/mockData/data/textResources.json
+++ b/packages/tocco-util/src/mockData/data/textResources.json
@@ -3,7 +3,7 @@
   "client.component.actions.defaultConfirmMessage",
   "client.component.actions.defaultProgressMessage",
   "client.component.actions.errorText",
-  "client.component.actions.successTitle",
+  "client.component.actions.successDefault",
   "client.component.remoteselect.noResultsText",
   "client.component.remoteselect.clearAllText",
   "client.component.remoteselect.clearValueText",


### PR DESCRIPTION
- use 'uploadFailedTitle' and 'uploadFailedMessage' text-resource from
  components.form since detail gets refactored away later.
- adjust 'alt' attribute and set at title as well for chrome
- rename actions.successTitle