### PR TITLE
feat(entity-browser): simple selection concept

### DIFF
--- a/packages/entity-list/README.md
+++ b/packages/entity-list/README.md
@@ -18,7 +18,6 @@ React-registry name: `entity-list`
 | `disableSimpleSearch`     |           | If true the full search form is always visible                                                                                                                 | Bool   | false                   |
 | `simpleSearchFields`      |           | List of fields, that should be shown with activated simple search. If empty, fulltext search field will be displayed in simple search. Comma-separated string. | String | (fulltext-search-field) |
 | `showCreateButton`        |           | (Temporary) Flag to show/hide a create button
-| `selectable`              |           | If true, the rows will be selectable.
 | `onSelectChange`          |           | Callback function which gets called on a row selection. The selection will be passed as argument.
 | `selection`               |           | Array of keys. The whole selection can be preset with this property.
 | `keepStore`               |           | If true the app preserves the store with given `id`. If the same list gets shown again, the store is recovered.

--- a/packages/entity-list/src/components/ListView/ListView.js
+++ b/packages/entity-list/src/components/ListView/ListView.js
@@ -15,7 +15,7 @@ class ListView extends React.Component {
 
   render() {
     const props = this.props
-
+    const selectedRecordsCurrentPage = this.props.currentPageIds.filter(id => this.props.selection.includes(id))
     return (
       <div className="list-view">
         <LoadMask
@@ -31,7 +31,7 @@ class ListView extends React.Component {
               return <actions.Action
                 key={`listAction${idx}`}
                 definition={child}
-                ids={props.selection}
+                ids={selectedRecordsCurrentPage}
                 entity={props.entityName}
               />
             }
@@ -49,7 +49,8 @@ ListView.propTypes = {
   formDefinition: PropTypes.shape({
     children: PropTypes.array
   }),
-  selection: PropTypes.arrayOf(PropTypes.string)
+  selection: PropTypes.arrayOf(PropTypes.string),
+  currentPageIds: PropTypes.arrayOf(PropTypes.string)
 }
 
 export default ListView

--- a/packages/entity-list/src/components/ListView/ListView.spec.js
+++ b/packages/entity-list/src/components/ListView/ListView.spec.js
@@ -31,7 +31,8 @@ const props = {
   selectable: true,
   onSelectChange: EMPTY_FUNC,
   selection: [],
-  refresh: EMPTY_FUNC
+  refresh: EMPTY_FUNC,
+  currentPageIds: ['1', '4']
 }
 
 describe('entity-list', () => {

--- a/packages/entity-list/src/components/Table/Table.js
+++ b/packages/entity-list/src/components/Table/Table.js
@@ -56,7 +56,8 @@ const Table = props => {
     mode: props.selectable ? 'checkbox' : 'none',
     onSelect: handleSelectionChange,
     onSelectAll: handleAllSelectionChange,
-    selected: props.selection ? props.selection : []
+    selected: props.selection ? props.selection : [],
+    className: 'selected'
   }
 
   const tableOption = {

--- a/packages/entity-list/src/components/Table/Table.scss
+++ b/packages/entity-list/src/components/Table/Table.scss
@@ -1,0 +1,6 @@
+.tocco-ui-theme .table-striped {
+  tr.selected {
+    background-color: lighten($brand-info, 35%);
+  }
+}
+

--- a/packages/entity-list/src/containers/ListViewContainer.js
+++ b/packages/entity-list/src/containers/ListViewContainer.js
@@ -11,6 +11,7 @@ const mapStateToProps = (state, props) => {
   return {
     formDefinition: state.list.formDefinition,
     selection: state.list.selection,
+    currentPageIds: state.list.entities.map(e => e.__key),
     entityName: state.entityList.entityName
   }
 }

--- a/packages/entity-list/src/input.js
+++ b/packages/entity-list/src/input.js
@@ -5,7 +5,7 @@ import {
   setDisableSimpleSearch,
   setSimpleSearchFields
 } from './modules/searchForm/actions'
-import {setLimit, setSearchFilters, setListFormName, setSelectable, setSelection} from './modules/list/actions'
+import {setLimit, setSearchFilters, setListFormName, setSelection} from './modules/list/actions'
 
 const isDefined = value => !(value === undefined || value === null)
 
@@ -68,10 +68,6 @@ const actionSettings = [
     name: 'simpleSearchFields',
     action: setSimpleSearchFields,
     argsFactory: input => [input.simpleSearchFields]
-  }, {
-    name: 'selectable',
-    action: setSelectable,
-    argsFactory: input => [input.selectable]
   },
   {
     name: 'selection',

--- a/packages/entity-list/src/main.js
+++ b/packages/entity-list/src/main.js
@@ -139,7 +139,6 @@ EntityListApp.propTypes = {
   ),
   disableSimpleSearch: PropTypes.bool,
   simpleSearchFields: PropTypes.string,
-  selectable: PropTypes.bool,
   onSelectChange: PropTypes.func,
   selection: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
   ...EXTERNAL_EVENTS.reduce((propTypes, event) => {

--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -5,7 +5,7 @@ import {externalEvents, actions as actionUtil, actionEmitter} from 'tocco-util'
 import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
 import {getSearchInputs} from '../searchForm/sagas'
-import {fetchForm, getSorting, getFields} from '../../util/api/forms'
+import {fetchForm, getSorting, getSelectable, getFields} from '../../util/api/forms'
 import {fetchEntityCount, fetchEntities, entitiesListTransformer, fetchModel} from '../../util/api/entities'
 import {combineSelection} from '../../util/selection'
 
@@ -128,6 +128,8 @@ export function* loadFormDefinition(formDefinition, formBase) {
     yield put(actions.setFormDefinition(formDefinition))
     const sorting = yield call(getSorting, formDefinition)
     yield put(actions.setSorting(sorting))
+    const selectable = yield call(getSelectable, formDefinition)
+    yield put(actions.setSelectable(selectable))
   }
 }
 

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -4,7 +4,7 @@ import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
 import {getSearchInputs} from '../searchForm/sagas'
 import rootSaga, * as sagas from './sagas'
-import {fetchForm, getSorting, getFields} from '../../util/api/forms'
+import {fetchForm, getSorting, getSelectable, getFields} from '../../util/api/forms'
 import {fetchEntityCount, fetchEntities, entitiesListTransformer, fetchModel} from '../../util/api/entities'
 import {actions as actionUtil} from 'tocco-util'
 
@@ -254,12 +254,15 @@ describe('entity-list', () => {
               children: []
             }
             const sorting = [{field: 'firstname', order: 'adsc'}]
+            const selectable = true
 
             const gen = sagas.loadFormDefinition(formDefinition, formBase)
             expect(gen.next().value).to.eql(call(fetchForm, `${formBase}_list`))
             expect(gen.next(loadedFormDefinition).value).to.eql(put(actions.setFormDefinition(loadedFormDefinition)))
             expect(gen.next().value).to.eql(call(getSorting, loadedFormDefinition))
             expect(gen.next(sorting).value).to.eql(put(actions.setSorting(sorting)))
+            expect(gen.next().value).to.eql(call(getSelectable, loadedFormDefinition))
+            expect(gen.next(selectable).value).to.eql(put(actions.setSelectable(selectable)))
             expect(gen.next().done).to.be.true
           })
 

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -20,6 +20,11 @@ export const getSorting = formDefinition => {
   return table.sorting ? table.sorting : []
 }
 
+export const getSelectable = formDefinition => {
+  const table = getTable(formDefinition)
+  return table.selectable !== false
+}
+
 const isDisplayableChild = child => !child.hidden
 
 export const getColumnDefinition = table =>

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -242,6 +242,31 @@ describe('entity-list', () => {
             expect(result).to.eql(['description', 'firstname', 'description2'])
           })
         })
+
+        describe('getSelectable', () => {
+          const getFormDefinition = selectable => ({
+            children: [{
+              layoutType: 'table',
+              componentType: 'layout',
+              ...(selectable !== null ? {selectable} : {})
+            }]
+          })
+
+          it('should return seletable boolean of the form definition', () => {
+            const result = forms.getSelectable(getFormDefinition(true))
+            expect(result).to.be.true
+          })
+
+          it('should return seletable boolean false of the form definition', () => {
+            const result = forms.getSelectable(getFormDefinition(false))
+            expect(result).to.be.false
+          })
+
+          it('should return true if selectable not in defintion', () => {
+            const result = forms.getSelectable(getFormDefinition(null))
+            expect(result).to.be.true
+          })
+        })
       })
     })
   })

--- a/packages/tocco-util/src/mockData/data/dummy_entity_list_form.json
+++ b/packages/tocco-util/src/mockData/data/dummy_entity_list_form.json
@@ -53,7 +53,8 @@
             "label": "Active"
           }
         ],
-        "label": null
+        "label": null,
+        "selectable": false
       }
     ],
     "label": null

--- a/packages/tocco-util/src/mockData/data/user_list_form.json
+++ b/packages/tocco-util/src/mockData/data/user_list_form.json
@@ -102,6 +102,7 @@
             "order": "asc"
           }
         ],
+        "selectable": true,
         "children": [
           {
             "id": "user_nr",


### PR DESCRIPTION
- new flag selectable in list form definition determines if checkboxes are shown
- remove input param selectable on entity-list (is now set via form defintion)
- action selection only current page (no multi page selection at the moment)