### PR TITLE
refactor(tocco-ui): wrap select menu in tether

### DIFF
--- a/packages/tocco-ui/package.json
+++ b/packages/tocco-ui/package.json
@@ -16,6 +16,7 @@
     "react-autosize-textarea": "^0.4.3",
     "react-dropzone": "^4.1.3",
     "react-quill": "^1.0.0-rc.2",
-    "react-select": "1.0.0-rc.10"
+    "react-select": "1.2.1",
+    "react-tether": "^0.6.1"
   }
 }

--- a/packages/tocco-ui/src/EditableValue/EditableValue.scss
+++ b/packages/tocco-ui/src/EditableValue/EditableValue.scss
@@ -57,3 +57,14 @@ $textarea-max-height: 25rem;
     }
   }
 }
+
+.tether-select {
+  z-index: 9999999999;
+
+  &.tether-target-attached-top {
+    margin-top: -35px; // magic-number representing the height of the input-field
+    .Select-menu-outer {
+      border-radius: 4px 4px 0 0;
+    }
+  }
+}

--- a/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 
 class MultiRemoteSelect extends React.Component {
   onValueClick = v => {
@@ -23,7 +23,7 @@ class MultiRemoteSelect extends React.Component {
   render() {
     return (
       <span tabIndex="-1" id={this.props.id} onFocus={this.focusSelect}>
-        <Select
+        <TetheredSelectWrap
           valueKey="key"
           labelKey="display"
           loadingPlaceholder="Laden"

--- a/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {shallow} from 'enzyme'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 
 import MultiRemoteSelect from './MultiRemoteSelect'
 
@@ -22,17 +22,17 @@ describe('tocco-ui', () => {
               onChange={() => {}}
             />)
 
-          expect(wrapper.find(Select)).to.have.length(1)
-          expect(wrapper.find(Select).prop('clearAllText')).to.be.eql('CLEAR_ALL_TEXT')
-          expect(wrapper.find(Select).prop('searchPromptText')).to.be.eql('SEARCH_PROMPT_TEXT')
-          expect(wrapper.find(Select).prop('noResultsText')).to.be.eql('NO_RESULTS_TEXT')
+          expect(wrapper.find(TetheredSelectWrap)).to.have.length(1)
+          expect(wrapper.find(TetheredSelectWrap).prop('clearAllText')).to.be.eql('CLEAR_ALL_TEXT')
+          expect(wrapper.find(TetheredSelectWrap).prop('searchPromptText')).to.be.eql('SEARCH_PROMPT_TEXT')
+          expect(wrapper.find(TetheredSelectWrap).prop('noResultsText')).to.be.eql('NO_RESULTS_TEXT')
         })
 
         it('should call onChange ', () => {
           const newValue = {key: 1, display: 'label1'}
           const spy = sinon.spy()
           const wrapper = shallow(<MultiRemoteSelect onChange={spy} options={{}}/>)
-          wrapper.find(Select).simulate('change', newValue)
+          wrapper.find(TetheredSelectWrap).simulate('change', newValue)
           expect(spy).to.have.been.calledWith(newValue)
         })
 
@@ -55,8 +55,8 @@ describe('tocco-ui', () => {
               options={options}
             />)
 
-          expect(wrapper.find(Select)).to.have.length(1)
-          expect(wrapper.find(Select).prop('options')).to.be.eql(option)
+          expect(wrapper.find(TetheredSelectWrap)).to.have.length(1)
+          expect(wrapper.find(TetheredSelectWrap).prop('options')).to.be.eql(option)
         })
       })
     })

--- a/packages/tocco-ui/src/EditableValue/typeEditors/MultiSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/MultiSelect.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 import _isEmpty from 'lodash/isEmpty'
 
 const MultiSelect = props => {
@@ -15,7 +15,7 @@ const MultiSelect = props => {
 
   return (
     <span tabIndex="-1" id={props.id} onFocus={focusSelect}>
-      <Select
+      <TetheredSelectWrap
         multi
         valueKey="key"
         labelKey="display"

--- a/packages/tocco-ui/src/EditableValue/typeEditors/MultiSelect.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/MultiSelect.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {shallow} from 'enzyme'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 
 import MultiSelect from './MultiSelect'
 
@@ -17,8 +17,8 @@ describe('tocco-ui', () => {
           }
 
           const wrapper = shallow(<MultiSelect options={options} value={[1]} onChange={() => {}}/>)
-          expect(wrapper.find(Select)).to.have.length(1)
-          const select = wrapper.find(Select)
+          expect(wrapper.find(TetheredSelectWrap)).to.have.length(1)
+          const select = wrapper.find(TetheredSelectWrap)
           expect(select.props().options).to.eql(options.store)
         })
 
@@ -32,7 +32,7 @@ describe('tocco-ui', () => {
             ]
           }
           const wrapper = shallow(<MultiSelect onChange={spy} options={options}/>)
-          wrapper.find(Select).simulate('change', newValues)
+          wrapper.find(TetheredSelectWrap).simulate('change', newValues)
           expect(spy).to.have.been.calledWith(newValues)
         })
       })

--- a/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 
 class RemoteSelect extends React.Component {
   onValueClick = v => {
@@ -23,7 +23,7 @@ class RemoteSelect extends React.Component {
   render() {
     return (
       <span tabIndex="-1" id={this.props.id} onFocus={this.focusSelect}>
-        <Select
+        <TetheredSelectWrap
           valueKey="key"
           labelKey="display"
           loadingPlaceholder="Laden"

--- a/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {shallow} from 'enzyme'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 
 import RemoteSelect from './RemoteSelect'
 
@@ -22,17 +22,17 @@ describe('tocco-ui', () => {
               onChange={() => {}}
             />)
 
-          expect(wrapper.find(Select)).to.have.length(1)
-          expect(wrapper.find(Select).prop('clearValueText')).to.be.eql('CLEAR_VALUE_TEXT')
-          expect(wrapper.find(Select).prop('searchPromptText')).to.be.eql('SEARCH_PROMPT_TEXT')
-          expect(wrapper.find(Select).prop('noResultsText')).to.be.eql('NO_RESULTS_TEXT')
+          expect(wrapper.find(TetheredSelectWrap)).to.have.length(1)
+          expect(wrapper.find(TetheredSelectWrap).prop('clearValueText')).to.be.eql('CLEAR_VALUE_TEXT')
+          expect(wrapper.find(TetheredSelectWrap).prop('searchPromptText')).to.be.eql('SEARCH_PROMPT_TEXT')
+          expect(wrapper.find(TetheredSelectWrap).prop('noResultsText')).to.be.eql('NO_RESULTS_TEXT')
         })
 
         it('should call onChange ', () => {
           const newValue = {key: 1, display: 'label1'}
           const spy = sinon.spy()
           const wrapper = shallow(<RemoteSelect onChange={spy} options={{}}/>)
-          wrapper.find(Select).simulate('change', newValue)
+          wrapper.find(TetheredSelectWrap).simulate('change', newValue)
           expect(spy).to.have.been.calledWith(newValue)
         })
 
@@ -55,8 +55,8 @@ describe('tocco-ui', () => {
               options={options}
             />)
 
-          expect(wrapper.find(Select)).to.have.length(1)
-          expect(wrapper.find(Select).prop('options')).to.be.eql(option)
+          expect(wrapper.find(TetheredSelectWrap)).to.have.length(1)
+          expect(wrapper.find(TetheredSelectWrap).prop('options')).to.be.eql(option)
         })
       })
     })

--- a/packages/tocco-ui/src/EditableValue/typeEditors/SingleSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/SingleSelect.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 import _isEmpty from 'lodash/isEmpty'
 
 const SingleSelect = props => {
@@ -23,7 +23,7 @@ const SingleSelect = props => {
 
   return (
     <span tabIndex="-1" id={props.id} onFocus={focusSelect}>
-      <Select
+      <TetheredSelectWrap
         single
         valueKey="key"
         labelKey="display"

--- a/packages/tocco-ui/src/EditableValue/typeEditors/SingleSelect.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/SingleSelect.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {shallow, mount} from 'enzyme'
-import Select from 'react-select'
+import TetheredSelectWrap from './TetherSelectWrap'
 
 import SingleSelect from './SingleSelect'
 
@@ -19,8 +19,8 @@ describe('tocco-ui', () => {
           }
 
           const wrapper = shallow(<SingleSelect options={options} value="1" onChange={() => {}}/>)
-          expect(wrapper.find(Select)).to.have.length(1)
-          const select = wrapper.find(Select)
+          expect(wrapper.find(TetheredSelectWrap)).to.have.length(1)
+          const select = wrapper.find(TetheredSelectWrap)
           expect(select.props().options).to.eql(options.store)
         })
 
@@ -34,7 +34,7 @@ describe('tocco-ui', () => {
             ]
           }
           const wrapper = shallow(<SingleSelect onChange={spy} options={options}/>)
-          wrapper.find(Select).simulate('change', newValue)
+          wrapper.find(TetheredSelectWrap).simulate('change', newValue)
           expect(spy).to.have.been.calledWith(newValue)
         })
 
@@ -43,13 +43,13 @@ describe('tocco-ui', () => {
           const options = {}
 
           const wrapper = mount(<SingleSelect value={value} options={options} onChange={EMPTY_FUNC}/>)
-          expect(wrapper.find(Select).first().props().options).to.eql([value])
+          expect(wrapper.find(TetheredSelectWrap).first().props().options).to.eql([value])
           wrapper.setProps({options: {store: []}})
-          expect(wrapper.find(Select).first().props().options).to.eql([value])
+          expect(wrapper.find(TetheredSelectWrap).first().props().options).to.eql([value])
 
           const store = [value, {key2: 'Label2'}]
           wrapper.setProps({options: {store}})
-          expect(wrapper.find(Select).first().props().options).to.eql(store)
+          expect(wrapper.find(TetheredSelectWrap).first().props().options).to.eql(store)
         })
       })
     })

--- a/packages/tocco-ui/src/EditableValue/typeEditors/TetherSelectWrap.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/TetherSelectWrap.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import Select from 'react-select'
+import TetherComponent from 'react-tether'
+
+/** from https://github.com/JedWatson/react-select/issues/810#issuecomment-250274937 **/
+export default class TetheredSelectWrap extends Select {
+  constructor(props) {
+    super(props)
+    this.renderOuter = this._renderOuter
+  }
+
+  _renderOuter() {
+    const menu = super.renderOuter.apply(this, arguments)
+
+    if (!menu) {
+      return
+    }
+
+    const selectWidth = this.wrapper ? this.wrapper.offsetWidth : null
+
+    return (
+      <TetherComponent
+        renderElementTo=".tocco-ui-theme"
+        attachment="top left"
+        targetAttachment="bottom left"
+        constraints={[{
+          to: 'window',
+          attachment: 'together'
+        }]}
+        classes={{
+          element: 'tocco-ui-theme tether-select'
+        }}
+      >
+        <div></div>
+        {React.cloneElement(menu, {style: {position: 'static', width: selectWidth}})}
+      </TetherComponent>
+    )
+  }
+}

--- a/packages/tocco-ui/yarn.lock
+++ b/packages/tocco-ui/yarn.lock
@@ -26,14 +26,6 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-create-react-class@^15.5.2:
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.3.tgz#fb0f7cae79339e9a179e194ef466efa3923820fe"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 deep-equal@^1.0.1, deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -182,11 +174,10 @@ react-dropzone@^4.1.3:
     attr-accept "^1.0.3"
     prop-types "^15.5.7"
 
-react-input-autosize@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.0.1.tgz#e92190497b4026c2780ad0f2fd703c835ba03e33"
+react-input-autosize@^2.1.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
   dependencies:
-    create-react-class "^15.5.2"
     prop-types "^15.5.8"
 
 react-quill@^1.0.0-rc.2:
@@ -196,17 +187,28 @@ react-quill@^1.0.0-rc.2:
     lodash "^4.17.4"
     quill "^1.2.0"
 
-react-select@1.0.0-rc.10:
-  version "1.0.0-rc.10"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.0.0-rc.10.tgz#f137346250f9255c979fbfa21860899928772350"
+react-select@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
   dependencies:
     classnames "^2.2.4"
     prop-types "^15.5.8"
-    react-input-autosize "^2.0.1"
+    react-input-autosize "^2.1.2"
+
+react-tether@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/react-tether/-/react-tether-0.6.1.tgz#de64dd81a5e40053a9f275c4fef0beb0877b3e4e"
+  dependencies:
+    prop-types "^15.5.8"
+    tether "^1.4.3"
 
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+tether@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.3.tgz#fd547024c47b6e5c9b87e1880f997991a9a6ad54"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
- to prevent overflow hidden problems and dynamically position the menu
  on top or at bottom
- update react-select