### PR TITLE
test(tocco-ui): increase timeout for DateAbstract test

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.spec.js
@@ -6,7 +6,9 @@ describe('tocco-ui', () => {
   describe('EditableValue', () => {
     describe('typeEditors', () => {
       describe('DateAbstract', () => {
-        it('should call initialized', done => {
+        it('should call initialized', function(done) {
+          this.timeout(4000)
+
           const initSpy = () => { done() }
 
           intlEnzyme.mountWithIntl(


### PR DESCRIPTION
- the async loading of the datepickr can sometimes take longer than
  2000 seconds.