### PR TITLE
refactor(tocco-util): color contrast tune lumniance limit

### DIFF
--- a/packages/tocco-util/src/color/contrast.js
+++ b/packages/tocco-util/src/color/contrast.js
@@ -1,6 +1,6 @@
 import {hexToRgb} from './hexToRgb'
 
-const LUMIANCE_LIMIT = 0.179
+const LUMIANCE_LIMIT = 0.25
 
 const calculateLight = colorItem => {
   let c = colorItem / 255.0

--- a/packages/tocco-util/src/color/contrast.spec.js
+++ b/packages/tocco-util/src/color/contrast.spec.js
@@ -19,6 +19,11 @@ describe('tocco-util', () => {
         expect(getContrastColor(khaki, bright, dark)).to.eql(dark)
       })
 
+      it('should return bright for the color red', () => {
+        const red = '#ff0000'
+        expect(getContrastColor(red, bright, dark)).to.eql(bright)
+      })
+
       it('should return default values for bright and dark', () => {
         expect(getContrastColor(black)).to.eql('#FFFFFF')
         expect(getContrastColor(white)).to.eql('#000000')


### PR DESCRIPTION
- contrast for red (#ff0000) should be a bright value since dark/black is not that readable
- add unit test