### PR TITLE
feat(entity-detail): Allow sub grid page limit to be set in model

### DIFF
--- a/packages/entity-detail/src/components/SubGrid/SubGrid.js
+++ b/packages/entity-detail/src/components/SubGrid/SubGrid.js
@@ -11,7 +11,7 @@ const SubGrid = props => {
         keepStore={true}
         entityName={props.modelField.targetEntity}
         formBase={formBase}
-        limit={5}
+        limit={props.limit}
         showSearchForm={props.showSearchForm}
         preselectedSearchFields={[{
           id: props.modelField.reverseRelationName,
@@ -41,6 +41,10 @@ const SubGrid = props => {
   )
 }
 
+SubGrid.defaultProps = {
+  limit: 5
+}
+
 SubGrid.propTypes = {
   entityKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   detailFormName: PropTypes.string.isRequired,
@@ -55,7 +59,8 @@ SubGrid.propTypes = {
   dispatchEmittedAction: PropTypes.func.isRequired,
   showSubGridsCreateButton: PropTypes.bool,
   appId: PropTypes.string,
-  showSearchForm: PropTypes.bool
+  showSearchForm: PropTypes.bool,
+  limit: PropTypes.number
 }
 
 export default SubGrid

--- a/packages/entity-detail/src/components/SubGrid/SubGrid.spec.js
+++ b/packages/entity-detail/src/components/SubGrid/SubGrid.spec.js
@@ -6,20 +6,33 @@ import EntityListApp from 'tocco-entity-list/src/main'
 describe('entity-detail', () => {
   describe('components', () => {
     describe('SubGrid', () => {
-      it('should render', () => {
-        const wrapper = shallow(
-          <SubGrid
-            detailFormName="User"
-            gridName="relFoo"
-            modelField={{targetEntity: 'Foo'}}
-            relationName="relFoo"
-            onNavigateToCreate={() => {}}
-            showSubGridsCreateButton={false}
-            dispatchEmittedAction={() => {}}
-          />
-        )
+      const testProps = {
+        detailFormName: 'User',
+        gridName: 'relFoo',
+        modelField: {targetEntity: 'Foo'},
+        relationName: 'relFoo',
+        onNavigateToCreate: () => {},
+        showSubGridsCreateButton: false,
+        dispatchEmittedAction: () => {}
+      }
 
+      it('should render', () => {
+        const wrapper = shallow(<SubGrid {...testProps} />)
         expect(wrapper.find(EntityListApp)).to.have.length(1)
+      })
+
+      it('should render with default limit 5', () => {
+        const wrapper = shallow(<SubGrid {...testProps} />)
+
+        const listApp = wrapper.find(EntityListApp)
+        expect(listApp.props().limit).to.equal(5)
+      })
+
+      it('should render with custom limit', () => {
+        const wrapper = shallow(<SubGrid {...testProps} limit={10} />)
+
+        const listApp = wrapper.find(EntityListApp)
+        expect(listApp.props().limit).to.equal(10)
       })
     })
   })

--- a/packages/entity-detail/src/util/detailView/fromFieldFactories/subGrid.js
+++ b/packages/entity-detail/src/util/detailView/fromFieldFactories/subGrid.js
@@ -9,5 +9,6 @@ export default type =>
       relationName={formField.id}
       modelField={modelField}
       showSearchForm={formField.showSearchForm}
+      limit={formField.limit || undefined}
     />
   )

--- a/packages/entity-detail/src/util/detailView/fromFieldFactories/subGrid.spec.js
+++ b/packages/entity-detail/src/util/detailView/fromFieldFactories/subGrid.spec.js
@@ -10,6 +10,18 @@ describe('entity-detail', () => {
             const grid = factory({children: [], name: 'relFoo'}, {}, {}, {}, {})
             expect(grid).to.not.be.null
           })
+
+          it('should pass limit from formModel', () => {
+            const factory = subGridFactory()
+            const grid = factory({children: [], name: 'relFoo', limit: 25}, {}, {}, {}, {})
+            expect(grid.props.limit).to.equal(25)
+          })
+
+          it('should pass undefined as limit if null in formModel', () => { // otherwise defaultProp won't be used
+            const factory = subGridFactory()
+            const grid = factory({children: [], name: 'relFoo', limit: null}, {}, {}, {}, {})
+            expect(grid.props.limit).to.be.undefined
+          })
         })
       })
     })


### PR DESCRIPTION
The previously hardcoded page limit of 5 now acts as a default value.