### PR TITLE
chore(scheduler): use raw html in calendar event popover

### DIFF
--- a/packages/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -68,16 +68,15 @@ class FullCalendar extends React.Component {
     },
     eventClick: event => this.props.onEventClick(event),
     eventRender: (event, element) => {
-      const content = <div>
-        <p>{event.description}</p>
+      const reservation = event.start.twix(event.end).format({monthFormat: 'MMMM', dayFormat: 'Do'})
+      const tooltipContent1 = <p dangerouslySetInnerHTML={{__html: `
+        <p>${event.description}</p>
         <p>
-          <i className="fa fa-clock-o" style={{paddingRight: '10px'}} aria-hidden="true"></i>
-          {event.start.twix(event.end).format({monthFormat: 'MMMM', dayFormat: 'Do'})}
-        </p>
-        <p>
-          <Conflict conflictStatus={event.conflict} intl={this.props.intl}/>
-        </p>
-      </div>
+          <i class="fa fa-clock-o" style="padding-right:10px" aria-hidden="true"></i>${reservation}
+        </p>`
+      }} />
+
+      const tooltipContent2 = <p><Conflict conflictStatus={event.conflict} intl={this.props.intl}/></p>
 
       window.jQuery(element).popover({
         title: event.title,
@@ -86,7 +85,10 @@ class FullCalendar extends React.Component {
         trigger: 'hover',
         html: true,
         container: `.${this.state.wrapperId}`,
-        content: ReactDOMServer.renderToString(content)
+        content: `
+          <div>
+            ${ReactDOMServer.renderToString(tooltipContent1)}${ReactDOMServer.renderToString(tooltipContent2)}
+          </div>`
       })
     }
   }

--- a/packages/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -69,14 +69,18 @@ class FullCalendar extends React.Component {
     eventClick: event => this.props.onEventClick(event),
     eventRender: (event, element) => {
       const reservation = event.start.twix(event.end).format({monthFormat: 'MMMM', dayFormat: 'Do'})
-      const tooltipContent1 = <p dangerouslySetInnerHTML={{__html: `
+
+      const tooltipDescriptionContent = <p dangerouslySetInnerHTML={{__html: `
         <p>${event.description}</p>
         <p>
           <i class="fa fa-clock-o" style="padding-right:10px" aria-hidden="true"></i>${reservation}
         </p>`
       }} />
 
-      const tooltipContent2 = <p><Conflict conflictStatus={event.conflict} intl={this.props.intl}/></p>
+      const tooltipConflictContent = <p><Conflict conflictStatus={event.conflict} intl={this.props.intl}/></p>
+
+      const content = [tooltipDescriptionContent, tooltipConflictContent]
+        .map(element => ReactDOMServer.renderToString(element)).join('')
 
       window.jQuery(element).popover({
         title: event.title,
@@ -87,7 +91,7 @@ class FullCalendar extends React.Component {
         container: `.${this.state.wrapperId}`,
         content: `
           <div>
-            ${ReactDOMServer.renderToString(tooltipContent1)}${ReactDOMServer.renderToString(tooltipContent2)}
+            ${content}
           </div>`
       })
     }

--- a/packages/scheduler/src/components/FullCalendar/FullCalendar.scss
+++ b/packages/scheduler/src/components/FullCalendar/FullCalendar.scss
@@ -40,3 +40,14 @@
     text-overflow: ellipsis;
   }
 }
+
+.tocco-resource-scheduler {
+  .popover{
+    min-width: 500px;
+    max-width: 600px;
+
+    .popover-content {
+      width: 100%;
+    }
+  }
+}

--- a/packages/scheduler/src/components/FullCalendar/FullCalendar.scss
+++ b/packages/scheduler/src/components/FullCalendar/FullCalendar.scss
@@ -42,7 +42,7 @@
 }
 
 .tocco-resource-scheduler {
-  .popover{
+  .popover {
     min-width: 500px;
     max-width: 600px;
 


### PR DESCRIPTION
the description property of a calendar event now will return html
instead of text. to correctly apply the html to the popover the
`dangerouslySetInnerHtml` property for React components is used.

the popover content has to be split because in raw html code the react
component `Conflict` will not be recognized otherwise.