### PR TITLE
Pr/styled components FormattedValues

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "react": "^16.3.1",
     "react-dom": "^16.3.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "moment": "^2.22.2"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",

--- a/packages/tocco-ui/src/FormattedValue/FormattedValue.js
+++ b/packages/tocco-ui/src/FormattedValue/FormattedValue.js
@@ -13,10 +13,7 @@ const FormattedValue = props => {
     return <span/>
   }
 
-  return (
-    <span>
-      {provider(props.type, props.value, props.options)}
-    </span>)
+  return provider(props.type, props.value, props.options)
 }
 
 FormattedValue.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/example.js
+++ b/packages/tocco-ui/src/FormattedValue/example.js
@@ -55,10 +55,6 @@ const Example = () => {
             </td>
           </tr>
           <tr>
-            <td>Duration</td>
-            <td><FormattedValue type="duration" value={3020000}/></td>
-          </tr>
-          <tr>
             <td>Dataamount<br/>Integer<br/>Long<br/>Number<br/>Short<br/>Sorting<br/>Version</td>
             <td>
               <FormattedValue type="dataamount" value={1}/><br/>

--- a/packages/tocco-ui/src/FormattedValue/example.js
+++ b/packages/tocco-ui/src/FormattedValue/example.js
@@ -19,73 +19,126 @@ const Example = () => {
       <table className="table table-striped">
         <tbody>
           <tr>
-            <td>String</td>
-            <td><FormattedValue type="string" value="Simple string"/></td>
-          </tr>
-          <tr>
-            <td>Text</td>
-            <td><FormattedValue type="text" value={'Test\nLine2'}/></td>
-          </tr>
-          <tr>
-            <td>Url</td>
-            <td><FormattedValue type="url" value="http://www.this-is-a.url"/></td>
-          </tr>
-          <tr>
-            <td>DateTime</td>
-            <td><FormattedValue type="datetime" value="2016-12-06T13:40:25.864Z"/></td>
-          </tr>
-          <tr>
-            <td>Date</td>
+            <td>Boolean</td>
             <td>
-              <FormattedValue type="date" value="1980-08-02"/><br/>
+              <FormattedValue type="boolean" value/><br/>
+              <FormattedValue type="boolean" value={false}/>
+            </td>
+          </tr>
+          <tr>
+            <td>Birthdate<br/>Date</td>
+            <td>
+              <FormattedValue type="birthdate" value="1980-08-02"/><br/>
               <FormattedValue type="date" value="1988-11-14"/>
             </td>
           </tr>
           <tr>
-            <td>Time</td>
-            <td><FormattedValue type="time" value={timeValue}/></td>
+            <td>Char<br/>Counter<br/>Createuser<br/>Email<br/>Identifier<br/>
+              Ipaddress<br/>Postcode<br/>String<br/>Uuid</td>
+            <td>
+              <FormattedValue type="char" value="Simple string"/><br/>
+              <FormattedValue type="counter" value="Simple string"/><br/>
+              <FormattedValue type="createuser" value="Simple string"/><br/>
+              <FormattedValue type="email" value="Simple string"/><br/>
+              <FormattedValue type="identifier" value="Simple string"/><br/>
+              <FormattedValue type="ipaddress" value="Simple string"/><br/>
+              <FormattedValue type="postcode" value="Simple string"/><br/>
+              <FormattedValue type="string" value="Simple string"/><br/>
+              <FormattedValue type="uuid" value="Simple string"/>
+            </td>
           </tr>
           <tr>
-            <td>Phone</td>
-            <td><FormattedValue type="phone" value="+41443886000"/></td>
-          </tr>
-          <tr>
-            <td>Phone</td>
-            <td><FormattedValue type="phone" value="+414438860011111110"/></td>
+            <td>Createts<br/>Datetime</td>
+            <td>
+              <FormattedValue type="createts" value="2016-12-06T13:40:25.864Z"/><br/>
+              <FormattedValue type="datetime" value="2017-11-16T03:21:23.123Z"/>
+            </td>
           </tr>
           <tr>
             <td>Duration</td>
             <td><FormattedValue type="duration" value={3020000}/></td>
           </tr>
           <tr>
+            <td>Dataamount<br/>Integer<br/>Long<br/>Number<br/>Short<br/>Sorting<br/>Version</td>
+            <td>
+              <FormattedValue type="dataamount" value={1}/><br/>
+              <FormattedValue type="integer" value={23}/><br/>
+              <FormattedValue type="long" value={2345678}/><br/>
+              <FormattedValue type="number" value={1337}/><br/>
+              <FormattedValue type="short" value={2}/><br/>
+              <FormattedValue type="sorting" value={4}/><br/>
+              <FormattedValue type="version" value={1}/><br/>
+            </td>
+          </tr>
+          <tr>
+            <td>Decimal<br/>Double</td>
+            <td>
+              <FormattedValue type="decimal" value={3333.3}/><br/>
+              <FormattedValue type="double" value={123.4}/>
+            </td>
+          </tr>
+          <tr>
+            <td>Document</td>
+            <td>
+              <FormattedValue type="document" value={{
+                alt: 'orange jellyfish floating in the deep blue sea',
+                binaryLink: 'https://picsum.photos/500/500?image=1069',
+                fileName: 'jellyfish.jpg',
+                thumbnailLink: 'https://picsum.photos/100/100?image=1069'}}/>
+              <FormattedValue type="document" value={{
+                alt: 'hundreds of juicy strawberries tempting to degustate',
+                binaryLink: 'https://picsum.photos/500/500?image=1080',
+                caption: 'hundred juicy strawberries',
+                fileName: 'jellyfish.jpg',
+                thumbnailLink: 'https://picsum.photos/100/100?image=1080'}}/>
+            </td>
+          </tr>
+          <tr>
+            <td>Document Compact</td>
+            <td>
+              <FormattedValue type="document-compact" value={{
+                alt: 'orange jellyfish floating in the deep blue sea',
+                binaryLink: 'https://picsum.photos/500/500?image=1069',
+                fileName: 'jellyfish.jpg',
+                thumbnailLink: 'https://picsum.photos/100/100?image=1069'}}/>&nbsp;
+              <FormattedValue type="document-compact" value={{
+                alt: 'hundreds of juicy strawberries tempting to degustate',
+                binaryLink: 'https://picsum.photos/500/500?image=1080',
+                caption: 'hundred juicy strawberries',
+                fileName: 'jellyfish.jpg',
+                thumbnailLink: 'https://picsum.photos/100/100?image=1080'}}/>
+            </td>
+          </tr>
+          <tr>
+            <td>Duration</td>
+            <td><FormattedValue type="duration" value={83000}/></td>
+          </tr>
+          <tr>
+            <td>HTML</td>
+            <td><FormattedValue type="html" value="<b>bold</b> <i>italic</i>"/></td>
+          </tr>
+          <tr>
+            <td>Login</td>
+            <td><FormattedValue type="login" value={{username: 'dake'}}/></td>
+          </tr>
+          <tr>
+            <td>Latitude<br/>Longitude</td>
+            <td>
+              <FormattedValue type="latitude" value={{value: 45.976575}}/>,
+              <FormattedValue type="longitude" value={{value: 7.658452}}/>
+            </td>
+          </tr>
+          <tr>
             <td>Money</td>
             <td><FormattedValue type="moneyamount" value={1245.6}/></td>
           </tr>
           <tr>
-            <td>Boolean</td>
+            <td>Multi Remote<br/>Multi Select</td>
             <td>
-              <FormattedValue type="boolean" value/>
-              <FormattedValue type="boolean" value={false}/><br/>
-            </td>
-          </tr>
-          <tr>
-            <td>Decimal</td>
-            <td><FormattedValue type="decimal" value={3333.3}/></td>
-          </tr>
-          <tr>
-            <td>Integer</td>
-            <td><FormattedValue type="integer" value={1337}/></td>
-          </tr>
-          <tr>
-            <td>Long/Langitude</td>
-            <td>
-              <FormattedValue type="longitude" value={{value: 0.82710405122667465}}/>
-            </td>
-          </tr>
-          <tr>
-            <td>Login</td>
-            <td>
-              <FormattedValue type="login" value={{username: 'dake'}}/>
+              <FormattedValue type="multi-remote" value={
+                [{key: '1', display: 'apple'}, {key: '2', display: 'khaki'}]}/><br/>
+              <FormattedValue type="multi-select" value={
+                [{key: '3', display: 'Matterhorn'}, {key: '4', display: 'Jungfraujoch'}, {key: '5', display: 'Rigi'}]}/>
             </td>
           </tr>
           <tr>
@@ -95,15 +148,30 @@ const Example = () => {
             </td>
           </tr>
           <tr>
-            <td>Document</td>
+            <td>Phone</td>
             <td>
-              <FormattedValue type="document" value={{
-                fileName: 'Blue-Square.png',
-                binaryLink: 'http://linkt.to/my/image.png',
-                thumbnailLink: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgAQMAAADYVuV7AAAACXBIWXMAAA7EAAA'
-                               + 'OxAGVKw4bAAAABlBMVEUCd72z5fwcX0uLAAAAHElEQVQ4y2NgwAns/8PBn1HOKGeUM8oZrBycAADOggXZNnQm'
-                               + 'gAAAAABJRU5ErkJggg=='}}/>
+              <FormattedValue type="phone" value="+41443886000"/><br/>
+              <FormattedValue type="phone" value="+414438860011111110"/>
             </td>
+          </tr>
+          <tr>
+            <td>Remote<br/>Single Select</td>
+            <td>
+              <FormattedValue type="remote" value={{key: '1', display: 'Apple'}}/><br/>
+              <FormattedValue type="single-select" value={{key: '3', display: 'Matterhorn'}}/>
+            </td>
+          </tr>
+          <tr>
+            <td>Text</td>
+            <td><FormattedValue type="text" value={'Lorem ipsum dolor sit amet.\nExcepturi alias face.'}/></td>
+          </tr>
+          <tr>
+            <td>Time</td>
+            <td><FormattedValue type="time" value={timeValue}/></td>
+          </tr>
+          <tr>
+            <td>Url</td>
+            <td><FormattedValue type="url" value="http://www.this-is-a.url"/></td>
           </tr>
         </tbody>
       </table>

--- a/packages/tocco-ui/src/FormattedValue/typeFormatterProvider.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatterProvider.js
@@ -1,25 +1,25 @@
 import React from 'react'
 
-import StringFormatter from './typeFormatters/StringFormatter'
-import TextFormatter from './typeFormatters/TextFormatter'
-import NumberFormatter from './typeFormatters/NumberFormatter'
-import DecimalFormatter from './typeFormatters/DecimalFormatter'
-import UrlFormatter from './typeFormatters/UrlFormatter'
+import BooleanFormatter from './typeFormatters/BooleanFormatter'
 import DateFormatter from './typeFormatters/DateFormatter'
 import DateTimeFormatter from './typeFormatters/DateTimeFormatter'
-import TimeFormatter from './typeFormatters/TimeFormatter'
+import DecimalFormatter from './typeFormatters/DecimalFormatter'
+import DocumentCompactFormatter from './typeFormatters/DocumentCompactFormatter'
+import DocumentFormatter from './typeFormatters/DocumentFormatter'
 import DurationFormatter from './typeFormatters/DurationFormatter'
-import MoneyFormatter from './typeFormatters/MoneyFormatter'
-import BooleanFormatter from './typeFormatters/BooleanFormatter'
+import HtmlFormatter from './typeFormatters/HtmlFormatter'
 import LoginFormatter from './typeFormatters/LoginFormatter'
 import LongitudeFormatter from './typeFormatters/LongitudeFormatter'
-import PercentFormatter from './typeFormatters/PercentFormatter'
-import DocumentFormatter from './typeFormatters/DocumentFormatter'
-import HtmlFormatter from './typeFormatters/HtmlFormatter'
-import SingleSelectFormatter from './typeFormatters/SingleSelectFormatter'
+import MoneyFormatter from './typeFormatters/MoneyFormatter'
+import NumberFormatter from './typeFormatters/NumberFormatter'
 import MultiSelectFormatter from './typeFormatters/MultiSelectFormatter'
-import DocumentCompactFormatter from './typeFormatters/DocumentCompactFormatter'
+import PercentFormatter from './typeFormatters/PercentFormatter'
 import PhoneFormatter from './typeFormatters/PhoneFormatter'
+import SingleSelectFormatter from './typeFormatters/SingleSelectFormatter'
+import StringFormatter from './typeFormatters/StringFormatter'
+import TextFormatter from './typeFormatters/TextFormatter'
+import TimeFormatter from './typeFormatters/TimeFormatter'
+import UrlFormatter from './typeFormatters/UrlFormatter'
 
 export default (type, value, options) => {
   if (map[type]) {
@@ -32,45 +32,45 @@ export default (type, value, options) => {
 }
 
 export const map = {
-  'string': StringFormatter,
-  'char': StringFormatter,
-  'uuid': StringFormatter,
-  'identifier': StringFormatter,
-  'postcode': StringFormatter,
-  'ipaddress': StringFormatter,
-  'html': HtmlFormatter,
-  'text': TextFormatter,
-  'short': NumberFormatter,
-  'integer': NumberFormatter,
-  'sorting': NumberFormatter,
-  'long': NumberFormatter,
-  'number': NumberFormatter,
-  'version': NumberFormatter,
-  'dataamount': NumberFormatter,
-  'decimal': DecimalFormatter,
-  'percent': PercentFormatter,
-  'double': DecimalFormatter,
-  'phone': PhoneFormatter,
-  'counter': StringFormatter,
-  'url': UrlFormatter,
-  'date': DateFormatter,
+  'binary': DocumentFormatter,
   'birthdate': DateFormatter,
+  'boolean': BooleanFormatter,
+  'char': StringFormatter,
+  'counter': StringFormatter,
+  'createts': DateTimeFormatter,
+  'createuser': StringFormatter,
+  'dataamount': NumberFormatter,
+  'date': DateFormatter,
   'datetime': DateTimeFormatter,
-  'time': TimeFormatter,
+  'decimal': DecimalFormatter,
+  'document': DocumentFormatter,
+  'document-compact': DocumentCompactFormatter,
+  'double': DecimalFormatter,
   'duration': DurationFormatter,
   'email': StringFormatter,
-  'moneyamount': MoneyFormatter,
-  'boolean': BooleanFormatter,
+  'html': HtmlFormatter,
+  'identifier': StringFormatter,
+  'integer': NumberFormatter,
+  'ipaddress': StringFormatter,
   'latitude': LongitudeFormatter,
-  'longitude': LongitudeFormatter,
   'login': LoginFormatter,
-  'document': DocumentFormatter,
-  'single-select': SingleSelectFormatter,
-  'remote': SingleSelectFormatter,
-  'multi-select': MultiSelectFormatter,
+  'long': NumberFormatter,
+  'longitude': LongitudeFormatter,
+  'moneyamount': MoneyFormatter,
   'multi-remote': MultiSelectFormatter,
-  'createuser': StringFormatter,
-  'createts': DateTimeFormatter,
-  'document-compact': DocumentCompactFormatter,
-  'binary': DocumentFormatter
+  'multi-select': MultiSelectFormatter,
+  'number': NumberFormatter,
+  'percent': PercentFormatter,
+  'phone': PhoneFormatter,
+  'postcode': StringFormatter,
+  'remote': SingleSelectFormatter,
+  'short': NumberFormatter,
+  'single-select': SingleSelectFormatter,
+  'sorting': NumberFormatter,
+  'string': StringFormatter,
+  'text': TextFormatter,
+  'time': TimeFormatter,
+  'url': UrlFormatter,
+  'uuid': StringFormatter,
+  'version': NumberFormatter
 }

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.js
@@ -1,11 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import Icon from '../../Icon'
 
 const BooleanFormatter = props => {
-  const icon = props.value ? 'glyphicon-ok' : 'glyphicon-remove'
-
   return (
-    <span className={`glyphicon ${icon}`} aria-hidden="true"/>
+    <Icon icon={props.value ? 'fa-check' : 'fa-times'}/>
   )
 }
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/BooleanFormatter.spec.js
@@ -10,14 +10,14 @@ describe('tocco-ui', function() {
           const wrapper = mount(
             <BooleanFormatter value/>
           )
-          expect(wrapper.html()).to.contains('glyphicon-ok')
+          expect(wrapper.html()).to.contains('fa-check')
         })
 
         it('should format falsy value', function() {
           const wrapper = mount(
             <BooleanFormatter value={false}/>
           )
-          expect(wrapper.html()).to.contains('glyphicon-remove')
+          expect(wrapper.html()).to.contains('fa-times')
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
@@ -2,15 +2,19 @@ import React from 'react'
 import {FormattedDate} from 'react-intl'
 import {matchesIsoDate} from '../util/DateUtils'
 
+import {Time} from '../../Typography'
+
 const DateFormatter = props => {
   return (
-    <FormattedDate
-      value={props.value}
-      year="numeric"
-      month="2-digit"
-      day="2-digit"
-      timeZone="UTC"
-    />
+    <Time dateTime={props.value}>
+      <FormattedDate
+        value={props.value}
+        year="numeric"
+        month="2-digit"
+        day="2-digit"
+        timeZone="UTC"
+      />
+    </Time>
   )
 }
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.js
@@ -1,12 +1,15 @@
 import React from 'react'
-import {FormattedDate} from 'react-intl'
+import {FormattedDate, injectIntl, intlShape} from 'react-intl'
 import {matchesIsoDate} from '../util/DateUtils'
 
 import {Time} from '../../Typography'
 
 const DateFormatter = props => {
   return (
-    <Time dateTime={props.value}>
+    <Time
+      dateTime={props.value}
+      title={props.intl.formatDate(props.value)}
+    >
       <FormattedDate
         value={props.value}
         year="numeric"
@@ -19,6 +22,7 @@ const DateFormatter = props => {
 }
 
 DateFormatter.propTypes = {
+  intl: intlShape.isRequired,
   value: (props, propName, componentName) => {
     if (!matchesIsoDate(props[propName])) {
       return new Error(`Invalid prop '${propName}' supplied to ${componentName}.`)
@@ -26,4 +30,4 @@ DateFormatter.propTypes = {
   }
 }
 
-export default DateFormatter
+export default injectIntl(DateFormatter)

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateFormatter.spec.js
@@ -16,24 +16,31 @@ describe('tocco-ui', function() {
         })
 
         const leftToRightMark = /\u200E/g // required for browser Edge
+        const dateInput = '1976-11-16'
+        const dateOutputIso = '1976-11-16'
+        const dateOutputEn = '11/16/1976'
+        const dateOutputDe = '16.11.1976'
 
         it('should format value', () => {
           const wrapper = mount(
             <IntlProvider locale="en">
-              <DateFormatter value="1976-11-16"/>
+              <DateFormatter value={dateInput}/>
             </IntlProvider>
           )
-
-          expect(wrapper.text().replace(leftToRightMark, '')).to.equal('11/16/1976')
+          expect(wrapper.text().replace(leftToRightMark, '')).to.equal(dateOutputEn)
+          expect(wrapper.find('time').prop('title')).to.equal(dateOutputEn)
+          expect(wrapper.find('time').prop('dateTime')).to.equal(dateOutputIso)
         })
 
         it('should format value according to locale', () => {
           const wrapper = mount(
             <IntlProvider locale="de">
-              <DateFormatter value="1976-11-16"/>
+              <DateFormatter value={dateInput}/>
             </IntlProvider>
           )
-          expect(wrapper.text().replace(leftToRightMark, '')).to.equal('16.11.1976')
+          expect(wrapper.text().replace(leftToRightMark, '')).to.equal(dateOutputDe)
+          expect(wrapper.find('time').prop('title')).to.equal(dateOutputDe)
+          expect(wrapper.find('time').prop('dateTime')).to.equal(dateOutputIso)
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateTimeFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateTimeFormatter.js
@@ -2,18 +2,20 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedDate, FormattedTime} from 'react-intl'
 
+import {Span, Time} from '../../Typography'
+
 const DateTimeFormatter = props => {
   const timestamp = Date.parse(props.value)
   if (isNaN(timestamp)) {
     // eslint-disable-next-line no-console
     console.error('DateTimeFormatter: Invalid date', props.value)
-    return <span/>
+    return <Span/>
   }
 
   const date = new Date(timestamp)
 
   return (
-    <span>
+    <Time dateTime={date.toISOString()}>
       <FormattedDate
         value={date}
         year="numeric"
@@ -23,7 +25,7 @@ const DateTimeFormatter = props => {
       <FormattedTime
         value={date}
       />
-    </span>
+    </Time>
   )
 }
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateTimeFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateTimeFormatter.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {FormattedDate, FormattedTime} from 'react-intl'
+import {FormattedDate, FormattedTime, injectIntl, intlShape} from 'react-intl'
 
 import {Span, Time} from '../../Typography'
 
@@ -13,9 +13,11 @@ const DateTimeFormatter = props => {
   }
 
   const date = new Date(timestamp)
-
   return (
-    <Time dateTime={date.toISOString()}>
+    <Time
+      dateTime={date.toISOString()}
+      title={`${props.intl.formatDate(date)}, ${props.intl.formatTime(date)}`}
+    >
       <FormattedDate
         value={date}
         year="numeric"
@@ -30,7 +32,8 @@ const DateTimeFormatter = props => {
 }
 
 DateTimeFormatter.propTypes = {
+  intl: intlShape.isRequired,
   value: PropTypes.string.isRequired
 }
 
-export default DateTimeFormatter
+export default injectIntl(DateTimeFormatter)

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DateTimeFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DateTimeFormatter.spec.js
@@ -25,6 +25,8 @@ describe('tocco-ui', function() {
           // expect(wrapper.text()).to.equal('3/16/1976,1:00 PM')
 
           expect(wrapper.text()).to.not.equal('')
+          expect(wrapper.find('time').prop('title')).to.not.equal('')
+          expect(wrapper.find('time').prop('dateTime')).to.not.equal('')
         })
 
         it('should format value according to locale', function() {
@@ -35,6 +37,8 @@ describe('tocco-ui', function() {
           // See above
           // expect(wrapper.text()).to.equal('16.3.1976,13:00')
           expect(wrapper.text()).to.not.equal('')
+          expect(wrapper.find('time').prop('title')).to.not.equal('')
+          expect(wrapper.find('time').prop('dateTime')).to.not.equal('')
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DecimalFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DecimalFormatter.js
@@ -2,13 +2,17 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedNumber} from 'react-intl'
 
+import {Span} from '../../Typography'
+
 const DecimalFormatter = props => {
   return (
-    <FormattedNumber
-      value={props.value}
-      style="decimal"
-      minimumFractionDigits={2}
-    />
+    <Span>
+      <FormattedNumber
+        value={props.value}
+        style="decimal"
+        minimumFractionDigits={2}
+      />
+    </Span>
   )
 }
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Preview from '../../Preview'
+import ButtonLink from '../../ButtonLink'
 
 const DocumentCompactFormatter = props => (
-  <Preview
+  <ButtonLink
     alt={props.value.alt || props.value.fileName}
-    caption={props.value.caption || props.value.fileName}
-    downloadOnClick={true}
-    fileName={props.value.fileName}
-    srcUrl={props.value.binaryLink}
+    download={props.value.fileName}
+    icon="fa-download"
+    look="raised"
+    href={props.value.binaryLink}
   />
 )
 
@@ -16,7 +16,6 @@ DocumentCompactFormatter.propTypes = {
   value: PropTypes.shape({
     alt: PropTypes.string,
     binaryLink: PropTypes.string.isRequired,
-    caption: PropTypes.string,
     fileName: PropTypes.string.isRequired
   }).isRequired
 }

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
@@ -1,31 +1,24 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import Preview from '../../Preview'
 
-const DocumentFormatter = props => (
-  <span className="form-control-static document-compact">
-    <a
-      download={props.value.fileName}
-      href={props.value.binaryLink}
-      title={props.options.downloadTitle || 'Download'}
-      onClick={e => e.stopPropagation()}
-      className="action btn btn-default"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <i className="fa fa-download" aria-hidden="true"></i>
-    </a>
-  </span>
+const DocumentCompactFormatter = props => (
+  <Preview
+    alt={props.value.alt || props.value.fileName}
+    caption={props.value.caption || props.value.fileName}
+    downloadOnClick={true}
+    fileName={props.value.fileName}
+    srcUrl={props.value.binaryLink}
+  />
 )
 
-DocumentFormatter.propTypes = {
+DocumentCompactFormatter.propTypes = {
   value: PropTypes.shape({
-    fileName: PropTypes.string.isRequired,
+    alt: PropTypes.string,
     binaryLink: PropTypes.string.isRequired,
-    thumbnailLink: PropTypes.string.isRequired
-  }).isRequired,
-  options: PropTypes.shape({
-    downloadTitle: PropTypes.string
-  })
+    caption: PropTypes.string,
+    fileName: PropTypes.string.isRequired
+  }).isRequired
 }
 
-export default DocumentFormatter
+export default DocumentCompactFormatter

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.spec.js
@@ -1,27 +1,43 @@
 import React from 'react'
-import {shallow} from 'enzyme'
-
+import {mount} from 'enzyme'
 import DocumentCompactFormatter from './DocumentCompactFormatter'
 
 describe('tocco-ui', () => {
   describe('FormattedValue', () => {
     describe('typeFormatters', () => {
-      describe('typeFormatters', () => {
-        describe('DocumentCompactFormatter ', () => {
-          it('should render a link', () => {
-            const binaryLink = 'http://test.ch/link/to/image.png'
-            const fileName = 'FileName.png'
-            const thumbnailLink = 'http://test.com/link/to/thumbnail.png'
+      describe('DocumentCompactFormatter ', () => {
+        it('should pass four props', () => {
+          const wrapper = mount(<DocumentCompactFormatter value={{
+            alt: 'alt text',
+            binaryLink: 'binary url',
+            caption: 'caption text',
+            fileName: 'file name'
+          }}/>)
 
-            const wrapper = shallow(<DocumentCompactFormatter value={{
-              fileName,
-              thumbnailLink,
-              binaryLink
-            }}
-            options={{downloadTitle: 'test'}}/>)
+          const {
+            alt,
+            binaryLink,
+            caption,
+            fileName
+          } = wrapper.props().value
 
-            expect(wrapper.find('a')).to.have.length(1)
-          })
+          expect(alt).to.equal('alt text')
+          expect(binaryLink).to.equal('binary url')
+          expect(caption).to.equal('caption text')
+          expect(fileName).to.equal('file name')
+        })
+
+        it('should render link but no image', () => {
+          const wrapper = mount(<DocumentCompactFormatter value={{
+            alt: 'alt text',
+            binaryLink: 'binary url',
+            caption: 'caption text',
+            fileName: 'file name',
+            thumbnailLink: 'thumbnail url'
+          }}/>)
+
+          expect(wrapper.find('a')).to.have.length(1)
+          expect(wrapper.find('img')).to.have.length(0)
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentFormatter.js
@@ -1,20 +1,24 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Upload from '../../Upload'
+import Preview from '../../Preview'
+
 const DocumentFormatter = props => (
-  <div className="form-control-static document">
-    <Upload
-      readOnly={true}
-      value={props.value ? props.value : null}
-      onUpload={() => {}}
-    />
-  </div>
+  <Preview
+    alt={props.value.alt || props.value.fileName}
+    caption={props.value.caption || props.value.fileName}
+    downloadOnClick={true}
+    fileName={props.value.fileName}
+    srcUrl={props.value.binaryLink}
+    thumbnailUrl={props.value.thumbnailLink}
+  />
 )
 
 DocumentFormatter.propTypes = {
   value: PropTypes.shape({
-    fileName: PropTypes.string.isRequired,
+    alt: PropTypes.string,
     binaryLink: PropTypes.string.isRequired,
+    caption: PropTypes.string,
+    fileName: PropTypes.string.isRequired,
     thumbnailLink: PropTypes.string.isRequired
   }).isRequired
 }

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentFormatter.spec.js
@@ -1,27 +1,46 @@
 import React from 'react'
-import {shallow} from 'enzyme'
-import Upload from '../../Upload'
-
+import {mount} from 'enzyme'
 import DocumentFormatter from './DocumentFormatter'
 
 describe('tocco-ui', () => {
   describe('FormattedValue', () => {
     describe('typeFormatters', () => {
       describe('DocumentFormatter ', () => {
-        it('should render Upload component as readonly', () => {
-          const binaryLink = 'http://test.ch/link/to/image.png'
-          const fileName = 'FileName.png'
-          const thumbnailLink = 'http://test.com/link/to/thumbnail.png'
+        it('should pass five props', () => {
+          const wrapper = mount(<DocumentFormatter value={{
+            alt: 'alt text',
+            binaryLink: 'binary url',
+            caption: 'caption text',
+            fileName: 'file name',
+            thumbnailLink: 'thumbnail url'
+          }}/>)
 
-          const wrapper = shallow(<DocumentFormatter value={{
+          const {
+            alt,
+            binaryLink,
+            caption,
             fileName,
-            thumbnailLink,
-            binaryLink
-          }}
-          options={{downloadTitle: 'test'}}/>)
+            thumbnailLink
+          } = wrapper.props().value
 
-          expect(wrapper.find(Upload)).to.have.length(1)
-          expect(wrapper.find(Upload)).to.have.prop('readOnly', true)
+          expect(alt).to.equal('alt text')
+          expect(binaryLink).to.equal('binary url')
+          expect(caption).to.equal('caption text')
+          expect(fileName).to.equal('file name')
+          expect(thumbnailLink).to.equal('thumbnail url')
+        })
+
+        it('should render link and image', () => {
+          const wrapper = mount(<DocumentFormatter value={{
+            alt: 'alt text',
+            binaryLink: 'binary url',
+            caption: 'caption text',
+            fileName: 'file name',
+            thumbnailLink: 'thumbnail url'
+          }}/>)
+
+          expect(wrapper.find('a')).to.have.length(1)
+          expect(wrapper.find('img')).to.have.length(1)
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
@@ -10,7 +10,10 @@ const DurationFormatter = props => {
   const twoDigits = n => { return String('00' + n).slice(-2) }
   const durationIso = `${twoDigits(date.getHours())}:${twoDigits(date.getMinutes())}:${twoDigits(date.getSeconds())}`
   return (
-    <Time dateTime={durationIso}>
+    <Time
+      dateTime={durationIso}
+      title={durationIso}
+    >
       <FormattedDate
         value={date}
         hour="2-digit"

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
@@ -1,18 +1,19 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedDate} from 'react-intl'
+import moment from 'moment'
 
 import {Time} from '../../Typography'
 
 const DurationFormatter = props => {
   const milliSeconds = parseInt(props.value)
   const date = new Date(2000, 1, 1, 0, 0, 0, milliSeconds)
-  const twoDigits = n => { return String('00' + n).slice(-2) }
-  const durationIso = `${twoDigits(date.getHours())}:${twoDigits(date.getMinutes())}:${twoDigits(date.getSeconds())}`
+  const durationIsoMs = moment(date).format(moment.HTML5_FMT.TIME_MS)
+  const durationIsoS = moment(date).format(moment.HTML5_FMT.TIME_SECONDS)
   return (
     <Time
-      dateTime={durationIso}
-      title={durationIso}
+      dateTime={durationIsoMs}
+      title={durationIsoS}
     >
       <FormattedDate
         value={date}

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
@@ -2,18 +2,23 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedDate} from 'react-intl'
 
+import {Time} from '../../Typography'
+
 const DurationFormatter = props => {
   const milliSeconds = parseInt(props.value)
   const date = new Date(2000, 1, 1, 0, 0, 0, milliSeconds)
-
+  const twoDigits = n => { return String('00' + n).slice(-2) }
+  const durationIso = `${twoDigits(date.getHours())}:${twoDigits(date.getMinutes())}:${twoDigits(date.getSeconds())}`
   return (
-    <FormattedDate
-      value={date}
-      hour="2-digit"
-      minute="2-digit"
-      second="2-digit"
-      hour12={false}
-    />
+    <Time dateTime={durationIso}>
+      <FormattedDate
+        value={date}
+        hour="2-digit"
+        minute="2-digit"
+        second="2-digit"
+        hour12={false}
+      />
+    </Time>
   )
 }
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
@@ -20,13 +20,15 @@ describe('tocco-ui', () => {
 
       it('should format value', () => {
         const durationMilliseconds = 83000
-        const durationFormated = '00:01:23'
+
+        const durationFormatedS = '00:01:23'
+        const durationFormatedMs = '00:01:23.000'
 
         const wrapper = mount(<IntlProvider locale="en"><DurationFormatter
           value={durationMilliseconds}/></IntlProvider>)
-        expect(wrapper.find('time').prop('title')).to.equal(durationFormated)
-        expect(wrapper.find('time').prop('dateTime')).to.equal(durationFormated)
-        expect(wrapper.find('span').text().replace(leftToRightMark, '')).to.equal(durationFormated)
+        expect(wrapper.find('time').prop('title')).to.equal(durationFormatedS)
+        expect(wrapper.find('time').prop('dateTime')).to.equal(durationFormatedMs)
+        expect(wrapper.find('span').text().replace(leftToRightMark, '')).to.equal(durationFormatedS)
       })
     })
   })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
@@ -3,27 +3,28 @@ import DurationFormatter from './DurationFormatter'
 import {mount} from 'enzyme'
 import {addLocaleData, IntlProvider} from 'react-intl'
 
-describe('tocco-ui', function() {
-  describe('FormattedValue', function() {
+describe('tocco-ui', () => {
+  describe('FormattedValue', () => {
     describe('typeFormatters', () => {
-      describe('DurationFormatter ', function() {
-        before(function() {
+      describe('DurationFormatter ', () => {
+        before(() => {
           require('intl/locale-data/jsonp/en.js')
           require('intl/locale-data/jsonp/de.js')
           const en = require('react-intl/locale-data/en')
           const de = require('react-intl/locale-data/de')
           addLocaleData([...en, ...de])
         })
+      })
 
-        const leftToRightMark = /\u200E/g // required for browser Edge
+      const leftToRightMark = /\u200E/g // required for browser Edge
 
-        it('should format value', function() {
-          const durationMilliseconds = 5401000
+      it('should format value', () => {
+        const durationMilliseconds = 83000
 
-          const wrapper = mount(<IntlProvider locale="en"><DurationFormatter
-            value={durationMilliseconds}/></IntlProvider>)
-          expect(wrapper.text().replace(leftToRightMark, '')).to.equal('01:30:01')
-        })
+        const wrapper = mount(<IntlProvider locale="en"><DurationFormatter
+          value={durationMilliseconds}/></IntlProvider>)
+        expect(wrapper.find('time').prop('dateTime')).to.equal('00:01:23')
+        expect(wrapper.find('span').text().replace(leftToRightMark, '')).to.equal('00:01:23')
       })
     })
   })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
@@ -20,11 +20,13 @@ describe('tocco-ui', () => {
 
       it('should format value', () => {
         const durationMilliseconds = 83000
+        const durationFormated = '00:01:23'
 
         const wrapper = mount(<IntlProvider locale="en"><DurationFormatter
           value={durationMilliseconds}/></IntlProvider>)
-        expect(wrapper.find('time').prop('dateTime')).to.equal('00:01:23')
-        expect(wrapper.find('span').text().replace(leftToRightMark, '')).to.equal('00:01:23')
+        expect(wrapper.find('time').prop('title')).to.equal(durationFormated)
+        expect(wrapper.find('time').prop('dateTime')).to.equal(durationFormated)
+        expect(wrapper.find('span').text().replace(leftToRightMark, '')).to.equal(durationFormated)
       })
     })
   })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/LoginFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/LoginFormatter.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import {Span} from '../../Typography'
+
 const LoginFormatter = props => (
-  <span>{props.value.username}</span>
+  <Span>{props.value.username}</Span>
 )
 
 LoginFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/LongitudeFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/LongitudeFormatter.js
@@ -2,15 +2,19 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedNumber} from 'react-intl'
 
+import {Span} from '../../Typography'
+
 const LongitudeFormatter = props => {
   const number = props.value.value
 
   return (
-    <FormattedNumber
-      value={number}
-      style="decimal"
-      maximumFractionDigits={15}
-    />
+    <Span>
+      <FormattedNumber
+        value={number}
+        style="decimal"
+        maximumFractionDigits={15}
+      />
+    </Span>
   )
 }
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/MoneyFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/MoneyFormatter.js
@@ -2,12 +2,16 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedNumber} from 'react-intl'
 
+import {Span} from '../../Typography'
+
 const MoneyFormatter = props => (
-  <FormattedNumber
-    value={props.value}
-    style="decimal"
-    minimumFractionDigits={2}
-  />
+  <Span>
+    <FormattedNumber
+      value={props.value}
+      style="decimal"
+      minimumFractionDigits={2}
+    />
+  </Span>
 )
 
 MoneyFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import {Span} from '../../Typography'
+
 const MultiSelectFormatter = props => (
-  <span>{props.value.map(v => v.display).join(', ')}</span>
+  <Span>{props.value.map(v => v.display).join(', ')}</Span>
 )
 
 MultiSelectFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/NumberFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/NumberFormatter.js
@@ -2,12 +2,16 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedNumber} from 'react-intl'
 
+import {Span} from '../../Typography'
+
 const NumberFormatter = props => (
-  <FormattedNumber
-    value={props.value}
-    style="decimal"
-    maximumFractionDigits={0}
-  />
+  <Span>
+    <FormattedNumber
+      value={props.value}
+      style="decimal"
+      maximumFractionDigits={0}
+    />
+  </Span>
 )
 
 NumberFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/PercentFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/PercentFormatter.js
@@ -2,8 +2,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import DecimalFormatter from './DecimalFormatter'
 
+import {Span} from '../../Typography'
+
 const PercentFormatter = props => (
-  <span><DecimalFormatter value={props.value}/>%</span>
+  <Span><DecimalFormatter value={props.value}/>%</Span>
 )
 
 PercentFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/PercentFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/PercentFormatter.spec.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PercentFormatter from './PercentFormatter'
+import {mount} from 'enzyme'
+import {addLocaleData, IntlProvider} from 'react-intl'
+
+describe('tocco-ui', () => {
+  describe('FormattedValue', () => {
+    describe('typeFormatters', () => {
+      describe('PercentFormatter ', () => {
+        before(() => {
+          require('intl/locale-data/jsonp/en.js')
+          require('intl/locale-data/jsonp/de.js')
+          const en = require('react-intl/locale-data/en')
+          const de = require('react-intl/locale-data/de')
+          addLocaleData([...en, ...de])
+        })
+
+        it('should format value', () => {
+          const wrapper = mount(
+            <IntlProvider locale="en">
+              <PercentFormatter value={2.41}/>
+            </IntlProvider>
+          )
+          expect(wrapper.text()).to.equal('2.41%')
+        })
+
+        it('should format value accorind to locale', () => {
+          const wrapper = mount(
+            <IntlProvider locale="de">
+              <PercentFormatter value={99.9}/>
+            </IntlProvider>
+          )
+          expect(wrapper.text()).to.equal('99,90%')
+        })
+      })
+    })
+  })
+})

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/SingleSelectFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/SingleSelectFormatter.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import {Span} from '../../Typography'
+
 const SingleSelectFormatter = props => (
-  <span>{props.value.display}</span>
+  <Span>{props.value.display}</Span>
 )
 
 SingleSelectFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/StringFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/StringFormatter.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import {Span} from '../../Typography'
+
 const StringFormatter = props => (
-  <span>{props.value.toString()}</span>
+  <Span>{props.value.toString()}</Span>
 )
 
 StringFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TextFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TextFormatter.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import {P} from '../../Typography'
 
-const TextFormatter = props => (
-  <span style={{whiteSpace: 'pre-wrap'}}>{props.value}</span>
-)
+const TextFormatter = props => {
+  return props.value.split('\n').map((line, index) => <P key={index}>{line}</P>)
+}
 
 TextFormatter.propTypes = {
   value: PropTypes.string

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TextFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TextFormatter.spec.js
@@ -1,15 +1,14 @@
 import React from 'react'
 import TextFormatter from './TextFormatter'
-import {shallow} from 'enzyme'
+import {mount} from 'enzyme'
 
 describe('tocco-ui', () => {
   describe('FormattedValue', () => {
     describe('typeFormatters', () => {
       describe('TextFormatter ', () => {
         it('should format value', () => {
-          const wrapper = shallow(<TextFormatter value="TEST\nTEST"/>)
-          expect(wrapper.find('span')).to.have.length(1)
-          expect(wrapper.find('span')).to.have.style('white-space', 'pre-wrap')
+          const wrapper = mount(<TextFormatter value={'Lorem\nipsum'}/>)
+          expect(wrapper.find('p')).to.have.length(2)
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedTime, injectIntl, intlShape} from 'react-intl'
+import moment from 'moment'
 
 import {Time} from '../../Typography'
 
@@ -9,11 +10,8 @@ const TimeFormatter = props => {
   const minutes = parseInt(props.value.value.minuteOfHour) || 0
   const seconds = parseInt(props.value.value.secondOfMinute) || 0
   const milliSeconds = parseInt(props.value.value.millisOfSecond) || 0
-
   const date = new Date(2000, 1, 1, hours, minutes, seconds, milliSeconds)
-
-  const twoDigits = n => { return String('00' + n).slice(-2) }
-  const timeIso = `${twoDigits(date.getHours())}:${twoDigits(date.getMinutes())}`
+  const timeIso = moment(date).format(moment.HTML5_FMT.TIME_MS)
 
   return (
     <Time

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormattedTime} from 'react-intl'
 
+import {Time} from '../../Typography'
+
 const TimeFormatter = props => {
   const hours = parseInt(props.value.value.hourOfDay) || 0
   const minutes = parseInt(props.value.value.minuteOfHour) || 0
@@ -10,10 +12,15 @@ const TimeFormatter = props => {
 
   const date = new Date(2000, 1, 1, hours, minutes, seconds, milliSeconds)
 
+  const twoDigits = n => { return String('00' + n).slice(-2) }
+  const timeIso = `${twoDigits(date.getHours())}:${twoDigits(date.getMinutes())}`
+
   return (
-    <FormattedTime
-      value={date}
-    />
+    <Time dateTime={timeIso}>
+      <FormattedTime
+        value={date}
+      />
+    </Time>
   )
 }
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {FormattedTime} from 'react-intl'
+import {FormattedTime, injectIntl, intlShape} from 'react-intl'
 
 import {Time} from '../../Typography'
 
@@ -16,7 +16,10 @@ const TimeFormatter = props => {
   const timeIso = `${twoDigits(date.getHours())}:${twoDigits(date.getMinutes())}`
 
   return (
-    <Time dateTime={timeIso}>
+    <Time
+      dateTime={timeIso}
+      title={props.intl.formatTime(date)}
+    >
       <FormattedTime
         value={date}
       />
@@ -25,7 +28,8 @@ const TimeFormatter = props => {
 }
 
 TimeFormatter.propTypes = {
+  intl: intlShape.isRequired,
   value: PropTypes.object.isRequired
 }
 
-export default TimeFormatter
+export default injectIntl(TimeFormatter)

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
@@ -42,6 +42,7 @@ describe('tocco-ui', () => {
             </IntlProvider>
           )
           expect(wrapper.text().replace(leftToRightMark, '')).to.equal('23:15')
+          expect(wrapper.find('time').prop('dateTime')).to.equal('23:15')
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
@@ -17,7 +17,7 @@ describe('tocco-ui', () => {
 
         const leftToRightMark = /\u200E/g // required for browser Edge
 
-        const timeOutputIso = '23:15'
+        const timeOutputIso = '23:15:00.000'
         const timeOutputEn = '11:15 PM'
         const timeOutputDe = '23:15'
 

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/TimeFormatter.spec.js
@@ -17,6 +17,10 @@ describe('tocco-ui', () => {
 
         const leftToRightMark = /\u200E/g // required for browser Edge
 
+        const timeOutputIso = '23:15'
+        const timeOutputEn = '11:15 PM'
+        const timeOutputDe = '23:15'
+
         const timeValue = {
           value: {
             hourOfDay: 23,
@@ -32,7 +36,9 @@ describe('tocco-ui', () => {
               <TimeFormatter value={timeValue}/>
             </IntlProvider>
           )
-          expect(wrapper.text().replace(leftToRightMark, '')).to.equal('11:15 PM')
+          expect(wrapper.text().replace(leftToRightMark, '')).to.equal(timeOutputEn)
+          expect(wrapper.find('time').prop('title')).to.equal(timeOutputEn)
+          expect(wrapper.find('time').prop('dateTime')).to.equal(timeOutputIso)
         })
 
         it('should format value accorind to locale', () => {
@@ -41,8 +47,9 @@ describe('tocco-ui', () => {
               <TimeFormatter value={timeValue}/>
             </IntlProvider>
           )
-          expect(wrapper.text().replace(leftToRightMark, '')).to.equal('23:15')
-          expect(wrapper.find('time').prop('dateTime')).to.equal('23:15')
+          expect(wrapper.text().replace(leftToRightMark, '')).to.equal(timeOutputDe)
+          expect(wrapper.find('time').prop('title')).to.equal(timeOutputDe)
+          expect(wrapper.find('time').prop('dateTime')).to.equal(timeOutputIso)
         })
       })
     })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/UrlFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/UrlFormatter.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import Link from '../../Link'
+
 const UrlFormatter = props => (
-  <span><a href={props.value}>{props.value}</a></span>
+  <Link href={props.value} label={props.value}/>
 )
 
 UrlFormatter.propTypes = {

--- a/packages/tocco-ui/src/Icon/Icon.spec.js
+++ b/packages/tocco-ui/src/Icon/Icon.spec.js
@@ -53,5 +53,11 @@ describe('tocco-ui', function() {
       expect(wrapper.dive().text()).to.equal('•')
       expect(wrapper.props().className).to.equal('fa')
     })
+
+    it('should render unicode and set classname', () => {
+      const wrapper = shallow(<Icon unicode={'\u2022'}/>)
+      expect(wrapper.dive().text()).to.equal('•')
+      expect(wrapper.props().className).to.equal('fa')
+    })
   })
 })

--- a/packages/tocco-ui/src/Typography/Misc.js
+++ b/packages/tocco-ui/src/Typography/Misc.js
@@ -124,7 +124,7 @@ const Strong = props =>
 const Time = props =>
   <StyledTime
     breakWords={props.breakWords}
-    title={props.breakWords ? undefined : getTextOfChildren(props.children)}
+    title={props.title}
     dateTime={props.dateTime}
   >{props.children}</StyledTime>
 
@@ -206,7 +206,8 @@ Time.propTypes = {
 */
   breakWords: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  dateTime: PropTypes.string.isRequired
+  dateTime: PropTypes.string.isRequired,
+  title: PropTypes.string
 }
 
 export {

--- a/packages/tocco-ui/src/Typography/Misc.spec.js
+++ b/packages/tocco-ui/src/Typography/Misc.spec.js
@@ -509,7 +509,10 @@ describe('tocco-ui', function() {
 
         it('should render title', () => {
           const wrapper = mount(
-            <Time dateTime="23:59:59">23:59:59</Time>
+            <Time
+              dateTime="23:59:59"
+              title="23:59:59"
+            >23:59:59</Time>
           )
           expect(wrapper.find('time').text()).to.equal('23:59:59')
           expect(wrapper.find('time').prop('title')).to.equal('23:59:59')

--- a/packages/tocco-ui/src/Typography/StyledMisc.js
+++ b/packages/tocco-ui/src/Typography/StyledMisc.js
@@ -106,7 +106,7 @@ const StyledP = styled.p`
   && {
     ${props => declareFont(props)}
     ${props => props.breakWords ? declareWrappingText() : declareNoneWrappingText()}
-    margin-bottom: ${theme('space.5')}
+    margin-bottom: ${theme('space.5')};
 
     &:last-child {
       margin-bottom: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7005,6 +7005,10 @@ modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
 
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 moment@^2.6.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"


### PR DESCRIPTION
@MethodenMann Have a close look on changes in DocumentFormatter.js and DocumentCompactFormatter of commit f087c90. You have adapted those formatters in #440.

Since formatted values are readable only `<Preview>` is a better choice than `<Upload>` and plain html. Probably it makes sense to remove prop.readOnly from `<Upload>` to enforce usage of `<Preview>`. Note that `<Preview>` provides a link for download instead of a button, which might be a usability issue.

**Solution:** ButtonLink is used 76543c98fb56199c0db13301aded0f7c9910a4e5