### PR TITLE
style(tocco-ui): limit maximal dimension of Preview image

### DIFF
--- a/packages/tocco-ui/src/Preview/Preview.js
+++ b/packages/tocco-ui/src/Preview/Preview.js
@@ -5,6 +5,7 @@ import Icon from '../Icon'
 import Link from '../Link'
 import {Figcaption} from '../Typography'
 import StyledPreview from './StyledPreview'
+import {validateCssDimension} from '../utilStyles'
 
 /**
  * Use <Preview> to display a preview of any kind of file. Provide URLs to thumbnail and file.
@@ -76,20 +77,14 @@ Preview.propTypes = {
    * thumbnailLink as arguments. onClick overrules downloadOnClick.
    */
   onClick: PropTypes.func,
-  maxDimensionX: function(props, propName, componentName) {
-    if (props[propName] !== undefined && !/^[1-9][0-9]*(px|em|rem|fr|%|vh|vw|vmin|vmax)$/.test(props[propName])) {
-      return new Error(
-        `Invalid prop ${propName} supplied to ${componentName} (${props.maxDimension}).`
-      )
-    }
-  },
-  maxDimensionY: function(props, propName, componentName) {
-    if (props[propName] !== undefined && !/^[1-9][0-9]*(px|em|rem|fr|%|vh|vw|vmin|vmax)$/.test(props[propName])) {
-      return new Error(
-        `Invalid prop ${propName} supplied to ${componentName} (${props.maxDimension}).`
-      )
-    }
-  },
+  /**
+   * Declare maximal width of displayed image as css property.
+   */
+  maxDimensionX: validateCssDimension,
+  /**
+   * Declare maximal height of displayed image as css property.
+   */
+  maxDimensionY: validateCssDimension,
   /**
    * The url to the document (can be any kind of file).
    */

--- a/packages/tocco-ui/src/Preview/Preview.js
+++ b/packages/tocco-ui/src/Preview/Preview.js
@@ -42,7 +42,11 @@ const Preview = props => {
   const interactive = ((props.downloadOnClick && props.srcUrl) || props.onClick)
 
   return (
-    <StyledPreview interactive={interactive}>
+    <StyledPreview
+      interactive={interactive}
+      maxDimensionX={props.maxDimensionX}
+      maxDimensionY={props.maxDimensionY}
+    >
       {imageWrapper}
       {props.caption && <Figcaption>{props.caption}</Figcaption>}
     </StyledPreview>
@@ -72,6 +76,20 @@ Preview.propTypes = {
    * thumbnailLink as arguments. onClick overrules downloadOnClick.
    */
   onClick: PropTypes.func,
+  maxDimensionX: function(props, propName, componentName) {
+    if (props[propName] !== undefined && !/^[1-9][0-9]*(px|em|rem|fr|%|vh|vw|vmin|vmax)$/.test(props[propName])) {
+      return new Error(
+        `Invalid prop ${propName} supplied to ${componentName} (${props.maxDimension}).`
+      )
+    }
+  },
+  maxDimensionY: function(props, propName, componentName) {
+    if (props[propName] !== undefined && !/^[1-9][0-9]*(px|em|rem|fr|%|vh|vw|vmin|vmax)$/.test(props[propName])) {
+      return new Error(
+        `Invalid prop ${propName} supplied to ${componentName} (${props.maxDimension}).`
+      )
+    }
+  },
   /**
    * The url to the document (can be any kind of file).
    */

--- a/packages/tocco-ui/src/Preview/StyledPreview.js
+++ b/packages/tocco-ui/src/Preview/StyledPreview.js
@@ -23,7 +23,8 @@ const StyledPreview = styled.figure`
     }
 
     img {
-      max-width: 100%;
+      max-width: ${props => props.maxDimensionX || '100%'};
+      max-height: ${props => props.maxDimensionY || '100%'};
       ${props => declareInteraction(props)}
     }
 

--- a/packages/tocco-ui/src/Preview/example.js
+++ b/packages/tocco-ui/src/Preview/example.js
@@ -11,6 +11,8 @@ export default () => {
         alt="orange jellyfish floating in the deep blue sea"
         srcUrl="https://picsum.photos/500/500?image=1069"
         thumbnailUrl="https://picsum.photos/150/150?image=1069"
+        maxDimensionY="130px"
+        maxDimensionX="120px"
       />
       <Preview
         alt="hundreds of juicy strawberries tempting to degustate"

--- a/packages/tocco-ui/src/Upload/UploadProgress.js
+++ b/packages/tocco-ui/src/Upload/UploadProgress.js
@@ -7,6 +7,8 @@ const UploadProgress = props => (
   <div>
     <Preview
       caption={props.file.name}
+      maxDimensionX="96px"
+      maxDimensionY="96px"
       srcUrl={props.file.preview}
       thumbnailUrl={props.file.type.startsWith('image') ? props.file.preview : null}
     />

--- a/packages/tocco-ui/src/Upload/View.js
+++ b/packages/tocco-ui/src/Upload/View.js
@@ -26,10 +26,12 @@ const View = props => (
       }
     </div>
     <Preview
+      alt={props.value.fileName}
+      caption={props.value.fileName}
+      maxDimensionX="96px"
+      maxDimensionY="96px"
       srcUrl={props.value.binaryLink}
       thumbnailUrl={props.value.thumbnailLink}
-      caption={props.value.fileName}
-      alt={props.value.fileName}
     />
   </StyledView>
 )

--- a/packages/tocco-ui/src/utilStyles/index.js
+++ b/packages/tocco-ui/src/utilStyles/index.js
@@ -29,6 +29,7 @@ import {
   positionPropTypes
 } from './stylingConstants'
 import assertObjectValuesMatchOtherObjectKeys from './assertObjectValuesMatchOtherObjectKeys'
+import {validateCssDimension} from './propTypesValidator'
 export {
   animationPropTypes,
   conditionPropTypes,
@@ -54,5 +55,6 @@ export {
   stylingCondition,
   stylingInk,
   stylingLook,
-  stylingPosition
+  stylingPosition,
+  validateCssDimension
 }

--- a/packages/tocco-ui/src/utilStyles/propTypesValidator.js
+++ b/packages/tocco-ui/src/utilStyles/propTypesValidator.js
@@ -1,0 +1,19 @@
+/**
+ * Validate if valid css dimension as PropTypes.
+ * @param  {object} props
+ * @param  {string} propName
+ * @param  {string} componentName
+ * @return {object or null}
+ */
+export const validateCssDimension = (props, propName, componentName) => {
+  componentName = componentName || 'ANONYMOUS'
+  const value = props[propName]
+
+  if (value !== undefined && !/^[1-9][0-9]*(%|em|fr|px|rem|vh|vmax|vmin|vw)$/.test(value)) {
+    return new Error(
+      `Invalid prop ${propName} supplied to ${componentName} (${value}).`
+    )
+  } else {
+    return null
+  }
+}

--- a/packages/tocco-ui/src/utilStyles/propTypesValidator.spec.js
+++ b/packages/tocco-ui/src/utilStyles/propTypesValidator.spec.js
@@ -1,0 +1,90 @@
+import {validateCssDimension} from '../utilStyles'
+
+describe('tocco-ui', () => {
+  describe('utilStyles', () => {
+    describe('validateCssDimension (propTypes)', () => {
+      const props = {}
+      const valid = [
+        '1%',
+        '1em',
+        '1fr',
+        '1px',
+        '12px',
+        '123px',
+        '1234px',
+        '1rem',
+        '1vh',
+        '1vmax',
+        '1vmin',
+        '1vw'
+      ]
+      const invalid = [
+        '%',
+        'em',
+        'fr',
+        'px',
+        'rem',
+        'vh',
+        'vmax',
+        'vmin',
+        'vw',
+        '-1%',
+        '-1em',
+        '-1fr',
+        '-1px',
+        '-1rem',
+        '-1vh',
+        '-1vmax',
+        '-1vmin',
+        '-1vw',
+        '0%',
+        '0em',
+        '0fr',
+        '0px',
+        '0rem',
+        '0vh',
+        '0vmax',
+        '0vmin',
+        '0vw',
+        '1 %',
+        '1 em',
+        '1 fr',
+        '1 px',
+        '1 2px',
+        '1 23px',
+        '1 234px',
+        '1 rem',
+        '1 vh',
+        '1 vmax',
+        '1 vmin',
+        '1 vw',
+        '1%;',
+        '1em;',
+        '1fr;',
+        '1px;',
+        '12px;',
+        '123px;',
+        '1234px;',
+        '1rem;',
+        '1vh;',
+        '1vmax;',
+        '1vmin;',
+        '1vw;'
+      ]
+
+      it('should be valid dimension', () => {
+        valid.map(value => {
+          props['dimension'] = value
+          expect(validateCssDimension(props, 'dimension')).to.be.null
+        })
+      })
+
+      it('should be invalid dimension', () => {
+        invalid.map(value => {
+          props['dimension'] = value
+          expect(validateCssDimension(props, 'dimension')).to.be.an('error')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
I have implemented maximal dimension as parameter because not always is such a limitation desirable or should be used equally. Unit 'vw' and 'vh' enables responsiveness to some limitations. 

Current implementation corresponds with scale only but not with a crop and scale. A crop and scale effect would be possible with css property background-image and an additional element but needs a lot more logic. 

Personally I question an automatic crop function in an editor centric view anyway. Crop is a good choice to assures a nice aligned layout in a multi image read only view but not to administer raw data.