### PR TITLE
feat(tocco-util): allow multiple modals

### DIFF
--- a/packages/tocco-util/src/notifier/modules/modalComponents/ModalDisplay.js
+++ b/packages/tocco-util/src/notifier/modules/modalComponents/ModalDisplay.js
@@ -5,20 +5,27 @@ import ModalContent from './ModalContent'
 const ModalDisplay = props => {
   return (
     <div>
-      {props.modal
-      && <ModalContent
-        id={props.modal.id}
-        title={props.modal.title}
-        message={props.modal.message}
-        component={props.modal.component}
-        close={props.close}
-      />}
+      {props.modals.map((modal, idx) =>
+        <ModalContent
+          key={idx}
+          id={modal.id}
+          title={modal.title}
+          message={modal.message}
+          component={modal.component}
+          close={props.close}
+        />
+      )}
     </div>
   )
 }
 
 ModalDisplay.propTypes = {
-  modal: propTypes.object,
+  modals: propTypes.arrayOf(propTypes.shape({
+    id: propTypes.oneOfType([propTypes.string, propTypes.number]),
+    title: propTypes.string,
+    message: propTypes.string,
+    component: propTypes.func
+  })),
   close: propTypes.func
 }
 

--- a/packages/tocco-util/src/notifier/modules/modalComponents/ModalDisplay.spec.js
+++ b/packages/tocco-util/src/notifier/modules/modalComponents/ModalDisplay.spec.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import {mount} from 'enzyme'
+import ModalDisplay from './ModalDisplay'
+import ModalContent from './ModalContent'
+
+describe('tocco-util', () => {
+  describe('notifier', () => {
+    describe('modules', () => {
+      describe('modalComponents', () => {
+        describe('ModalDisplay', () => {
+          it('should render all modals', () => {
+            const modals = [
+              {id: 1, title: 'Test1', message: 'Message1', component: () => <div>Test1</div>},
+              {id: 2, title: 'Test2', message: 'Message2', component: () => <div>Test2</div>}
+            ]
+
+            const wrapper = mount(
+              <ModalDisplay
+                modals={modals}
+                close={() => {}}
+              />
+            )
+
+            expect(wrapper.find(ModalContent)).to.have.length(modals.length)
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/tocco-util/src/notifier/modules/modalComponents/ModalDisplayContainer.js
+++ b/packages/tocco-util/src/notifier/modules/modalComponents/ModalDisplayContainer.js
@@ -7,7 +7,7 @@ const mapActionCreators = {
 }
 
 const mapStateToProps = (state, props) => ({
-  modal: state.notifier.modalComponents.modals[0]
+  modals: state.notifier.modalComponents.modals
 })
 
 export default connect(mapStateToProps, mapActionCreators)(ModalDisplay)


### PR DESCRIPTION
- first simple solution to show a modal over a modal. this is used
  for example to prompt an advancedsearch modal over an action form data modal.