### PR TITLE
refactor(tocco-util): remove FormQuestionHandler in action

### DIFF
--- a/packages/tocco-util/src/rest/clientQuestions.js
+++ b/packages/tocco-util/src/rest/clientQuestions.js
@@ -1,15 +1,12 @@
-import React from 'react'
 import {channel} from 'redux-saga'
 import {call, put, take} from 'redux-saga/effects'
 import notifier from '../notifier'
 import {sendRequest} from './request'
 import ClientQuestionCancelledException from './ClientQuestionCancelledException'
-import SimpleFormApp from 'tocco-simple-form/src/main'
 
 const HANDLERS = {
   ConfirmQuestionHandler: handleConfirmQuestion,
-  YesNoQuestionHandler: handleYesNoQuestion,
-  FormQuestionHandler: handleFormQuestion
+  YesNoQuestionHandler: handleYesNoQuestion
 }
 
 export function* handleClientQuestion(response, requestData, options) {
@@ -80,26 +77,4 @@ export function* handleYesNoQuestion(question) {
   yield put(notifier.yesNoQuestion(header, message, yesText, noText, cancelText, onYes, onNo, onCancel))
 
   return yield take(answerChannel)
-}
-
-export function* handleFormQuestion(question) {
-  const answerChannel = yield call(channel)
-
-  const onSend = values => answerChannel.put(answer(values))
-  const onCancel = () => answerChannel.put(answer(null))
-
-  const {id, header, message, model, form, sendText, cancelText} = question
-
-  yield put(notifier.modalComponent(id, header, message, () => (
-    <SimpleFormApp
-      onSubmit={onSend}
-      onCancel={onCancel}
-      model={model}
-      form={form}
-      submitText={sendText}
-      cancelText={cancelText}
-    />)))
-  const returnedAnswer = yield take(answerChannel)
-  yield put(notifier.removeModalComponent(id))
-  return returnedAnswer
 }

--- a/packages/tocco-util/src/rest/clientQuestions.spec.js
+++ b/packages/tocco-util/src/rest/clientQuestions.spec.js
@@ -1,15 +1,13 @@
-import {call, put, take} from 'redux-saga/effects'
+import {call, take} from 'redux-saga/effects'
 import {channel} from 'redux-saga'
 import {
   handleClientQuestion,
   getAnswer,
   handleConfirmQuestion,
   handleYesNoQuestion,
-  answer,
-  handleFormQuestion
+  answer
 } from './clientQuestions'
 import {sendRequest} from './request'
-import notifier from '../notifier'
 
 describe('tocco-util', () => {
   describe('rest', () => {
@@ -233,43 +231,6 @@ describe('tocco-util', () => {
 
           expect(next.value).to.equal(ans)
           expect(next.done).to.be.true
-        })
-      })
-
-      describe('handleFormQuestion', () => {
-        it('should get and object with form values', () => {
-          const form = {}
-          const model = {}
-          const question = {
-            id: 'formquestion',
-            handler: 'FormQuestionHandler',
-            header: 'title',
-            message: 'msg',
-            model,
-            form,
-            sendText: 'ok',
-            cancelText: 'cancel'
-          }
-
-          const gen = handleFormQuestion(question)
-
-          expect(gen.next().value).to.eql(call(channel))
-          const mockedChannel = channel()
-
-          const formActionPut = gen.next(mockedChannel).value
-
-          const actionPayload = formActionPut.PUT.action.payload
-
-          expect(actionPayload.title).to.eql(question.header)
-          expect(actionPayload.message).to.eql(question.message)
-          expect(actionPayload.component).to.be.an('function')
-          expect(gen.next().value).to.eql(take(mockedChannel))
-
-          const formValues = {firstname: 'test'}
-          const ans = answer(formValues)
-
-          expect(gen.next(ans).value).to.eql(put(notifier.removeModalComponent(question.id)))
-          expect(gen.next().done).to.be.true
         })
       })
     })


### PR DESCRIPTION
- We don't want to further develop client questions support.
  Form client questions would need some refactoring to work with the new
  advanced search feature. Also it creates a circular dependency between
  simple-form and tocco-util. Therefore it gets removed completely.