### PR TITLE
refactor(entity-list): add default for unhandled list types

### DIFF
--- a/packages/entity-list/src/util/api/entities.js
+++ b/packages/entity-list/src/util/api/entities.js
@@ -63,6 +63,11 @@ export const entitiesListTransformer = json => {
           type: 'html',
           value: paths[path].value
         }
+      } else {
+        result[path] = {
+          type: 'string',
+          value: ''
+        }
       }
     }
     return result


### PR DESCRIPTION
There are other types such as "multi" that get implemented later.
As a workaround a fallback to an empty string is added.