### PR TITLE
fix(tocco-ui): ensure correct color and spacing for icons

### DIFF
--- a/packages/tocco-ui/src/Button/Button.js
+++ b/packages/tocco-ui/src/Button/Button.js
@@ -34,7 +34,7 @@ const Button = props => {
       {props.pending && <IconTocco
         ink={props.ink || props.buttonGroupInk || stylingInk.BASE}
         look={props.look}
-        position="prepend"
+        position={props.iconPosition}
         size="1em"/>}
       {props.label ? <span>{props.label}</span> : props.children}
     </StyledButton>

--- a/packages/tocco-ui/src/Button/example.js
+++ b/packages/tocco-ui/src/Button/example.js
@@ -10,6 +10,7 @@ export default () => {
       {/* start example */}
       <Button
         label="Base color flat"
+        onClick={() => alert('do something')}
       />
       <Button
         ink="primary"
@@ -25,16 +26,16 @@ export default () => {
         look="raised"
       />
       <Button
-        dense
-        icon="hand-peace"
-        label="Dense"
-        look="raised"
-      />
-      <Button
         icon="handshake"
         iconPosition="append"
         label="Icon with text"
         type="submit"
+      />
+      <Button
+        dense
+        icon="hand-peace"
+        label="Dense"
+        look="raised"
       />
       <Button
         icon="hand-spock"
@@ -43,32 +44,14 @@ export default () => {
       />
       <Button
         disabled
+        icon="handshake"
+        ink="primary"
         label="Disabled"
-        onClick={() => alert('do something')}
-        title="This button is disabled"
-      />
-      <Button
-        label="Pending"
-        onClick={() => alert('do something')}
-        pending
+        look="raised"
       />
       <Button
         ink="primary"
         label="Pending"
-        onClick={() => alert('do something')}
-        pending
-      />
-      <Button
-        label="Pending"
-        look="raised"
-        onClick={() => alert('do something')}
-        pending
-      />
-      <Button
-        ink="primary"
-        label="Pending"
-        look="raised"
-        onClick={() => alert('do something')}
         pending
       />
       {/* end example */}

--- a/packages/tocco-ui/src/Icon/Icon.js
+++ b/packages/tocco-ui/src/Icon/Icon.js
@@ -40,7 +40,7 @@ class Icon extends React.Component {
   }
 
   render() {
-    const filteredProps = _omit(this.props, ['dense', 'position', 'onLoaded'])
+    const filteredProps = _omit(this.props, ['dense', 'onLoaded', 'position', 'theme'])
     return <this.lazyFontAwesomeIcon
       {...filteredProps}
       style={{...this.props.style, ...(getSpacing(this.props))}}

--- a/packages/tocco-ui/src/IconTocco/IconTocco.js
+++ b/packages/tocco-ui/src/IconTocco/IconTocco.js
@@ -6,17 +6,15 @@ import {
   StyledIconToccoSvg
 } from './StyledIconTocco'
 import {
-  inkPropTypes,
   positionPropTypes,
-  stylingInk,
-  stylingLook,
   stylingPosition
 } from '../utilStyles'
 
+/**
+ * Use <IconTocco> as spinner. Circle color is inherited from parent.
+ */
 const IconTocco = props =>
   <StyledIconToccoWrapper
-    ink={props.ink || stylingInk.BASE}
-    look={props.look}
     position={props.position}
     size={props.size}
   >
@@ -28,8 +26,6 @@ const IconTocco = props =>
   </StyledIconToccoWrapper>
 
 IconTocco.defaultProps = {
-  ink: stylingInk.PRIMARY,
-  look: stylingLook.FLAT,
   position: stylingPosition.SOLE
 }
 
@@ -38,14 +34,6 @@ IconTocco.propTypes = {
    * Specify if icon is positioned next to text or not to control spacing. Default value is 'prepend'.
    */
   position: positionPropTypes,
-  /**
-   * Specify color palette. Default value is 'base'.
-   */
-  ink: inkPropTypes,
-  /**
-   * Look of button. Default value is 'flat'.
-   */
-  look: PropTypes.oneOf([stylingLook.FLAT, stylingLook.RAISED]),
   /**
    * Specify width and height.
    */

--- a/packages/tocco-ui/src/IconTocco/StyledIconTocco.js
+++ b/packages/tocco-ui/src/IconTocco/StyledIconTocco.js
@@ -1,31 +1,6 @@
 import styled, {keyframes} from 'styled-components'
 
-import {
-  declareFlatBaseColors,
-  declareFlatPrimaryColors,
-  declareInteractionColors,
-  declareRaisedBaseColors,
-  declareRaisedPrimaryColors,
-  stylingInk,
-  stylingLook
-} from '../utilStyles'
-
-const declareIconColor = props => {
-  let declareColor
-  const {ink, look} = props
-  const {FLAT, RAISED} = stylingLook
-  const {BASE, PRIMARY} = stylingInk
-  if (look === FLAT && ink === BASE) {
-    declareColor = declareFlatBaseColors
-  } else if (look === FLAT && ink === PRIMARY) {
-    declareColor = declareFlatPrimaryColors
-  } else if (look === RAISED && ink === BASE) {
-    declareColor = declareRaisedBaseColors
-  } else if (look === RAISED && ink === PRIMARY) {
-    declareColor = declareRaisedPrimaryColors
-  }
-  return declareInteractionColors(declareColor(props), 'svg')
-}
+import {getSpacing} from '../Icon'
 
 const rotateClockwise = keyframes`
   from {transform: rotate(0deg);}
@@ -71,7 +46,7 @@ const StyledIconToccoWrapper = styled.i`
     display: block;
     height: ${props => props.size ? props.size : ''};
     width: ${props => props.size ? props.size : '100%'};
-    ${props => declareIconColor(props)}
+    ${props => getSpacing(props)}
 
     // if not Internet Explorer 11 or lower do sophisticated animation (https://bit.ly/2Okub3j)
     @supports not (old: ie) {
@@ -97,7 +72,7 @@ const StyledIconToccoSvg = styled.svg.attrs({
   viewBox: '0 0 100 100'
 })`
   &&& {
-    fill: inherit;
+    fill: transparent;
     height: ${props => props.size ? props.size : ''};
     width: ${props => props.size ? props.size : '100%'};
 
@@ -108,7 +83,7 @@ const StyledIconToccoSvg = styled.svg.attrs({
       animation-iteration-count: infinite;
       fill: transparent;
       stroke-width: 14.4;
-      stroke: inherit;
+      stroke: currentColor;
     }
 
     .tocco-icon-top-left {

--- a/packages/tocco-ui/src/LoadMask/StyledLoadMask.js
+++ b/packages/tocco-ui/src/LoadMask/StyledLoadMask.js
@@ -2,6 +2,7 @@ import styled, {css, keyframes} from 'styled-components'
 import {theme} from 'styled-system'
 
 import {StyledSpan} from '../Typography/StyledMisc'
+import {StyledIconToccoWrapper} from '../IconTocco'
 
 const fadeIn = keyframes`
   from {opacity: 0;}
@@ -23,6 +24,10 @@ const StyledLoadMask = styled.div`
       > ${StyledSpan} {
         margin-top: ${theme('space.4')}
         z-index: 1;
+      }
+
+      > ${StyledIconToccoWrapper} {
+        color: ${theme('colors.primary.line.0')};
       }
     }
   `}


### PR DESCRIPTION
- correct spacing for buttons with prop spacing
- do not pass obsolete props ink, look and theme to component FontAwesomeIcon
- simplify color handling in component IconTocco by inheriting colors with svg feature currentColor instead of redeclaring
- declare primary color for IconTocco in LoadMask