### PR TITLE
chore: improve build with sourcemaps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,12 +19,10 @@
     "jest/globals": true
   },
   "globals" : {
+    "__CI__"      : false,
     "__DEV__"      : false,
-    "__TEST__"     : false,
     "__PROD__"     : false,
-    "__DEBUG__"    : false,
     "__STANDALONE__": false,
-    "__COVERAGE__" : false,
     "__BACKEND_URL__" : false,
     "__PACKAGE__": false,
     "__PACKAGE_NAME__": false,

--- a/config/_base.js
+++ b/config/_base.js
@@ -46,11 +46,10 @@ config.globals = {
     'NODE_ENV' : JSON.stringify(config.env)
   },
   'NODE_ENV'     : config.env,
+  '__CI__'       : !!process.env.CI,
   '__DEV__'      : config.env === 'development',
   '__PROD__'     : config.env === 'production',
   '__STANDALONE__': config.env === 'standalone',
-  '__TEST__'     : config.env === 'test',
-  '__DEBUG__'    : config.env === 'development' && !argv.no_debug,
   '__BACKEND_URL__': JSON.stringify(''),
   '__PACKAGE__'   : argv.package,
   '__PACKAGE_NAME__'   : JSON.stringify(argv.package),

--- a/packages/app-extensions/src/appFactory/store/store.js
+++ b/packages/app-extensions/src/appFactory/store/store.js
@@ -23,7 +23,7 @@ export const createStore = (reducers = {}, sagas = [], input, name = '', logErro
   const sagaMiddleware = createSagaMiddleware()
   let middleware = applyMiddleware(thunk, sagaMiddleware)
 
-  if (__DEBUG__) {
+  if (__DEV__) {
     const composeEnhancers = composeWithDevTools({
       name,
       shouldHotReload: false

--- a/server/main.js
+++ b/server/main.js
@@ -22,10 +22,17 @@ if (config.env === 'development') {
 
   updateMutableImportSCSS()
 
+  const wdm = require('webpack-dev-middleware')(compiler, {
+    publicPath: webpackConfig.output.publicPath,
+    logLevel: 'warn'
+  })
+
   logger.info('Enabling webpack dev and HMR middleware')
-  app.use(require('webpack-dev-middleware')(compiler, {
-    publicPath: webpackConfig.output.publicPath
-  }))
+  app.use(wdm)
+  wdm.waitUntilValid(() => {
+    logger.success('Compilation finished! Hot reload is watching for changes...')
+  })
+
   app.use(require('webpack-hot-middleware')(compiler))
 
   // Serve static assets from ~/public since Webpack is unaware of


### PR DESCRIPTION
To improve (re)build time:
- no source map files in CI mode
- no source map files for 3rd party bundles
- use eval-source-map for DEV and source-map for PROD

- improve webpack console log
- cleanup global vars