### PR TITLE
refactor(app-extensions): auto hide successful action messages

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/simpleAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/simpleAction.js
@@ -30,8 +30,9 @@ export function* invokeRequest(definition, entity, ids, parent, params) {
       const type = success ? 'success' : 'warning'
       const title = response.body.message || 'client.component.actions.successDefault'
       const icon = success ? 'check' : 'exclamation'
+      const timeOut = success ? 3000 : null
 
-      yield put(notifier.info(type, title, null, icon))
+      yield put(notifier.info(type, title, null, icon, timeOut))
     }
 
     return response.body


### PR DESCRIPTION
- this is a temporary fix. Long term the message should disappear
as soon as user activity (a click) is registered. This will prevent
unseen successful messages.