### PR TITLE
fix(app-extensions): workaround ugly style in safari

### DIFF
--- a/packages/app-extensions/src/notifier/components/StyledNotifier.js
+++ b/packages/app-extensions/src/notifier/components/StyledNotifier.js
@@ -182,6 +182,13 @@ const StyledNotifier = styled.div`
       margin: 0 auto;
     }
   }
+
+  // Safari 10.1+ according https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome
+  @media not all and (min-resolution:.001dpcm) { @media {
+      .tocco-notifier .redux-toastr .toastr-attention {
+        background-color: transparent;
+      }
+  }}
 }
 `
 


### PR DESCRIPTION
The fixed positioned div (.toastr-attention) is not displayed correctly in Safari if the div is nested in an element which declares scroll for overflow-y (.top-right).

Check https://stackoverflow.com/questions/26704903/only-in-safari-positionfixed-child-cut-off-when-parent-is-positionfixed-and and https://bugs.webkit.org/show_bug.cgi?id=160953 for more information.

The colored background of .toastr-attention only covers the area of .top-right even if .toastr-attention spans the whole viewport. Which is wanted to prevent clicks while the blocking info is showed.

Since it is only a styling error in Safari and accessibility (scroll) and functionality (preventing clicks) is more important than visualization (background color) the background was made transparent.