### PR TITLE
refactor: move advanced search and value change to app-extensions

### DIFF
--- a/packages/app-extensions/src/form/ReduxFormFieldAdapter.js
+++ b/packages/app-extensions/src/form/ReduxFormFieldAdapter.js
@@ -17,7 +17,8 @@ const ReduxFormFieldAdapter = props => {
     entityField,
     modelField,
     formFieldUtils,
-    readOnlyForm
+    readOnlyForm,
+    formName
   } = props
 
   const events = extractEventsFromInput(input)
@@ -26,6 +27,7 @@ const ReduxFormFieldAdapter = props => {
     formDefinitionField,
     modelField,
     id,
+    formName,
     value: input.value,
     dirty,
     touched,

--- a/packages/app-extensions/src/form/formBuilder.js
+++ b/packages/app-extensions/src/form/formBuilder.js
@@ -120,6 +120,7 @@ export default (
           readOnlyForm={isReadOnlyForm}
           name={transformFieldName(fieldName)}
           id={getFieldId(formName, fieldName)}
+          formName={formName}
           component={ReduxFormFieldAdapter}
           formDefinitionField={formDefinitionField}
           entityField={entityField}

--- a/packages/app-extensions/src/formData/advancedSearch/actions.js
+++ b/packages/app-extensions/src/formData/advancedSearch/actions.js
@@ -2,11 +2,10 @@ export const OPEN_ADVANCED_SEARCH = 'formData/OPEN_ADVANCED_SEARCH'
 export const ADVANCED_SEARCH_UPDATE = 'formData/ADVANCED_SEARCH_UPDATE'
 export const ADVANCED_SEARCH_CLOSE = 'formData/ADVANCED_SEARCH_CLOSE'
 
-export const openAdvancedSearch = (listApp, onSelect, formField, modelField, value) => ({
+export const openAdvancedSearch = (formName, formField, modelField, value) => ({
   type: OPEN_ADVANCED_SEARCH,
   payload: {
-    listApp,
-    onSelect,
+    formName,
     formField,
     modelField,
     value

--- a/packages/app-extensions/src/formData/formData.js
+++ b/packages/app-extensions/src/formData/formData.js
@@ -1,26 +1,30 @@
 import {combineReducers} from 'redux'
 import PropTypes from 'prop-types'
 import {reducer as reducerUtil} from 'tocco-util'
+import _get from 'lodash/get'
 
 import relationEntities from './relationEntities/reducer'
 import tooltips from './tooltips/reducer'
 import relationEntitiesSagas from './relationEntities/sagas'
 import tooltipsSaga from './tooltips/sagas'
 import advancedSearchSagas from './advancedSearch/sagas'
+import valueSagas from './values/sagas'
 import {setRelationEntities} from './relationEntities/actions'
 export const relationEntitiesSelector = store => store.formData.relationEntities.data
 export const tooltipSelector = store => store.formData.tooltips.data
 
-export const addToStore = (store, values) => {
+export const addToStore = (store, config) => {
   reducerUtil.injectReducers(store, {formData: combineReducers({relationEntities, tooltips})})
 
   store.sagaMiddleware.run(relationEntitiesSagas)
   store.sagaMiddleware.run(tooltipsSaga)
-  store.sagaMiddleware.run(advancedSearchSagas)
+  store.sagaMiddleware.run(advancedSearchSagas, config)
+  store.sagaMiddleware.run(valueSagas)
 
-  if (values && values.relationEntities) {
-    Object.keys(values.relationEntities).forEach(field => {
-      store.dispatch(setRelationEntities(field, values.relationEntities[field], false))
+  const relationEntitiesData = _get(config, 'data.relationEntities', null)
+  if (relationEntitiesData !== null) {
+    Object.keys(relationEntitiesData).forEach(field => {
+      store.dispatch(setRelationEntities(field, relationEntitiesData[field], false))
     })
   }
 }

--- a/packages/app-extensions/src/formData/index.js
+++ b/packages/app-extensions/src/formData/index.js
@@ -2,6 +2,7 @@ import {addToStore, relationEntitiesSelector, tooltipSelector, formDataPropType}
 import {loadRelationEntities} from './relationEntities/actions'
 import {loadTooltip} from './tooltips/actions'
 import {openAdvancedSearch} from './advancedSearch/actions'
+import {changeFieldValue} from './values/actions'
 
 export default {
   addToStore,
@@ -10,5 +11,6 @@ export default {
   relationEntitiesSelector,
   tooltipSelector,
   openAdvancedSearch,
-  formDataPropType
+  formDataPropType,
+  changeFieldValue
 }

--- a/packages/app-extensions/src/formData/values/actions.js
+++ b/packages/app-extensions/src/formData/values/actions.js
@@ -1,0 +1,10 @@
+export const CHANGE_FIELD_VALUE = 'formData/CHANGE_FIELD_VALUE'
+
+export const changeFieldValue = (formName, fieldName, value) => ({
+  type: CHANGE_FIELD_VALUE,
+  payload: {
+    formName,
+    fieldName,
+    value
+  }
+})

--- a/packages/app-extensions/src/formData/values/sagas.js
+++ b/packages/app-extensions/src/formData/values/sagas.js
@@ -1,0 +1,16 @@
+import {actions as formActions} from 'redux-form'
+
+import form from '../../form'
+import * as tooltipActions from './actions'
+
+import {all, fork, put, takeEvery} from 'redux-saga/effects'
+
+export default function* sagas() {
+  yield all([
+    fork(takeEvery, tooltipActions.CHANGE_FIELD_VALUE, changeValue)
+  ])
+}
+
+export function* changeValue({payload: {formName, fieldName, value}}) {
+  yield put(formActions.change(formName, form.transformFieldName(fieldName), value))
+}

--- a/packages/app-extensions/src/formData/values/sagas.spec.js
+++ b/packages/app-extensions/src/formData/values/sagas.spec.js
@@ -1,0 +1,38 @@
+import {expectSaga, testSaga} from 'redux-saga-test-plan'
+import {actions as formActions} from 'redux-form'
+
+import * as actions from './actions'
+import * as sagas from './sagas'
+
+import {fork, takeEvery} from 'redux-saga/effects'
+
+describe('app-extensions', () => {
+  describe('formData', () => {
+    describe('values', () => {
+      describe('sagas', () => {
+        describe('main saga', () => {
+          test('should fork sagas', () => {
+            const saga = testSaga(sagas.default)
+            saga.next().all([
+              fork(takeEvery, actions.CHANGE_FIELD_VALUE, sagas.changeValue)
+            ])
+          })
+        })
+
+        describe('changeValue saga', () => {
+          test('should put redux form action', () => {
+            const formName = 'detailForm'
+            const field = 'firstname'
+            const value = 'Test'
+
+            return expectSaga(
+              sagas.changeValue, actions.changeFieldValue(formName, field, value)
+            )
+              .put(formActions.change(formName, field, value))
+              .run()
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/app-extensions/src/formField/editableValueFactory.js
+++ b/packages/app-extensions/src/formField/editableValueFactory.js
@@ -10,13 +10,13 @@ const settings = {
 }
 
 export default type =>
-  (formField, modelField, props, events, utils) => {
-    const options = getOptions(type, formField, modelField, utils)
+  (formField, modelField, formName, props, events, utils) => {
+    const options = getOptions(type, formField, modelField, utils, formName)
 
     return <EditableValue type={type} events={events} {...props} options={options}/>
   }
 
-const getOptions = (type, formField, modelField, utils) => {
+const getOptions = (type, formField, modelField, utils, formName) => {
   const options = {}
 
   switch (type) {
@@ -56,7 +56,7 @@ const getOptions = (type, formField, modelField, utils) => {
         formBase: formField.formBase
       })
 
-      options.openAdvancedSearch = value => utils.openAdvancedSearch(formField, modelField, value)
+      options.openAdvancedSearch = value => utils.openAdvancedSearch(formName, formField, modelField, value)
       options.tooltips = _get(utils.tooltips, modelField.targetEntity, null)
       options.loadTooltip = id => utils.loadTooltip(modelField.targetEntity, id)
 

--- a/packages/app-extensions/src/formField/editableValueFactory.spec.js
+++ b/packages/app-extensions/src/formField/editableValueFactory.spec.js
@@ -18,7 +18,7 @@ describe('app-extensions', () => {
           }
         }
 
-        const editableValue = factory({}, {}, props, events, {})
+        const editableValue = factory({}, {}, 'formName', props, events, {})
 
         const wrapper = mount(editableValue)
 
@@ -35,7 +35,7 @@ describe('app-extensions', () => {
           }
         }
 
-        const editableValue = factory({}, {}, {}, {}, util)
+        const editableValue = factory({}, {}, 'formName', {}, {}, util)
 
         const wrapper = mount(editableValue)
 

--- a/packages/app-extensions/src/formField/formField.js
+++ b/packages/app-extensions/src/formField/formField.js
@@ -19,7 +19,8 @@ export const formFieldFactory = (mapping, data, resources = {}) => {
       error,
       utils,
       submitting,
-      readOnlyForm
+      readOnlyForm,
+      formName
     } = data
 
     const readOnly = (
@@ -35,6 +36,7 @@ export const formFieldFactory = (mapping, data, resources = {}) => {
       mapping,
       formDefinitionField,
       modelField,
+      formName,
       {
         id,
         value,
@@ -67,7 +69,7 @@ export const formFieldFactory = (mapping, data, resources = {}) => {
   }
 }
 
-const valueFieldFactory = (mapping, formField, modelField, props, events, utils) => {
+const valueFieldFactory = (mapping, formField, modelField, formName, props, events, utils) => {
   const type = formField.dataType ? 'dataType' : 'componentType'
 
   let typeFactory = mapping[formField[type]]
@@ -85,5 +87,5 @@ const valueFieldFactory = (mapping, formField, modelField, props, events, utils)
     }
   }
 
-  return typeFactory(formField, modelField, props, events, utils)
+  return typeFactory(formField, modelField, formName, props, events, utils)
 }

--- a/packages/entity-browser/src/dev/input-no-mock.json
+++ b/packages/entity-browser/src/dev/input-no-mock.json
@@ -1,8 +1,8 @@
 {
   "id": "DEV",
-  "entityName": "User",
+  "entityName": "Event",
   "limit": 25,
-  "formBase": "User",
+  "formBase": "Event",
   "showSearchForm": true,
   "showCreateButton": true,
   "disableSimpleSearch": false,

--- a/packages/entity-detail/src/components/DetailForm/DetailForm.js
+++ b/packages/entity-detail/src/components/DetailForm/DetailForm.js
@@ -11,8 +11,6 @@ import modes from '../../util/modes'
 import readOnlyFormFieldMapping from '../../util/detailView/readOnlyFormFieldMapping'
 import StyledDetailForm from './StyledDetailForm'
 
-const REDUX_FORM_NAME = 'detailForm'
-
 export class DetailForm extends React.Component {
   constructor(props) {
     super(props)
@@ -34,7 +32,7 @@ export class DetailForm extends React.Component {
       uploadDocument: props.uploadDocument,
       intl: this.props.intl,
       openAdvancedSearch: props.openAdvancedSearch,
-      changeFieldValue: props.changeFieldValue.bind(null, REDUX_FORM_NAME)
+      changeFieldValue: props.changeFieldValue
     }
 
     return form.initFormBuilder(
@@ -174,6 +172,6 @@ DetailForm.propTypes = {
 }
 
 export default reduxForm({
-  form: REDUX_FORM_NAME,
+  form: 'detailForm',
   destroyOnUnmount: false
 })(DetailForm)

--- a/packages/entity-detail/src/containers/DetailFormContainer.js
+++ b/packages/entity-detail/src/containers/DetailFormContainer.js
@@ -6,19 +6,16 @@ import {
   getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
-  getFormSubmitErrors,
-  actions as formActions
+  getFormSubmitErrors
 } from 'redux-form'
 import {errorLogging, formData} from 'tocco-app-extensions'
-import EntityListApp from 'tocco-entity-list/src/main'
 
 import DetailForm from '../components/DetailForm/DetailForm'
 import {
   unloadDetailView,
   submitForm,
   uploadDocument,
-  fireTouched,
-  advancedSearchUpdate
+  fireTouched
 } from '../modules/entityDetail/actions'
 
 const mapActionCreators = {
@@ -29,8 +26,8 @@ const mapActionCreators = {
   uploadDocument,
   logError: errorLogging.logError,
   fireTouched,
-  openAdvancedSearch: (...args) => formData.openAdvancedSearch(EntityListApp, advancedSearchUpdate, ...args),
-  changeFieldValue: formActions.change
+  openAdvancedSearch: formData.openAdvancedSearch,
+  changeFieldValue: formData.changeFieldValue
 }
 
 const getFormGeneralErrors = formName =>

--- a/packages/entity-detail/src/main.js
+++ b/packages/entity-detail/src/main.js
@@ -39,7 +39,7 @@ const initApp = (id, input, events = {}, publicPath) => {
   errorLogging.addToStore(store, false)
   notifier.addToStore(store, false)
   actions.addToStore(store, {formApp: SimpleFormApp, listApp: EntityListApp})
-  formData.addToStore(store)
+  formData.addToStore(store, {listApp: EntityListApp})
 
   const dispatchActions = getDispatchActions(input)
 

--- a/packages/entity-detail/src/modules/entityDetail/actions.js
+++ b/packages/entity-detail/src/modules/entityDetail/actions.js
@@ -14,7 +14,6 @@ export const SET_FORM_NAME = 'entityDetail/SET_FORM_NAME'
 export const SET_SHOW_SUB_GRIDS_CREATE_BUTTON = 'entityDetail/SET_SHOW_SUB_GRIDS_CREATE_BUTTON'
 export const UPLOAD_DOCUMENT = 'entityDetail/UPLOAD_DOCUMENT'
 export const SET_APP_ID = 'entityDetail/SET_APP_ID'
-export const ADVANCED_SEARCH_UPDATE = 'entityDetail/ADVANCED_SEARCH_UPDATE'
 
 export const setFormDefinition = formDefinition => ({
   type: SET_FORM_DEFINITION,
@@ -118,13 +117,5 @@ export const setAppId = appId => ({
   type: SET_APP_ID,
   payload: {
     appId
-  }
-})
-
-export const advancedSearchUpdate = (field, ids) => ({
-  type: ADVANCED_SEARCH_UPDATE,
-  payload: {
-    field,
-    ids
   }
 })

--- a/packages/entity-detail/src/modules/entityDetail/sagas.js
+++ b/packages/entity-detail/src/modules/entityDetail/sagas.js
@@ -31,7 +31,6 @@ export default function* sagas() {
     fork(takeEvery, actions.SUBMIT_FORM, submitForm),
     fork(takeEvery, actions.UPLOAD_DOCUMENT, uploadDocument),
     fork(takeEvery, actions.FIRE_TOUCHED, fireTouched),
-    fork(takeEvery, actions.ADVANCED_SEARCH_UPDATE, advancedSearchUpdate),
     fork(takeEvery, actionUtil.actions.ACTION_INVOKED, actionInvoked)
   ])
 }
@@ -179,10 +178,6 @@ export function* uploadDocument({payload}) {
       error
     ))
   }
-}
-
-export function* advancedSearchUpdate({payload: {field, ids}}) {
-  yield put(formActions.change(FORM_ID, field, ids))
 }
 
 export function* fireTouched({payload}) {

--- a/packages/entity-detail/src/modules/entityDetail/sagas.spec.js
+++ b/packages/entity-detail/src/modules/entityDetail/sagas.spec.js
@@ -34,7 +34,6 @@ describe('entity-detail', () => {
               fork(takeEvery, actions.SUBMIT_FORM, sagas.submitForm),
               fork(takeEvery, actions.UPLOAD_DOCUMENT, sagas.uploadDocument),
               fork(takeEvery, actions.FIRE_TOUCHED, sagas.fireTouched),
-              fork(takeEvery, actions.ADVANCED_SEARCH_UPDATE, sagas.advancedSearchUpdate),
               fork(takeEvery, actionUtil.actions.ACTION_INVOKED, sagas.actionInvoked)
             ]))
             expect(generator.next().done).to.be.true

--- a/packages/entity-list/src/containers/SearchFormContainer.js
+++ b/packages/entity-list/src/containers/SearchFormContainer.js
@@ -8,8 +8,7 @@ import {
   submitSearchForm,
   resetSearch,
   setShowExtendedSearchForm,
-  loadSearchFilters,
-  advancedSearchUpdate
+  loadSearchFilters
 } from '../modules/searchForm/actions'
 
 const mapActionCreators = {
@@ -19,8 +18,7 @@ const mapActionCreators = {
   setShowExtendedSearchForm,
   loadRelationEntities: formData.loadRelationEntities,
   loadTooltip: formData.loadTooltip,
-  openAdvancedSearch: (...args) =>
-    formData.openAdvancedSearch(require('./../main').default, advancedSearchUpdate, ...args),
+  openAdvancedSearch: formData.openAdvancedSearch,
   changeFieldValue: formActions.change
 }
 

--- a/packages/entity-list/src/main.js
+++ b/packages/entity-list/src/main.js
@@ -43,7 +43,7 @@ const initApp = (id, input, events = {}, publicPath) => {
     errorLogging.addToStore(store, false)
     notifier.addToStore(store, false)
     actions.addToStore(store, {formApp: SimpleFormApp, listApp: EntityListApp})
-    formData.addToStore(store)
+    formData.addToStore(store, {listApp: EntityListApp})
 
     dispatchActions = getDispatchActions(input, true)
     storeStorage.set(id, store)

--- a/packages/entity-list/src/modules/searchForm/actions.js
+++ b/packages/entity-list/src/modules/searchForm/actions.js
@@ -99,14 +99,6 @@ export const setValuesInitialized = valuesInitialized => ({
   }
 })
 
-export const advancedSearchUpdate = (field, ids) => ({
-  type: ADVANCED_SEARCH_UPDATE,
-  payload: {
-    field,
-    ids
-  }
-})
-
 export const setShowFullTextSearchForm = showFullTextSearchForm => ({
   type: SET_SHOW_FULL_TEXT_SEARCH_FORM,
   payload: {

--- a/packages/entity-list/src/modules/searchForm/sagas.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.js
@@ -28,8 +28,7 @@ export default function* sagas() {
     fork(takeLatest, actions.LOAD_SEARCH_FILTERS, loadSearchFilters),
     fork(takeLatest, formActionTypes.CHANGE, submitSearchFrom),
     fork(takeLatest, actions.SUBMIT_SEARCH_FORM, submitSearchFrom),
-    fork(takeLatest, actions.RESET_SEARCH, resetSearch),
-    fork(takeLatest, actions.ADVANCED_SEARCH_UPDATE, advancedSearchUpdate)
+    fork(takeLatest, actions.RESET_SEARCH, resetSearch)
   ])
 }
 
@@ -147,8 +146,4 @@ export function* getSearchFormValues() {
       ...(!Array.isArray(value) || value.length) ? {[form.transformFieldNameBack(key)]: value} : {}
     }
   ), {})
-}
-
-export function* advancedSearchUpdate({payload: {field, ids}}) {
-  yield put(formActions.change(FORM_ID, form.transformFieldName(field), ids))
 }

--- a/packages/entity-list/src/modules/searchForm/sagas.spec.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.spec.js
@@ -26,8 +26,7 @@ describe('entity-list', () => {
               fork(takeLatest, actions.LOAD_SEARCH_FILTERS, sagas.loadSearchFilters),
               fork(takeLatest, formActionTypes.CHANGE, sagas.submitSearchFrom),
               fork(takeLatest, actions.SUBMIT_SEARCH_FORM, sagas.submitSearchFrom),
-              fork(takeLatest, actions.RESET_SEARCH, sagas.resetSearch),
-              fork(takeLatest, actions.ADVANCED_SEARCH_UPDATE, sagas.advancedSearchUpdate)
+              fork(takeLatest, actions.RESET_SEARCH, sagas.resetSearch)
             ]))
             expect(generator.next().done).to.be.true
           })

--- a/packages/simple-form/src/containers/FormContainer.js
+++ b/packages/simple-form/src/containers/FormContainer.js
@@ -1,29 +1,21 @@
 import {connect} from 'react-redux'
-import {bindActionCreators} from 'redux'
 import {form, formData} from 'tocco-app-extensions'
 import {injectIntl} from 'react-intl'
-import {actions as formActions} from 'redux-form'
 
 import Form from '../../src/components/Form'
-import {initializeForm, submit, cancel, advancedSearchUpdate} from '../modules/simpleForm/actions'
+import {initializeForm, submit, cancel} from '../modules/simpleForm/actions'
 import {uploadDocument} from '../utils/form/document/actions'
 
-const mapActionCreators = (dispatch, props) => (
-  {
-    ...bindActionCreators(
-      {
-        initializeForm,
-        onSubmit: submit,
-        onCancel: cancel,
-        loadRelationEntities: formData.loadRelationEntities,
-        loadTooltip: formData.loadTooltip,
-        changeFieldValue: formActions.change,
-        uploadDocument
-      }, dispatch
-    ),
-    openAdvancedSearch: (...args) => dispatch(formData.openAdvancedSearch(props.listApp, advancedSearchUpdate, ...args))
-  }
-)
+const mapActionCreators = {
+  initializeForm,
+  onSubmit: submit,
+  onCancel: cancel,
+  loadRelationEntities: formData.loadRelationEntities,
+  loadTooltip: formData.loadTooltip,
+  uploadDocument,
+  openAdvancedSearch: formData.openAdvancedSearch,
+  changeFieldValue: formData.changeFieldValue
+}
 
 const mapStateToProps = (state, props) => ({
   noButtons: state.input.noButtons,

--- a/packages/simple-form/src/main.js
+++ b/packages/simple-form/src/main.js
@@ -20,7 +20,7 @@ const initApp = (id, input, events = {}, publicPath) => {
   const store = appFactory.createStore(reducers, sagas, input, packageName)
   actionEmitter.addToStore(store, events.emitAction)
   externalEvents.addToStore(store, events)
-  formData.addToStore(store, input.formData)
+  formData.addToStore(store, {data: input.formData, listApp: input.listApp})
   notifier.addToStore(store, false)
 
   const app = appFactory.createApp(

--- a/packages/simple-form/src/modules/simpleForm/actions.js
+++ b/packages/simple-form/src/modules/simpleForm/actions.js
@@ -17,11 +17,3 @@ export const submit = () => ({
 export const cancel = () => ({
   type: CANCEL
 })
-
-export const advancedSearchUpdate = (field, ids) => ({
-  type: ADVANCED_SEARCH_UPDATE,
-  payload: {
-    field,
-    ids
-  }
-})

--- a/packages/simple-form/src/modules/simpleForm/sagas.js
+++ b/packages/simple-form/src/modules/simpleForm/sagas.js
@@ -18,7 +18,6 @@ export default function* sagas() {
     fork(takeEvery, actions.SUBMIT, submit),
     fork(takeEvery, actions.CANCEL, cancel),
     fork(takeLatest, documentActions.UPLOAD_DOCUMENT, documentSagas.uploadDocument),
-    fork(takeLatest, actions.ADVANCED_SEARCH_UPDATE, advancedSearchUpdate),
     fork(takeLatest, CHANGE, change),
     fork(takeLatest, UPDATE_SYNC_ERRORS, change),
     fork(takeLatest, INITIALIZE, change)
@@ -46,8 +45,4 @@ export function* change() {
   const values = yield select(getFormValues(FORM_ID))
   const valid = yield select(isValid(FORM_ID))
   yield put(externalEvents.fireExternalEvent('onChange', {values, valid}))
-}
-
-export function* advancedSearchUpdate({payload: {field, ids}}) {
-  yield put(formActions.change(FORM_ID, formUtil.transformFieldName(field), ids))
 }


### PR DESCRIPTION
- This refactoring helps to eliminate duplicate code in the packages and is
  the groundwork for an upcoming refactoring.
  The goal is to move all "form utils" to formData so that they can be
  provided with a container.