### PR TITLE
fix(app-extensions): readonly display bug

### DIFF
--- a/packages/app-extensions/src/form/FormBuilder.js
+++ b/packages/app-extensions/src/form/FormBuilder.js
@@ -65,13 +65,13 @@ class FormBuilder extends React.Component {
         return false
       }
 
-      if (this.props.beforeRenderField && this.props.beforeRenderField(formDefinitionField.id) === false) {
+      if (this.props.beforeRenderField && this.props.beforeRenderField(fieldName) === false) {
         return false
       }
 
       const hasEmptyValue = (fieldName, formValues) => {
         if (!formValues.hasOwnProperty(fieldName)) {
-          return false
+          return true
         } else {
           const value = formValues[fieldName]
           return (value == null || value === '' || (Array.isArray(value) && value.length === 0))
@@ -86,7 +86,7 @@ class FormBuilder extends React.Component {
       }
 
       return !(this.props.formDefinition.readonly
-        && hasEmptyValue(transformFieldName(formDefinitionField.id), this.props.formValues))
+        && hasEmptyValue(transformFieldName(fieldName), this.props.formValues))
     }
 
     if (shouldRenderField(

--- a/packages/app-extensions/src/form/FormBuilder.spec.js
+++ b/packages/app-extensions/src/form/FormBuilder.spec.js
@@ -46,7 +46,7 @@ const testData = {
   },
   formDefinition: {
     'id': 'UserSearch_detail',
-    'readonly': true,
+    'readonly': false,
     'children': [
       {
         'id': 'box1',
@@ -163,10 +163,11 @@ describe('app-extensions', () => {
 
       test('should not render empty values in readonly form', () => {
         const {entity, model, formName, formDefinition} = testData
-        const formValues = {...testData.formValues, lastname: ''}
-        const props = {entity, model, formName, formDefinition, formValues, formFieldMapping: {}}
-        const wrapper = shallow(<FormBuilder {...props}/>)
-        expect(wrapper.find(Field)).to.have.length(1)
+        const formDefinitionReadOnly = {...formDefinition, readonly: true}
+        const formValues = {lastname: undefined}
+        const props = {entity, model, formName, formValues, formFieldMapping: {}}
+        const wrapper = shallow(<FormBuilder {...props} formDefinition={formDefinitionReadOnly}/>)
+        expect(wrapper.find(Field)).to.have.length(0)
       })
 
       test('should render fields with matching scope', () => {

--- a/packages/app-extensions/src/formField/formattedValueFactory.js
+++ b/packages/app-extensions/src/formField/formattedValueFactory.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import {FormattedValue} from 'tocco-ui'
 
-export default type => (formField, modelField, properties, events, utils) => {
-  return <output><FormattedValue type={type} value={properties.value}/></output>
-}
+export default type => (formField, modelField, formName, properties, events, utils) =>
+  <output><FormattedValue type={type} value={properties.value}/></output>

--- a/packages/app-extensions/src/formField/formattedValueFactory.spec.js
+++ b/packages/app-extensions/src/formField/formattedValueFactory.spec.js
@@ -14,7 +14,7 @@ describe('app-extensions', () => {
           value
         }
 
-        const editableValue = factory({}, {}, props, {}, {})
+        const editableValue = factory({}, {}, 'formName', props, {}, {})
 
         const wrapper = mount(editableValue)
 

--- a/packages/tocco-util/src/mockData/entityFactory.js
+++ b/packages/tocco-util/src/mockData/entityFactory.js
@@ -189,6 +189,22 @@ export const createUsers = amount => {
             writable: false
           }
         },
+        decimal: {
+          type: 'field',
+          value: {
+            value: 1337.11,
+            type: 'moneyamount',
+            writable: true
+          }
+        },
+        moneyamount: {
+          type: 'field',
+          value: {
+            value: 28123.33,
+            type: 'moneyamount',
+            writable: true
+          }
+        },
         'relMulti_entity1.relPayment_status': {
           path: 'relMulti_entity1.relPayment_status',
           type: 'multi',


### PR DESCRIPTION
- in readonly mode field were not displayed because wrongly set
  parameters (formName was missing) after refactoring.
- also hide fields if field is absent in value object.
- adjust tests
- add mockData for decimal and moneyamount field