### PR TITLE
Pr/style selection buttons

### DIFF
--- a/packages/entity-list/src/components/SelectionController/SelectionController.js
+++ b/packages/entity-list/src/components/SelectionController/SelectionController.js
@@ -4,15 +4,13 @@ import {FormattedMessage} from 'react-intl'
 import {
   Button,
   ButtonGroup,
-  Typography,
-  stylingInk
+  Typography
 } from 'tocco-ui'
 
 import StyledSelectionController from './StyledSelectionController'
 
 const SelectionController = props => {
   const msg = id => (props.intl.formatMessage({id}))
-  const getInk = primary => primary ? {ink: stylingInk.PRIMARY} : {}
   const type = props.selection.length > 0 ? 'ID' : 'QUERY'
   const count = type === 'ID' ? props.selection.length : props.queryCount
 
@@ -31,15 +29,15 @@ const SelectionController = props => {
 
       {type === 'ID' && <ButtonGroup melt look="raised">
         <Button
+          aria={{'aria-pressed': !props.showSelectedRecords}}
           icon="search"
           title={msg('client.entity-list.showAllFilteredItems')}
-          {...(getInk(!props.showSelectedRecords))}
           onClick={props.toggleShowSelectedRecords}
         />
         <Button
+          aria={{'aria-pressed': props.showSelectedRecords}}
           icon="check-square"
           title={msg('client.entity-list.showSelectedItemsOnly')}
-          {...(getInk(props.showSelectedRecords))}
           onClick={props.toggleShowSelectedRecords}
         />
       </ButtonGroup>

--- a/packages/entity-list/src/components/SelectionController/SelectionController.js
+++ b/packages/entity-list/src/components/SelectionController/SelectionController.js
@@ -18,6 +18,7 @@ const SelectionController = props => {
     <StyledSelectionController>
       {type === 'ID' && <Button
         icon="times"
+        look="raised"
         title={msg('client.entity-list.clearSelection')}
         onClick={props.clearSelection}
       />}
@@ -26,7 +27,6 @@ const SelectionController = props => {
           id={`client.entity-list.operateOn${type === 'ID' ? 'Selected' : 'Queried'}Items`}
           values={{count: count}}/>
       </Typography.Span>
-
       {type === 'ID' && <ButtonGroup melt look="raised">
         <Button
           aria={{'aria-pressed': !props.showSelectedRecords}}
@@ -36,7 +36,7 @@ const SelectionController = props => {
         />
         <Button
           aria={{'aria-pressed': props.showSelectedRecords}}
-          icon="check-square"
+          icon="far, check-square"
           title={msg('client.entity-list.showSelectedItemsOnly')}
           onClick={props.toggleShowSelectedRecords}
         />

--- a/packages/entity-list/src/components/SelectionController/StyledSelectionController.js
+++ b/packages/entity-list/src/components/SelectionController/StyledSelectionController.js
@@ -7,8 +7,12 @@ import {
 export default styled.div`
   float: right;
 
+  > *:not(:last-child) {
+    margin-right: ${props => spaceScale(props, -1)};
+  }
+
   ${StyledButtonGroup} {
-    margin-left: ${props => spaceScale(props, -1)};
     display: inline-flex;
+    vertical-align: bottom;
   }
 `

--- a/packages/tocco-ui/src/Button/Button.js
+++ b/packages/tocco-ui/src/Button/Button.js
@@ -17,6 +17,7 @@ import {
 const Button = props => {
   return (
     <StyledButton
+      {...props.aria}
       dense={props.dense}
       disabled={props.disabled}
       iconPosition={props.iconPosition}
@@ -49,6 +50,10 @@ Button.defaultProps = {
 }
 
 Button.propTypes = {
+  /**
+   * A flat object of ARIA keys and values.
+   */
+  aria: PropTypes.object,
   /**
    * May be passed from <ButtonGroup> to use as default for ink. Do not set manually.
    */

--- a/packages/tocco-ui/src/Button/Button.js
+++ b/packages/tocco-ui/src/Button/Button.js
@@ -38,7 +38,7 @@ const Button = props => {
         look={props.look}
         position={props.iconPosition}
         size="1em"/>}
-      {props.label ? <span>{props.label}</span> : props.children}
+      {props.label ? <span>{props.label}</span> : props.children ? props.children : '\u200B' }
     </StyledButton>
   )
 }

--- a/packages/tocco-ui/src/Button/Button.stories.js
+++ b/packages/tocco-ui/src/Button/Button.stories.js
@@ -94,10 +94,15 @@ storiesOf('Button', module)
         />,
         <Button
           {...knobs}
-          icon="times"
+          label="I"
           key="10"
           look="ball"
-        />
+        />,
+        <Button
+          {...knobs}
+          key="10"
+          look="raised"
+        ><i>child</i></Button>
       ]
     }
   )

--- a/packages/tocco-ui/src/Button/StyledButton.js
+++ b/packages/tocco-ui/src/Button/StyledButton.js
@@ -80,7 +80,10 @@ const declareBall = props => {
       align-items: center;
 
       // ensure that width has at least the size of height
-      min-width: calc(1rem * ${theme('fontSize.base')(props)} * ${theme('lineHeights.regular')(props)});
+      min-width: calc(1rem
+        * ${theme('fontSize.base')(props)}
+        * ${theme('lineHeights.regular')(props)}
+        + 2 * ${spaceScale(props, -3)});
 
       // increase height to the size of width
       &:before {

--- a/packages/tocco-ui/src/utilStyles/declareInteractionColors.js
+++ b/packages/tocco-ui/src/utilStyles/declareInteractionColors.js
@@ -45,7 +45,8 @@ const declareInteractionColors = (colors, format = stylingFormat.HTML) => {
     }
 
     /* :active must be declared after :hover and :focus to visualize state change */
-    &:active {
+    &:active,
+    &[aria-pressed="true"] {
       ${fillProperty}: ${colors.activeBackground};
       ${strokeProperty}: ${colors.activeColor};
     }

--- a/packages/tocco-ui/src/utilStyles/declareInteractionColors.spec.js
+++ b/packages/tocco-ui/src/utilStyles/declareInteractionColors.spec.js
@@ -106,7 +106,8 @@ describe('tocco-ui', () => {
           const css = declareInteractionColors(colorSet)
           expect(css).to.match(/background-color: #000;[\n\s]*color: #300;/)
           expect(css).to.match(/&:focus,[\n\s]*&:hover {[\n\s]*background-color: #030;[\n\s]*color: #330;[\n\s]*}/)  // eslint-disable-line
-          expect(css).to.match(/&:active {[\n\s]*background-color: #003;[\n\s]*color: #033;[\n\s]*}/)
+          expect(css).to.match(/&:active,[\n\s]*&\[aria-pressed="true"\] {[\n\s]*background-color: #003;[\n\s]*color: #033;[\n\s]*}/)  // eslint-disable-line
+          expect(css).to.match(/&:disabled {[\n\s]*background-color: #7f7f7f;[\n\s]*color: #997f7f;[\n\s]*}/)  // eslint-disable-line
         }
       )
 


### PR DESCRIPTION
Why was selection count removed from text ressource. Value count is still passed to FormattedMessage in SelectionController. I strongly believe that users want to know on how many items actions are executed.