### PR TITLE
Pr/floating label

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "react-redux": "5.0.7",
     "react-redux-toastr": "7.3.0",
     "react-router-dom": "4.3.1",
+    "react-simple-focus-within": "^1.1.4",
     "react-test-renderer": "^16.4.1",
     "redbox-react": "^1.6.0",
     "redux": "4.0.0",

--- a/packages/tocco-ui/src/StatedValue/StatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.js
@@ -25,7 +25,7 @@ const detectSignal = (dirty, hasError) => {
  */
 const StatedValue = props => {
   const {
-    content,
+    children,
     description,
     dirty,
     error,
@@ -44,7 +44,7 @@ const StatedValue = props => {
       <StyledStatedValueBox
         hasValue={hasValue}
         signal={signal}>
-        {content}
+        {children}
         <StyledStatedValueLabel
           hasValue={hasValue}
           signal={signal}
@@ -66,7 +66,7 @@ StatedValue.propTypes = {
   /**
    * A component to enter or display data.
    */
-  content: PropTypes.node,
+  children: PropTypes.node,
   /**
    * A helper text to instruct users.
    */

--- a/packages/tocco-ui/src/StatedValue/StatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import FocusWithin from 'react-simple-focus-within'
 
 import ErrorList from '../FormField/ErrorList'
 import {
@@ -40,25 +41,33 @@ const StatedValue = props => {
   const signal = detectSignal(dirty, hasError)
 
   return (
-    <StyledStatedValueWrapper hasValue={hasValue}>
-      <StyledStatedValueBox
-        hasValue={hasValue}
-        signal={signal}>
-        {children}
-        <StyledStatedValueLabel
-          hasValue={hasValue}
-          signal={signal}
-          htmlFor={id}
-        >{label}{mandatory && ' *'}</StyledStatedValueLabel>
-      </StyledStatedValueBox>
-      {description
-        && <StyledStatedValueDescription>{description}</StyledStatedValueDescription>}
-      {hasError
-        && <StyledStatedValueError>
-          <ErrorList error={error}/>
-        </StyledStatedValueError>
-      }
-    </StyledStatedValueWrapper>
+    <FocusWithin>
+      {({focused, getRef}) => {
+        const secondaryPosition = focused || hasValue
+        return (
+          <StyledStatedValueWrapper
+            ref={getRef}
+            secondaryPosition={secondaryPosition}>
+            <StyledStatedValueBox
+              signal={signal}>
+              {children}
+              <StyledStatedValueLabel
+                secondaryPosition={secondaryPosition}
+                signal={signal}
+                htmlFor={id}
+              >{label}{mandatory && ' *'}</StyledStatedValueLabel>
+            </StyledStatedValueBox>
+            {description
+              && <StyledStatedValueDescription>{description}</StyledStatedValueDescription>}
+            {hasError
+              && <StyledStatedValueError>
+                <ErrorList error={error}/>
+              </StyledStatedValueError>
+            }
+          </StyledStatedValueWrapper>
+        )
+      }}
+    </FocusWithin>
   )
 }
 

--- a/packages/tocco-ui/src/StatedValue/StatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.js
@@ -34,6 +34,7 @@ const StatedValue = props => {
     id,
     label,
     mandatory,
+    immutable,
     touched
   } = props
 
@@ -49,12 +50,14 @@ const StatedValue = props => {
             ref={getRef}
             secondaryPosition={secondaryPosition}>
             <StyledStatedValueBox
+              immutable={immutable}
               signal={signal}>
               {children}
               <StyledStatedValueLabel
+                htmlFor={immutable ? '' : id}
+                immutable={immutable}
                 secondaryPosition={secondaryPosition}
                 signal={signal}
-                htmlFor={id}
               >{label}{mandatory && ' *'}</StyledStatedValueLabel>
             </StyledStatedValueBox>
             {description
@@ -106,6 +109,10 @@ StatedValue.propTypes = {
    * If true an asterisk is appended to the label.
    */
   mandatory: PropTypes.bool,
+  /**
+   * Determines if value is editable
+   */
+  immutable: PropTypes.bool,
   /**
    * If true field was in focus.
    */

--- a/packages/tocco-ui/src/StatedValue/StatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.js
@@ -1,0 +1,104 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import ErrorList from '../FormField/ErrorList'
+import {
+  StyledStatedValueBox,
+  StyledStatedValueDescription,
+  StyledStatedValueError,
+  StyledStatedValueLabel,
+  StyledStatedValueWrapper
+} from './StyledStatedValue'
+import {design} from '../utilStyles'
+
+const detectSignal = (dirty, hasError) => {
+  if (hasError) {
+    return design.condition.DANGER
+  } else if (dirty) {
+    return design.condition.WARNING
+  }
+}
+
+/**
+ * Wrap <EditableValue> and <FormattedVaule> in <StatedValue> to describe it
+ * and signal conditions.
+ */
+const StatedValue = props => {
+  const {
+    content,
+    description,
+    dirty,
+    error,
+    hasValue,
+    id,
+    label,
+    mandatory,
+    touched
+  } = props
+
+  const hasError = touched && props.error && Object.keys(props.error).length > 0
+  const signal = detectSignal(dirty, hasError)
+
+  return (
+    <StyledStatedValueWrapper hasValue={hasValue}>
+      <StyledStatedValueBox signal={signal}>
+        {content}
+        <StyledStatedValueLabel
+          hasValue={hasValue}
+          signal={signal}
+          htmlFor={id}
+        >{label}{mandatory && ' *'}</StyledStatedValueLabel>
+      </StyledStatedValueBox>
+      {description
+        && <StyledStatedValueDescription>{description}</StyledStatedValueDescription>}
+      {hasError
+        && <StyledStatedValueError>
+          <ErrorList error={error}/>
+        </StyledStatedValueError>
+      }
+    </StyledStatedValueWrapper>
+  )
+}
+
+StatedValue.propTypes = {
+  /**
+   * A component to enter or display data.
+   */
+  content: PropTypes.node,
+  /**
+   * A helper text to instruct users.
+   */
+  description: PropTypes.string,
+  /**
+   * If true field is marked as changed.
+   */
+  dirty: PropTypes.bool,
+  /**
+   * Error object.
+   */
+  error: PropTypes.objectOf(PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.node, PropTypes.string]))
+  ),
+  /**
+   * If true label is moved to uncover value.
+   */
+  hasValue: PropTypes.bool,
+  /**
+   * Focus target id by clicking on label.
+   */
+  id: PropTypes.string,
+  /**
+   * Describe editable value briefly.
+   */
+  label: PropTypes.string,
+  /**
+   * If true an asterisk is appended to the label.
+   */
+  mandatory: PropTypes.bool,
+  /**
+   * If true field was in focus.
+   */
+  touched: PropTypes.bool
+}
+
+export default StatedValue

--- a/packages/tocco-ui/src/StatedValue/StatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.js
@@ -41,7 +41,9 @@ const StatedValue = props => {
 
   return (
     <StyledStatedValueWrapper hasValue={hasValue}>
-      <StyledStatedValueBox signal={signal}>
+      <StyledStatedValueBox
+        hasValue={hasValue}
+        signal={signal}>
         {content}
         <StyledStatedValueLabel
           hasValue={hasValue}

--- a/packages/tocco-ui/src/StatedValue/StatedValue.spec.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.spec.js
@@ -10,9 +10,9 @@ import {
 } from './StyledStatedValue'
 
 describe('tocco-ui', () => {
-  describe('Button', () => {
+  describe('StatedValue', () => {
     test('should show content', () => {
-      const wrapper = mount(<StatedValue content={<input key="StatedValueContent"/>} />)
+      const wrapper = mount(<StatedValue><input key="StatedValueContent"/></StatedValue>)
       expect(wrapper.find(StyledStatedValueBox).children().children().children()).to.have.length(2)
       expect(wrapper.find('input')).to.have.length(1)
     })

--- a/packages/tocco-ui/src/StatedValue/StatedValue.spec.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.spec.js
@@ -1,4 +1,4 @@
-import {mount, shallow} from 'enzyme'
+import {mount} from 'enzyme'
 import React from 'react'
 
 import StatedValue from './StatedValue'
@@ -41,19 +41,19 @@ describe('tocco-ui', () => {
     })
 
     test('should not detect condition error if not touched', () => {
-      const wrapper = shallow(<StatedValue error={{error: ['error']}}/>)
+      const wrapper = mount(<StatedValue error={{error: ['error']}}/>)
       expect(wrapper.find(StyledStatedValueBox).prop('signal')).to.be.undefined
       expect(wrapper.find(StyledStatedValueLabel).prop('signal')).to.be.undefined
     })
 
     test('should detect condition error if touched', () => {
-      const wrapper = shallow(<StatedValue error={{error: ['error']}} touched={true}/>)
+      const wrapper = mount(<StatedValue error={{error: ['error']}} touched={true}/>)
       expect(wrapper.find(StyledStatedValueBox).prop('signal')).to.be.equal('danger')
       expect(wrapper.find(StyledStatedValueLabel).prop('signal')).to.be.equal('danger')
     })
 
     test('condition error should overrule condition dirty', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <StatedValue
           dirty={true}
           error={{error: ['error']}}
@@ -74,10 +74,10 @@ describe('tocco-ui', () => {
       expect(el.last().text()).to.be.equal('error 2')
     })
 
-    test('should pass prop hasValue', () => {
+    test('should pass prop hasValue as secondaryPosition', () => {
       const wrapper = mount(<StatedValue hasValue={true} />)
-      expect(wrapper.find(StyledStatedValueWrapper).prop('hasValue')).to.be.true
-      expect(wrapper.find(StyledStatedValueLabel).prop('hasValue')).to.be.true
+      expect(wrapper.find(StyledStatedValueWrapper).prop('secondaryPosition')).to.be.true
+      expect(wrapper.find(StyledStatedValueLabel).prop('secondaryPosition')).to.be.true
     })
 
     test('should show label', () => {

--- a/packages/tocco-ui/src/StatedValue/StatedValue.spec.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.spec.js
@@ -1,0 +1,100 @@
+import {mount, shallow} from 'enzyme'
+import React from 'react'
+
+import StatedValue from './StatedValue'
+import {
+  StyledStatedValueBox,
+  StyledStatedValueDescription,
+  StyledStatedValueLabel,
+  StyledStatedValueWrapper
+} from './StyledStatedValue'
+
+describe('tocco-ui', () => {
+  describe('Button', () => {
+    test('should show content', () => {
+      const wrapper = mount(<StatedValue content={<input key="StatedValueContent"/>} />)
+      expect(wrapper.find(StyledStatedValueBox).children().children().children()).to.have.length(2)
+      expect(wrapper.find('input')).to.have.length(1)
+    })
+
+    test('should not have content', () => {
+      const wrapper = mount(<StatedValue />)
+      expect(wrapper.find(StyledStatedValueBox).children().children().children()).to.have.length(1)
+    })
+
+    test('should show description', () => {
+      const wrapper = mount(<StatedValue description="description"/>)
+      const el = wrapper.find(StyledStatedValueDescription)
+      expect(el).to.have.length(1)
+      expect(el.text('description')).to.be.equal('description')
+    })
+
+    test('should not have description', () => {
+      const wrapper = mount(<StatedValue/>)
+      expect(wrapper.find(StyledStatedValueDescription)).to.have.length(0)
+    })
+
+    test('should detect condition dirty', () => {
+      const wrapper = mount(<StatedValue dirty={true} />)
+      expect(wrapper.find(StyledStatedValueBox).prop('signal')).to.be.equal('warning')
+      expect(wrapper.find(StyledStatedValueLabel).prop('signal')).to.be.equal('warning')
+    })
+
+    test('should not detect condition error if not touched', () => {
+      const wrapper = shallow(<StatedValue error={{error: ['error']}}/>)
+      expect(wrapper.find(StyledStatedValueBox).prop('signal')).to.be.undefined
+      expect(wrapper.find(StyledStatedValueLabel).prop('signal')).to.be.undefined
+    })
+
+    test('should detect condition error if touched', () => {
+      const wrapper = shallow(<StatedValue error={{error: ['error']}} touched={true}/>)
+      expect(wrapper.find(StyledStatedValueBox).prop('signal')).to.be.equal('danger')
+      expect(wrapper.find(StyledStatedValueLabel).prop('signal')).to.be.equal('danger')
+    })
+
+    test('condition error should overrule condition dirty', () => {
+      const wrapper = shallow(
+        <StatedValue
+          dirty={true}
+          error={{error: ['error']}}
+          touched={true}/>)
+      expect(wrapper.find(StyledStatedValueBox).prop('signal')).to.be.equal('danger')
+      expect(wrapper.find(StyledStatedValueLabel).prop('signal')).to.be.equal('danger')
+    })
+
+    test('should list errors', () => {
+      const wrapper = mount(
+        <StatedValue
+          dirty={true}
+          error={{error1: ['error 1-1', 'error 1-2'], error2: ['error 2']}}
+          touched={true}/>)
+      const el = wrapper.find('li')
+      expect(el).to.have.length(3)
+      expect(el.first().text()).to.be.equal('error 1-1')
+      expect(el.last().text()).to.be.equal('error 2')
+    })
+
+    test('should pass prop hasValue', () => {
+      const wrapper = mount(<StatedValue hasValue={true} />)
+      expect(wrapper.find(StyledStatedValueWrapper).prop('hasValue')).to.be.true
+      expect(wrapper.find(StyledStatedValueLabel).prop('hasValue')).to.be.true
+    })
+
+    test('should show label', () => {
+      const wrapper = mount(<StatedValue label="label a"/>)
+      const el = wrapper.find(StyledStatedValueLabel)
+      expect(el).to.have.length(1)
+      expect(el.text()).to.be.equal('label a')
+    })
+
+    test('should extend label if mandatory', () => {
+      const wrapper = mount(<StatedValue label="label b" mandatory={true}/>)
+      expect(wrapper.find(StyledStatedValueLabel).text()).to.be.equal('label b *')
+    })
+
+    test('should use prop id for htmlFor on label', () => {
+      const wrapper = mount(<StatedValue id="target-element" />)
+      expect(wrapper.find(StyledStatedValueLabel).prop('htmlFor')).to.be.equal('target-element')
+    })
+  })
+})

--- a/packages/tocco-ui/src/StatedValue/StatedValue.stories.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.stories.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import {storiesOf} from '@storybook/react'
+import {withKnobs, boolean, select, text} from '@storybook/addon-knobs'
+
+import StatedValue from './StatedValue'
+
+const errors = {
+  no: {},
+  mixed: {
+    error1: ['error1-1', 'error1-2'],
+    error2: ['error2']
+  }
+}
+
+const content = <input id="input" style={{width: '100%', border: 0, outline: 0}} />
+
+storiesOf('StatedValue', module)
+  .addDecorator(withKnobs)
+  .add(
+    'StatedValue',
+    () => {
+      const knobs = {
+        description: text('description', 'A helper text to instruct users.'),
+        dirty: boolean('dirty', false) || undefined,
+        error: select('error', {
+          'mixed errors': errors.mixed,
+          'no errors': errors.no
+        }, errors.mixed),
+        hasValue: boolean('hasValue', false) || undefined,
+        label: text('label', 'label'),
+        mandatory: boolean('mandatory', false) || undefined,
+        touched: boolean('touched', false) || undefined
+      }
+      return [
+        <StatedValue
+          {...knobs}
+          content={content}
+          id="input"
+          key="input-1"
+        />,
+        <StatedValue
+          {...knobs}
+          content={content}
+          id="input"
+          key="input-2"
+        />
+      ]
+    }
+  )

--- a/packages/tocco-ui/src/StatedValue/StatedValue.stories.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {storiesOf} from '@storybook/react'
 import {withKnobs, boolean, select, text} from '@storybook/addon-knobs'
 
@@ -12,7 +13,67 @@ const errors = {
   }
 }
 
-const content = <input id="input" style={{width: '100%', border: 0, outline: 0}} />
+class StatedValueWrapper extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      hasValue: props.value.length > 0 || false,
+      value: props.value
+    }
+    this.handleChange = this.handleChange.bind(this)
+  }
+
+  handleChange(event) {
+    this.setState({
+      dirty: event.target.value !== this.props.value,
+      hasValue: event.target.value.length > 0,
+      touched: true,
+      value: event.target.value
+    })
+  }
+
+  render() {
+    const {
+      id,
+      knobs
+    } = this.props
+
+    const {
+      dirty,
+      hasValue,
+      touched,
+      value
+    } = this.state
+
+    return (
+      <StatedValue
+        {...knobs}
+        dirty={dirty}
+        hasValue={hasValue}
+        id={id}
+        key={id}
+        touched={touched}>
+        <input
+          id={id}
+          onChange={this.handleChange}
+          style={{width: '100%', border: 0, outline: 0}}
+          type="text"
+          value={value}
+        />
+      </StatedValue>
+    )
+  }
+}
+
+StatedValueWrapper.defaultProps = {
+  value: ''
+}
+
+StatedValueWrapper.propTypes = {
+  id: PropTypes.string,
+  value: PropTypes.string,
+  knobs: PropTypes.object
+}
 
 storiesOf('StatedValue', module)
   .addDecorator(withKnobs)
@@ -21,28 +82,29 @@ storiesOf('StatedValue', module)
     () => {
       const knobs = {
         description: text('description', 'A helper text to instruct users.'),
-        dirty: boolean('dirty', false) || undefined,
         error: select('error', {
-          'mixed errors': errors.mixed,
-          'no errors': errors.no
-        }, errors.mixed),
-        hasValue: boolean('hasValue', false) || undefined,
+          'no errors': errors.no,
+          'mixed errors': errors.mixed
+        }),
         label: text('label', 'label'),
-        mandatory: boolean('mandatory', false) || undefined,
-        touched: boolean('touched', false) || undefined
+        mandatory: boolean('mandatory', false) || undefined
       }
       return [
-        <StatedValue
-          {...knobs}
-          content={content}
-          id="input"
+        <StatedValueWrapper
+          id="input-1"
           key="input-1"
+          knobs={knobs}
         />,
-        <StatedValue
-          {...knobs}
-          content={content}
-          id="input"
+        <StatedValueWrapper
+          id="input-2"
           key="input-2"
+          knobs={knobs}
+          value="initial value"
+        />,
+        <StatedValueWrapper
+          id="input-3"
+          key="input-3"
+          knobs={knobs}
         />
       ]
     }

--- a/packages/tocco-ui/src/StatedValue/StatedValue.stories.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.stories.js
@@ -55,8 +55,16 @@ class StatedValueWrapper extends React.Component {
         touched={touched}>
         <input
           id={id}
+          disabled={knobs.immutable}
           onChange={this.handleChange}
-          style={{width: '100%', border: 0, outline: 0}}
+          style={{
+            border: 0,
+            cursor: knobs.immutable ? 'not-allowed' : 'auto',
+            color: knobs.immutable ? '#909090' : '#000',
+            outline: 0,
+            transition: 'color 200ms',
+            width: '100%'
+          }}
           type="text"
           value={value}
         />
@@ -71,8 +79,9 @@ StatedValueWrapper.defaultProps = {
 
 StatedValueWrapper.propTypes = {
   id: PropTypes.string,
-  value: PropTypes.string,
-  knobs: PropTypes.object
+  knobs: PropTypes.object,
+  immutable: PropTypes.bool,
+  value: PropTypes.string
 }
 
 storiesOf('StatedValue', module)
@@ -87,7 +96,8 @@ storiesOf('StatedValue', module)
           'mixed errors': errors.mixed
         }),
         label: text('label', 'label'),
-        mandatory: boolean('mandatory', false) || undefined
+        mandatory: boolean('mandatory', false) || undefined,
+        immutable: boolean('immutable', false) || undefined
       }
       return [
         <StatedValueWrapper

--- a/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
@@ -22,31 +22,24 @@ const getBorderColor = ({theme, signal}) =>
     ? getTheme.color(`signal.${signal}.text`)({theme})
     : shadeColor(_get(theme, 'colors.paper'), 2)
 
-const moveLabel = () => css`
-  ${StyledStatedValueLabel}  {
+const transformLabel = ({secondaryPosition, theme}) => css`
+  &&& {
     transition: top ${ANIMATION_DURATION},
                 font-size ${ANIMATION_DURATION},
                 font-weight ${ANIMATION_DURATION};
     will-change: top, font-size, font-weight;
-  }
 
-
-  ${props => props.hasValue && css`${StyledStatedValueLabel},`}
-  &:focus-within ${StyledStatedValueLabel} {
-    top: 0%;
-    font-size: ${scale.font(-1)};
-    font-weight: ${getTheme.fontWeight('bold')};
-  }
+    ${secondaryPosition && css`
+      top: 0%;
+      font-size: ${scale.font(-1)};
+      font-weight: ${getTheme.fontWeight('bold')};
+    `}
 `
 
-const retainSpace = () => css`
+const retainSpace = ({secondaryPosition, theme}) => css`
   transition: padding-top ${ANIMATION_DURATION};
   will-change: padding-top;
-
-  ${props => props.hasValue && '&,'}
-  &:focus-within {
-    padding-top: calc(${scale.font(-1)} / 2 );
-  }
+  padding-top: ${secondaryPosition ? css`calc(${scale.font(-1)} / 2 )` : 0};
 `
 
 const StyledStatedValueLabel = styled.label`
@@ -63,6 +56,7 @@ const StyledStatedValueLabel = styled.label`
     padding: 0 ${scale.space(-2)};
     position: absolute;
     top: 50%;
+    ${props => transformLabel(props)}
   }
 `
 
@@ -73,7 +67,6 @@ const StyledStatedValueBox = styled.div`
     padding: ${scale.space(-2)} ${scale.space(-1)};
     position: relative;
     ${props => declareFocus(props)}
-    ${moveLabel()}
   }
 `
 
@@ -111,7 +104,7 @@ const StyledStatedValueWrapper = styled.div`
       margin-left: calc(${scale.space(-1)} + ${BORDER_WIDTH});
     }
 
-    ${retainSpace()}
+    ${props => retainSpace(props)}
   }
 `
 

--- a/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
@@ -4,6 +4,7 @@ import _get from 'lodash/get'
 import {
   declareFocus,
   declareFont,
+  generateDisabledShade,
   scale,
   shadeColor,
   theme as getTheme
@@ -12,22 +13,26 @@ import {
 const BORDER_WIDTH = '1px'
 const ANIMATION_DURATION = '200ms'
 
-const getTextColor = ({theme, signal}) =>
-  signal
+const getTextColor = ({immutable, theme, signal}) => {
+  const color = signal
     ? getTheme.color(`signal.${signal}.text`)({theme})
     : getTheme.color('text')({theme})
-
-const getBorderColor = ({theme, signal}) =>
-  signal
+  return immutable ? generateDisabledShade(color) : color
+}
+const getBorderColor = ({immutable, theme, signal}) => {
+  const color = signal
     ? getTheme.color(`signal.${signal}.text`)({theme})
     : shadeColor(_get(theme, 'colors.paper'), 2)
+  return immutable ? generateDisabledShade(color) : color
+}
 
 const transformLabel = ({secondaryPosition, theme}) => css`
   &&& {
-    transition: top ${ANIMATION_DURATION},
+    transition: color ${ANIMATION_DURATION},
                 font-size ${ANIMATION_DURATION},
-                font-weight ${ANIMATION_DURATION};
-    will-change: top, font-size, font-weight;
+                font-weight ${ANIMATION_DURATION},
+                top ${ANIMATION_DURATION};
+    will-change: color, font-size, font-weight, top;
 
     ${secondaryPosition && css`
       top: 0%;
@@ -35,6 +40,8 @@ const transformLabel = ({secondaryPosition, theme}) => css`
       font-weight: ${getTheme.fontWeight('bold')};
     `}
 `
+
+const declareCursor = ({immutable}) => `cursor: ${immutable ? 'not-allowed' : 'auto'};`
 
 const retainSpace = ({secondaryPosition, theme}) => css`
   transition: padding-top ${ANIMATION_DURATION};
@@ -57,6 +64,7 @@ const StyledStatedValueLabel = styled.label`
     position: absolute;
     top: 50%;
     ${props => transformLabel(props)}
+    ${props => declareCursor(props)}
   }
 `
 
@@ -67,6 +75,9 @@ const StyledStatedValueBox = styled.div`
     padding: ${scale.space(-2)} ${scale.space(-1)};
     position: relative;
     ${props => declareFocus(props)}
+    ${props => declareCursor(props)}
+    transition: border-color ${ANIMATION_DURATION};
+    will-change: border-color;
   }
 `
 

--- a/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
@@ -1,0 +1,113 @@
+import styled, {css} from 'styled-components'
+import _get from 'lodash/get'
+
+import {
+  declareFocus,
+  declareFont,
+  scale,
+  shadeColor,
+  theme as getTheme
+} from '../utilStyles'
+
+const BORDER_WIDTH = '1px'
+
+const getTextColor = ({theme, signal}) =>
+  signal
+    ? getTheme.color(`signal.${signal}.text`)({theme})
+    : getTheme.color('text')({theme})
+
+const getBorderColor = ({theme, signal}) =>
+  signal
+    ? getTheme.color(`signal.${signal}.text`)({theme})
+    : shadeColor(_get(theme, 'colors.paper'), 2)
+
+const moveLabel = () => css`
+  top: 0%;
+  font-size: ${scale.font(-1)};
+  font-weight: ${getTheme.fontWeight('bold')};
+`
+
+const retainSpace = () => css`
+  padding-top: calc(${scale.font(-1)} / 2 );
+`
+
+const StyledStatedValueLabel = styled.label`
+  &&& {
+    ${declareFont({
+    fontSize: scale.font(0),
+    fontWeight: getTheme.fontWeight('regular'),
+    lineHeight: 1
+  })}
+    background-color: ${getTheme.color('paper')};
+    color: ${props => getTextColor(props)};
+    left: ${scale.space(-2)};
+    margin-top: calc(${scale.font(-1)} / -2);
+    padding: 0 ${scale.space(-2)};
+    position: absolute;
+    top: 50%;
+    ${props => props.hasValue && moveLabel()}
+  }
+`
+
+const StyledStatedValueBox = styled.div`
+  &&& {
+    border-radius: ${getTheme.radii('regular')};
+    border: ${BORDER_WIDTH} solid ${props => getBorderColor(props)};
+    padding: ${scale.space(-2)} ${scale.space(-1)};
+    position: relative;
+    ${props => declareFocus(props)}
+
+    &:focus-within ${StyledStatedValueLabel} {
+      ${props => moveLabel()}
+    }
+  }
+`
+
+const StyledStatedValueDescription = styled.p`
+  &&& {
+    ${declareFont()}
+    font-size: ${scale.font(-1)};
+  }
+`
+
+const StyledStatedValueError = styled.div`
+  &&& {
+    li {
+      font-size: ${scale.font(-1)};
+    }
+  }
+`
+
+const StyledStatedValueWrapper = styled.div`
+  &&& {
+    margin-bottom: ${scale.space(-1)};
+
+    ${props => props.hasValue && retainSpace()}
+    &:focus-within {
+      ${retainSpace()}
+    }
+
+    ${StyledStatedValueBox},
+    ${StyledStatedValueDescription},
+    ${StyledStatedValueError} {
+      margin-bottom: ${scale.space(-2)};
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    ${StyledStatedValueDescription},
+    ${StyledStatedValueError} {
+      margin-left: calc(${scale.space(-1)} + ${BORDER_WIDTH});
+    }
+  }
+`
+
+export {
+  StyledStatedValueBox,
+  StyledStatedValueDescription,
+  StyledStatedValueError,
+  StyledStatedValueLabel,
+  StyledStatedValueWrapper
+}

--- a/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
@@ -10,6 +10,7 @@ import {
 } from '../utilStyles'
 
 const BORDER_WIDTH = '1px'
+const ANIMATION_DURATION = '200ms'
 
 const getTextColor = ({theme, signal}) =>
   signal
@@ -22,13 +23,30 @@ const getBorderColor = ({theme, signal}) =>
     : shadeColor(_get(theme, 'colors.paper'), 2)
 
 const moveLabel = () => css`
-  top: 0%;
-  font-size: ${scale.font(-1)};
-  font-weight: ${getTheme.fontWeight('bold')};
+  ${StyledStatedValueLabel}  {
+    transition: top ${ANIMATION_DURATION},
+                font-size ${ANIMATION_DURATION},
+                font-weight ${ANIMATION_DURATION};
+    will-change: top, font-size, font-weight;
+  }
+
+
+  ${props => props.hasValue && css`${StyledStatedValueLabel},`}
+  &:focus-within ${StyledStatedValueLabel} {
+    top: 0%;
+    font-size: ${scale.font(-1)};
+    font-weight: ${getTheme.fontWeight('bold')};
+  }
 `
 
 const retainSpace = () => css`
-  padding-top: calc(${scale.font(-1)} / 2 );
+  transition: padding-top ${ANIMATION_DURATION};
+  will-change: padding-top;
+
+  ${props => props.hasValue && '&,'}
+  &:focus-within {
+    padding-top: calc(${scale.font(-1)} / 2 );
+  }
 `
 
 const StyledStatedValueLabel = styled.label`
@@ -45,7 +63,6 @@ const StyledStatedValueLabel = styled.label`
     padding: 0 ${scale.space(-2)};
     position: absolute;
     top: 50%;
-    ${props => props.hasValue && moveLabel()}
   }
 `
 
@@ -56,10 +73,7 @@ const StyledStatedValueBox = styled.div`
     padding: ${scale.space(-2)} ${scale.space(-1)};
     position: relative;
     ${props => declareFocus(props)}
-
-    &:focus-within ${StyledStatedValueLabel} {
-      ${props => moveLabel()}
-    }
+    ${moveLabel()}
   }
 `
 
@@ -82,11 +96,6 @@ const StyledStatedValueWrapper = styled.div`
   &&& {
     margin-bottom: ${scale.space(-1)};
 
-    ${props => props.hasValue && retainSpace()}
-    &:focus-within {
-      ${retainSpace()}
-    }
-
     ${StyledStatedValueBox},
     ${StyledStatedValueDescription},
     ${StyledStatedValueError} {
@@ -101,6 +110,8 @@ const StyledStatedValueWrapper = styled.div`
     ${StyledStatedValueError} {
       margin-left: calc(${scale.space(-1)} + ${BORDER_WIDTH});
     }
+
+    ${retainSpace()}
   }
 `
 

--- a/packages/tocco-ui/src/StatedValue/index.js
+++ b/packages/tocco-ui/src/StatedValue/index.js
@@ -1,0 +1,17 @@
+import StatedValue from './StatedValue'
+import {
+  StyledStatedValueBox,
+  StyledStatedValueDescription,
+  StyledStatedValueError,
+  StyledStatedValueLabel,
+  StyledStatedValueWrapper
+} from './StyledStatedValue'
+
+export {
+  StatedValue as default,
+  StyledStatedValueBox,
+  StyledStatedValueDescription,
+  StyledStatedValueError,
+  StyledStatedValueLabel,
+  StyledStatedValueWrapper
+}

--- a/packages/tocco-ui/src/utilStyles/declareInteractionColors.js
+++ b/packages/tocco-ui/src/utilStyles/declareInteractionColors.js
@@ -157,8 +157,9 @@ const generateDisabledShade = color => tint(0.5, color)
 export {
   declareFocus,
   declareInteractionColors,
-  generateShades,
+  generateDisabledShade,
   generateInteractionColors,
+  generateShades,
   getBestContrast,
   shadeColor
 }

--- a/packages/tocco-ui/src/utilStyles/index.js
+++ b/packages/tocco-ui/src/utilStyles/index.js
@@ -3,8 +3,10 @@ import declareDensity from './declareDensity'
 import {
   declareFocus,
   declareInteractionColors,
+  generateDisabledShade,
   generateInteractionColors,
   generateShades,
+  getBestContrast,
   shadeColor
 } from './declareInteractionColors'
 import declareFont from './declareFont'
@@ -28,9 +30,11 @@ export {
   declareNoneWrappingText,
   declareWrappingText,
   design,
+  filterObjectByKeysStartingWith,
+  generateDisabledShade,
   generateInteractionColors,
   generateShades,
-  filterObjectByKeysStartingWith,
+  getBestContrast,
   getTextOfChildren,
   objectToCss,
   scale,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12644,6 +12644,13 @@ react-router@^4.3.1:
     prop-types "^15.6.1"
     warning "^4.0.1"
 
+react-simple-focus-within@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-simple-focus-within/-/react-simple-focus-within-1.1.4.tgz#fb0ac8e1e82e44954b72b281e8493ac43830f208"
+  integrity sha512-aM6rncaJ8W2IJ0tiLVlQDY8DstoWIxKnKP252EW7YjxnDvC81U+fa+dUTpgo/PMwyc49eyrdnZ8v1IJ2HX3w/Q==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-split-pane@^0.1.84:
   version "0.1.85"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.85.tgz#64819946a99b617ffa2d20f6f45a0056b6ee4faa"


### PR DESCRIPTION
Current implementation requires a polyfill for css pseudo selector `:focus-within` like https://github.com/jonathantneal/focus-within. Microsoft browser does not support it yet.

`:focus-within` makes code much cleaner and lighter than using a react library like https://github.com/ferdaber/react-focus-within.

Do we already other polyfills included in tocco-client? What do you think about polyfills in general?