### PR TITLE
fix(tocco-ui): do not pass unnecessary props to FontAwesomeIcon

### DIFF
--- a/packages/tocco-ui/src/Button/Button.js
+++ b/packages/tocco-ui/src/Button/Button.js
@@ -76,10 +76,7 @@ Button.propTypes = {
    * Font Awesome 5.1 icons by setting specific classname (e.g. "check").
    * https://fontawesome.com/icons?d=gallery&s=brands,regular,solid&m=free
    */
-  icon: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string)
-  ]),
+  icon: PropTypes.string,
   /**
    * Prepend icon or append icon to label. Use 'sole' if label text is omitted. Default value is 'prepend'.
    * Possible values: append|prepend|sole

--- a/packages/tocco-ui/src/Button/Button.stories.js
+++ b/packages/tocco-ui/src/Button/Button.stories.js
@@ -19,7 +19,7 @@ storiesOf('Button', module)
         icon={select('icon', {
           '-': null,
           regular: 'air-freshener',
-          brand: ['fab', 'google'],
+          brand: 'fab, google',
           times: 'times'}) || undefined
         }
         iconPosition={select('iconPosition', {

--- a/packages/tocco-ui/src/Icon/Icon.js
+++ b/packages/tocco-ui/src/Icon/Icon.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import {withTheme} from 'styled-components'
+import _omit from 'lodash/omit'
 
 import getSpacing from './StyledIcon'
 import {design} from '../utilStyles'
@@ -50,12 +51,14 @@ export class Icon extends React.Component {
   }
 
   render() {
+    const filteredProps = _omit(this.props, ['dense', 'position', 'theme'])
+
     const icon = (typeof this.props.icon === 'string' && this.props.icon.includes(','))
       ? this.props.icon.replace(/\s+/, '').split(',')
       : this.props.icon
 
     return <this.lazyFontAwesomeIcon
-      {...this.props}
+      {...filteredProps}
       icon={icon}
       style={{...this.props.style, ...(getSpacing(this.props))}}
     />


### PR DESCRIPTION
- do not pass on Button defined Icon props to FontAwesomeIcon to suppress warning
- adapt icon prop on Button story to suppress warning