### PR TITLE
fix(entity-list): align buttons vertically

### DIFF
--- a/packages/tocco-ui/src/Menu/StyledMenuButton.js
+++ b/packages/tocco-ui/src/Menu/StyledMenuButton.js
@@ -12,6 +12,7 @@ const StyledMenuButton = styled(StyledMenu)`
     display: inline-flex;
     flex-flow: row wrap;
     margin-bottom: ${props => props.look === design.look.RAISED ? `-${scale.space(-1)(props)}` : 0};
+    vertical-align: middle;
 
     > hr {
       border: none;


### PR DESCRIPTION
This change removes the 1px terrace from Button to MenuButton but is not an overall alignment fix (vertical-align is limited to siblings inside an inline element).