### PR TITLE
feat(tocco-ui): show unit in DurationEdit if not disturbing

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.js
@@ -16,7 +16,8 @@ class DurationEdit extends React.Component {
     this.hoursShadow = React.createRef()
     this.minutesShadow = React.createRef()
     this.state = {
-      ...this.millisecondsToDuration(props.value)
+      ...this.millisecondsToDuration(props.value),
+      showUnits: props.value >= 0
     }
   }
 
@@ -95,6 +96,11 @@ class DurationEdit extends React.Component {
     this.props.onChange(calculateMilliseconds(hoursValue, minutesValue))
   }
 
+  handleOnBlur = () => this.setState({showUnits:
+    (this.state.hours.toString().length >= 1 || this.state.minutes.toString().length >= 1)})
+
+  handleOnFocus = () => this.setState({showUnits: true})
+
   preventNonNumeric = event => {
     if (!(event.charCode >= 48 && event.charCode <= 57)) {
       event.preventDefault()
@@ -104,36 +110,39 @@ class DurationEdit extends React.Component {
   render() {
     return (
       <StyledEditableWrapper
+        onBlur={this.handleOnBlur}
         readOnly={this.props.readOnly}
         style={{overflowX: 'auto'}}>
         <StyledDurationEditFocusable>
           <StyledDurationEdit
-            type="number"
-            step={1}
+            disabled={this.props.readOnly}
+            min={0}
             onChange={() => {}} // Empty onChange function to prevent React internal error
-            value={this.state.hours}
+            onFocus={this.handleOnFocus}
             onInput={this.handleHourChange}
             onKeyPress={this.preventNonNumeric}
-            disabled={this.props.readOnly}
             pattern="\d+"
-            min={0}
+            step={1}
             style={{width: this.state.hoursWidth}}
+            type="number"
+            value={this.state.hours}
           />
-          <Typography.Span>{this.props.options.hoursLabel}</Typography.Span>
+          {this.state.showUnits && <Typography.Span>{this.props.options.hoursLabel}</Typography.Span>}
         </StyledDurationEditFocusable>
         <StyledDurationEditFocusable>
           <StyledDurationEdit
-            type="number"
-            step={1}
+            disabled={this.props.readOnly}
             onChange={() => {}} // Empty onChange function to prevent React internal error
-            value={this.state.minutes}
+            onFocus={this.handleOnFocus}
             onInput={this.handleMinutesChange}
             onKeyPress={this.preventNonNumeric}
-            disabled={this.props.readOnly}
             pattern="\d+"
+            step={1}
             style={{width: this.state.minutesWidth}}
+            type="number"
+            value={this.state.minutes}
           />
-          <Typography.Span>{this.props.options.minutesLabel}</Typography.Span>
+          {this.state.showUnits && <Typography.Span>{this.props.options.minutesLabel}</Typography.Span>}
         </StyledDurationEditFocusable>
         <StyledDurationEditShadow ref={this.hoursShadow}>{this.state.hours}</StyledDurationEditShadow>
         <StyledDurationEditShadow ref={this.minutesShadow}>{this.state.minutes}</StyledDurationEditShadow>

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {mount} from 'enzyme'
 
+import Typography from '../../Typography'
 import DurationEdit from './DurationEdit'
 
 const EMPTY_FUNC = () => {}
@@ -62,6 +63,26 @@ describe('tocco-ui', () => {
             <DurationEdit value={null} onChange={EMPTY_FUNC} readOnly/>
           )
           expect(wrapper.props().readOnly).to.eql(true)
+        })
+
+        test('should always show units', () => {
+          const wrapper = mount(
+            <DurationEdit value={0} onChange={EMPTY_FUNC}/>
+          )
+          expect(wrapper.find(Typography.Span)).to.have.length(2)
+          expect(wrapper.state('showUnits')).to.be.true
+        })
+
+        test('should show and hide units', () => {
+          const wrapper = mount(
+            <DurationEdit onChange={EMPTY_FUNC}/>
+          )
+          expect(wrapper.find(Typography.Span)).to.have.length(0)
+          expect(wrapper.state('showUnits')).to.be.false
+          wrapper.instance().handleOnFocus()
+          expect(wrapper.state('showUnits')).to.be.true
+          wrapper.instance().handleOnBlur()
+          expect(wrapper.state('showUnits')).to.be.false
         })
       })
     })


### PR DESCRIPTION
- Label of StatedValue covers units of DurationEdit which looks ugly and is confusing.
- Show units only if focus is on DurationEdit or if hours or minutes are set.