### PR TITLE
fix(scheduler): fix description HTML display

### DIFF
--- a/packages/scheduler/src/components/Conflict/Conflict.js
+++ b/packages/scheduler/src/components/Conflict/Conflict.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {intlShape} from 'react-intl'
+import {Typography} from 'tocco-ui'
 
 import conflicts from '../../utils/conflicts'
 
@@ -16,10 +17,10 @@ const Conflict = ({conflictStatus, intl}) => {
     ...(accepted ? {} : {color: '#8b0000'})
   }
 
-  return <span style={style}>
-    {accepted ? <span>&#10003; </span> : <span>&#10005; </span>}
+  return <Typography.Span style={style}>
+    {accepted ? <Typography.Span>&#10003; </Typography.Span> : <span>&#10005; </span>}
     {intl.formatMessage({id: textResource})}
-  </span>
+  </Typography.Span>
 }
 
 Conflict.propTypes = {

--- a/packages/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -13,7 +13,7 @@ import '!style-loader!css-loader!fullcalendar/dist/fullcalendar.css'
 import '!style-loader!css-loader!fullcalendar-scheduler/dist/scheduler.css'
 import {injectIntl, intlShape} from 'react-intl'
 import {consoleLogger} from 'tocco-util'
-import {FormattedValue} from 'tocco-ui'
+import {FormattedValue, Typography} from 'tocco-ui'
 
 import Conflict from '../Conflict'
 import NavigationFullCalendar from '../NavigationFullCalendar'
@@ -53,8 +53,8 @@ class FullCalendar extends React.Component {
       const time = event.start.twix(event.end).format({monthFormat: 'MMMM', dayFormat: 'Do'})
       const tooltipDescriptionContent = <div>
         <FormattedValue type="html" value={event.description}/>
-        <p>{time}</p>
-        <p><Conflict conflictStatus={event.conflict} intl={this.props.intl}/></p>
+        <Typography.P>{time}</Typography.P>
+        <Typography.P><Conflict conflictStatus={event.conflict} intl={this.props.intl}/></Typography.P>
       </div>
 
       const content = ReactDOMServer.renderToString(tooltipDescriptionContent)

--- a/packages/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -13,6 +13,7 @@ import '!style-loader!css-loader!fullcalendar/dist/fullcalendar.css'
 import '!style-loader!css-loader!fullcalendar-scheduler/dist/scheduler.css'
 import {injectIntl, intlShape} from 'react-intl'
 import {consoleLogger} from 'tocco-util'
+import {FormattedValue} from 'tocco-ui'
 
 import Conflict from '../Conflict'
 import NavigationFullCalendar from '../NavigationFullCalendar'
@@ -51,7 +52,7 @@ class FullCalendar extends React.Component {
     eventRender: (event, element) => {
       const time = event.start.twix(event.end).format({monthFormat: 'MMMM', dayFormat: 'Do'})
       const tooltipDescriptionContent = <div>
-        <p>{event.description}</p>
+        <FormattedValue type="html" value={event.description}/>
         <p>{time}</p>
         <p><Conflict conflictStatus={event.conflict} intl={this.props.intl}/></p>
       </div>


### PR DESCRIPTION
- An event description can contain HTML. Use FormattedValue to proper format
  otherwise HTML would be shown as string.

Changelog: Format HTML event descriptions