### PR TITLE
refactor(tocco-ui): add download query param to Upload download

### DIFF
--- a/packages/tocco-ui/src/Upload/View.js
+++ b/packages/tocco-ui/src/Upload/View.js
@@ -6,6 +6,12 @@ import ButtonLink from '../ButtonLink'
 import Preview from '../Preview'
 import StyledView from './StyledView'
 
+const addParameterToURL = (url, param, value) =>
+  `${url}${url.indexOf('?') >= 0 ? '&' : '?'}${param}=${value}`
+
+export const getDownloadUrl = binaryLink =>
+  addParameterToURL(binaryLink, 'download', true)
+
 const View = props => (
   <StyledView>
     <div>
@@ -13,7 +19,7 @@ const View = props => (
         icon="download"
         iconPosition="sole"
         download={props.value.fileName}
-        href={props.value.binaryLink}
+        href={getDownloadUrl(props.value.binaryLink)}
         tabIndex={-1}
         title={props.downloadTitle || 'download'}
       />

--- a/packages/tocco-ui/src/Upload/View.spec.js
+++ b/packages/tocco-ui/src/Upload/View.spec.js
@@ -1,0 +1,19 @@
+import {getDownloadUrl} from './View'
+
+describe('tocco-ui', () => {
+  describe('Upload', () => {
+    describe('Viev', () => {
+      describe('getDownloadUrl', () => {
+        test('should add download param to url without query params', () => {
+          const result = getDownloadUrl('https://tocco.ch/files/test.pdf')
+          expect(result).to.eql('https://tocco.ch/files/test.pdf?download=true')
+        })
+
+        test('should add download param to url with query params', () => {
+          const result = getDownloadUrl('www.tocco.ch/245df43d/test.pdf?yc=a234ms')
+          expect(result).to.eql('www.tocco.ch/245df43d/test.pdf?yc=a234ms&download=true')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- A query param was introduces in backend to set the Content-Disposition as attachment.
  This header is needed for a direct file download with a link attribute.

Changelog: Upload Component: Add download query param to file download link