### PR TITLE
fix(app-extensions): restrict global icon dom watch

### DIFF
--- a/packages/app-extensions/src/appFactory/App.js
+++ b/packages/app-extensions/src/appFactory/App.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
 import {Provider} from 'react-redux'
 import {LoadMask} from 'tocco-ui'
@@ -7,20 +7,34 @@ import {IntlProvider} from 'react-intl-redux/lib'
 import ThemeWrapper from './ThemeWrapper'
 import keyDown from '../keyDown'
 
-const App = ({store, initIntlPromise, name, content, theme}) =>
-  <ThemeWrapper appTheme={theme}>
-    <Provider store={store}>
-      <keyDown.KeyDownWatcher>
-        <LoadMask promises={[initIntlPromise]}>
-          <IntlProvider>
-            <div className={`tocco-${name}`}>
-              {content}
-            </div>
-          </IntlProvider>
-        </LoadMask>
-      </keyDown.KeyDownWatcher>
-    </Provider>
-  </ThemeWrapper>
+const App = ({store, initIntlPromise, name, content, theme}) => {
+  const wrapperCallback = useCallback(node => {
+    if (node) {
+      import(/* webpackChunkName: "fontawesome" */ '@fortawesome/fontawesome-svg-core').then(fontawesome => {
+        fontawesome.dom.watch({
+          autoReplaceSvgRoot: node,
+          observeMutationsRoot: node
+        })
+      })
+    }
+  }, [])
+
+  return (
+    <ThemeWrapper appTheme={theme}>
+      <Provider store={store}>
+        <keyDown.KeyDownWatcher>
+          <LoadMask promises={[initIntlPromise]}>
+            <IntlProvider>
+              <div className={`tocco-${name}`} ref={wrapperCallback}>
+                {content}
+              </div>
+            </IntlProvider>
+          </LoadMask>
+        </keyDown.KeyDownWatcher>
+      </Provider>
+    </ThemeWrapper>
+  )
+}
 
 App.propTypes = {
   store: PropTypes.object.isRequired,

--- a/packages/app-extensions/src/appFactory/appFactory.js
+++ b/packages/app-extensions/src/appFactory/appFactory.js
@@ -33,10 +33,6 @@ export const createApp = (name,
 
     const initIntlPromise = setupIntl(input, store, name, textResourceModules)
 
-    import(/* webpackChunkName: "fontawesome" */ '@fortawesome/fontawesome-svg-core').then(fontawesome => {
-      fontawesome.dom.watch()
-    })
-
     return {
       component: <App store={store} initIntlPromise={initIntlPromise} name={name} content={content} theme={theme} />,
       store,


### PR DESCRIPTION
- without the watch config, the whole dom (body) will be watched.
  This leads to problems when an app in embedded into nice2 since nice
  also uses fontawesome.

Refs: TOCDEV-1083
Changelog: Restrict global icon dom watch