### PR TITLE
refactor(entity-list): replace parent search field

### DIFF
--- a/packages/entity-list/src/modules/searchForm/sagas.spec.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.spec.js
@@ -83,13 +83,14 @@ describe('entity-list', () => {
             () => {
               const FORM_ID = 'searchForm'
               const parent = {key: '22', reverseRelationName: 'relWhatever'}
-              const expectedValues = {relWhatever: {key: '22'}}
+              const expectedValues = {relWhatever: {key: '22', display: 'Test User'}}
 
               return expectSaga(sagas.setInitialFormValues, false, null)
                 .provide([
                   [select(sagas.inputSelector), {parent}],
                   [matchers.call.fn(sagas.getListFormDefinition), null],
-                  [matchers.call.fn(getEndpoint), null]
+                  [matchers.call.fn(getEndpoint), null],
+                  [matchers.call.fn(rest.fetchDisplay), 'Test User']
                 ])
                 .put(formActions.initialize(FORM_ID, expectedValues))
                 .run()
@@ -188,7 +189,8 @@ describe('entity-list', () => {
             return expectSaga(sagas.loadSearchForm)
               .provide([
                 [matchers.call.fn(rest.fetchForm), formDefinition],
-                [select(sagas.entityListSelector), {searchFormType: 'basic'}]
+                [select(sagas.entityListSelector), {searchFormType: 'basic'}],
+                [select(sagas.inputSelector), {}]
               ])
               .put(actions.setFormDefinition(formDefinition))
               .returns(formDefinition)

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -60,3 +60,29 @@ const searchChildren = node => {
     }), {})
   }
 }
+
+/**
+ * If the search form contains a field pointing to the parent entity this must not be a full-text
+ * search field and should be readonly. This function will search for the correct field and replace its
+ * type and change the readonly attribute.
+ */
+export const changeParentFieldType = (formElement, parentPath) => {
+  if (formElement.componentType === 'field-set') {
+    const containsParentField = formElement.children.some(child => child.path === parentPath)
+
+    return {
+      ...formElement,
+      ...(containsParentField && {readonly: true}),
+      children: formElement.children.map(child =>
+        child.path === parentPath
+          ? {...child, dataType: 'single-select-box'}
+          : child)
+    }
+  }
+  if (formElement.children) {
+    return {
+      ...formElement,
+      children: formElement.children.map(child => changeParentFieldType(child, parentPath))
+    }
+  }
+}

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -85,4 +85,6 @@ export const changeParentFieldType = (formElement, parentPath) => {
       children: formElement.children.map(child => changeParentFieldType(child, parentPath))
     }
   }
+
+  return formElement
 }

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -258,6 +258,15 @@ describe('entity-list', () => {
             expect(result).to.eql(expectedResult)
           })
         })
+
+        describe('changeParentFieldType', () => {
+          test('should ', () => {
+            const result = forms.changeParentFieldType(mockData.data.dummyEntitySearchForm.form, 'relUser')
+
+            const flatten = forms.getFormFieldFlat(result)
+            expect(flatten.relUser).to.eql('single-select-box')
+          })
+        })
       })
     })
   })

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -260,11 +260,44 @@ describe('entity-list', () => {
         })
 
         describe('changeParentFieldType', () => {
-          test('should ', () => {
+          test('should change the type of a parent field to single-select-box', () => {
             const result = forms.changeParentFieldType(mockData.data.dummyEntitySearchForm.form, 'relUser')
-
             const flatten = forms.getFormFieldFlat(result)
             expect(flatten.relUser).to.eql('single-select-box')
+          })
+
+          test('should not change the type of any other field or the form structure', () => {
+            const form = mockData.data.dummyEntitySearchForm.form
+            const result = forms.changeParentFieldType(form, 'relUser')
+
+            expect(result.children[0].children[0]).to.eql(form.children[0].children[0])
+
+            const flatten = forms.getFormFieldFlat(result)
+            expect(flatten.txtFulltext).to.eql('fulltext-search')
+            expect(flatten.label).to.eql('string')
+            expect(flatten.active).to.eql('boolean')
+          })
+
+          test('should not break if children property is not defined', () => {
+            const form = {
+              id: 'User_detail_relDummySubGrid_search',
+              label: null,
+              children: [
+                {
+                  id: 'box1',
+                  componentType: 'layout',
+                  layoutType: 'vertical-box',
+                  hidden: false,
+                  label: null,
+                  useLabel: 'NO'
+                }
+              ],
+              componentType: 'form',
+              modelName: 'Dummy_entity'
+            }
+
+            const result = forms.changeParentFieldType(form, 'relUser')
+            expect(result).to.deep.eql(form)
           })
         })
       })

--- a/packages/tocco-util/src/mockData/data/dummy_entity_search_form.json
+++ b/packages/tocco-util/src/mockData/data/dummy_entity_search_form.json
@@ -30,6 +30,25 @@
             ]
           },
           {
+            "id": "relUser",
+            "label": "Person",
+            "componentType": "field-set",
+            "children": [
+              {
+                "id": "relUser",
+                "label": null,
+                "componentType": "fulltext-search",
+                "path": "relUser",
+                "dataType": "fulltext-search",
+                "defaultValue": null,
+                "minChars": null
+              }
+            ],
+            "readonly": false,
+            "hidden": false,
+            "scopes": []
+          },
+          {
             "componentType": "field-set",
             "id": "label",
             "label": "Bezeichnung",
@@ -64,6 +83,7 @@
         "useLabel": "NO"
       }
     ],
-    "model": "Dummy_entity"
+    "componentType": "form",
+    "modelName": "Dummy_entity"
   }
 }


### PR DESCRIPTION
- if a search form has a parent condition and a search-field with the same
  path, this field must not be a full-text search field. And it should be
  read only. This change makes sure such fields are replaced with a readonly
  single-select field.

Refs: TOCDEV-1084
Changelog: Fix parent Search field bug