### PR TITLE
feat(app-extension): add handler for legacy actions (ExtJs)

### DIFF
--- a/packages/app-extensions/src/actions/actionTypes.js
+++ b/packages/app-extensions/src/actions/actionTypes.js
@@ -2,5 +2,6 @@ export default Object.freeze({
   CUSTOM: 'custom',
   SIMPLE: 'simple',
   REPORT: 'report',
-  DIVIDER: 'divider'
+  DIVIDER: 'divider',
+  LEGACY: 'legacy'
 })

--- a/packages/app-extensions/src/actions/modules/actionHandlers/index.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/index.js
@@ -2,9 +2,11 @@ import actionTypes from '../../actionTypes'
 import handleSimpleAction from './simpleAction'
 import handleReportAction from './report'
 import handleCustomAction from './customAction'
+import handleLegacyAction from './legacyAction'
 
 export default {
   [actionTypes.SIMPLE]: handleSimpleAction,
   [actionTypes.REPORT]: handleReportAction,
-  [actionTypes.CUSTOM]: handleCustomAction
+  [actionTypes.CUSTOM]: handleCustomAction,
+  [actionTypes.LEGACY]: handleLegacyAction
 }

--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -1,0 +1,73 @@
+import {call} from 'redux-saga/effects'
+
+export const loadScript = src => new Promise((resolve, reject) => {
+  const s = document.createElement('script')
+  s.src = src
+  s.onload = resolve
+  s.onerror = reject
+  document.head.appendChild(s)
+})
+
+export const loadCss = src => new Promise((resolve, reject) => {
+  const head = document.getElementsByTagName('head')[0]
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.type = 'text/css'
+  link.href = src
+  link.media = 'all'
+  link.onload = resolve
+  link.onerror = reject
+  head.appendChild(link)
+})
+
+export function* loadSequentially(sources) {
+  for (const source of sources) {
+    yield call(source.handler, source.src)
+  }
+}
+
+export const sources = [
+  {src: '/nice2/javascript/lang.release.js', handler: loadScript},
+  {src: '/nice2/javascript/nice2-ext-newclient-actions.debug.js', handler: loadScript},
+  {src: '/nice2/javascript/nice2-admin.debug.js', handler: loadScript},
+  {src: '/nice2/javascript/nice2-newclient-actions-setup.debug.js', handler: loadScript},
+  {src: '/nice2/dwr-all.js', handler: loadScript},
+  {src: '/css/themes/blue-medium.css', handler: loadCss},
+  {src: '/css/nice2-admin.css', handler: loadCss}
+]
+
+export function* initLegacyActionsEnv() {
+  if (window.legacyActionsEnvInitialized !== true) {
+    yield call(loadSequentially, sources)
+    yield call(window.setUpLegacyActionsEnv)
+  }
+}
+
+export default function* (definition, selection, parent, params, config) {
+  yield call(initLegacyActionsEnv)
+
+  const actionDefinition = new window.nice2.netui.actions.model.ClientActionDefinition(definition.id, definition.id)
+  actionDefinition.setEnabled(!definition.readOnly)
+
+  const entityExplorer = new window.nice2.modules.NewClientLegacyActionsModule({
+    entityName: selection.entityName,
+    formName: selection.entityName
+  })
+  entityExplorer.init()
+
+  const ctx = new window.nice2.modules.entityexplorer.EntityExplorerActionContext(entityExplorer, null)
+
+  const situation = {
+    entityName: selection.entityName
+  }
+
+  const action = window.NetuiActionRegistry.newActionFromDefinition(actionDefinition, situation, ctx)
+
+  action.getSelectionNumber = () => selection.ids.length
+  action.getSelection = () => ({
+    entityName: selection.entityName,
+    selectedEntities: selection.ids
+  })
+
+  action.perform()
+}

--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
@@ -1,0 +1,50 @@
+import {testSaga} from 'redux-saga-test-plan'
+
+import {initLegacyActionsEnv, loadSequentially, sources, loadScript, loadCss} from './legacyAction'
+
+describe('app-extensions', () => {
+  describe('actions', () => {
+    describe('modules', () => {
+      describe('actionHandler', () => {
+        describe('legacyAction', () => {
+          describe('initLegacyActionsEnv', () => {
+            test('should init if not initialized', () => {
+              window.legacyActionsEnvInitialized = undefined
+              window.setUpLegacyActionsEnv = () => {}
+
+              testSaga(initLegacyActionsEnv)
+                .next()
+                .call(loadSequentially, sources)
+                .next()
+                .call(window.setUpLegacyActionsEnv)
+                .next()
+                .isDone()
+            })
+
+            test('should not init if already initialized', () => {
+              window.legacyActionsEnvInitialized = true
+
+              testSaga(initLegacyActionsEnv)
+                .next()
+                .isDone()
+            })
+          })
+
+          describe('loadSequentially', () => {
+            test('should load the required sources sequentially', () => {
+              testSaga(loadSequentially, sources).next()
+                .call(loadScript, '/nice2/javascript/lang.release.js').next()
+                .call(loadScript, '/nice2/javascript/nice2-ext-newclient-actions.debug.js').next()
+                .call(loadScript, '/nice2/javascript/nice2-admin.debug.js').next()
+                .call(loadScript, '/nice2/javascript/nice2-newclient-actions-setup.debug.js').next()
+                .call(loadScript, '/nice2/dwr-all.js').next()
+                .call(loadCss, '/css/themes/blue-medium.css').next()
+                .call(loadCss, '/css/nice2-admin.css').next()
+                .isDone()
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- The first time a legacy action handler is executed, the required
  ExtJS and legacy-client sources are loaded
- There's are still some things to do. For instance, there are several
  types of record selections that must be supported eventually (e.g.
  actual selection of some particular records by key or a set of entities
  defined by query conditions only). At the moment, only actual selection
  by entity key is implemented.

Refs: TOCDEV-1507