### PR TITLE
refactor(entity-list): only set fallback sorting if field exists

### DIFF
--- a/packages/entity-list/src/components/Table/Table.js
+++ b/packages/entity-list/src/components/Table/Table.js
@@ -104,8 +104,7 @@ const Table = props => {
 
   return (
     <StyledTable>
-      {props.sorting
-      && <BootstrapTable
+      <BootstrapTable
         remote
         data={props.inProgress ? [] : props.entities}
         pagination={showPagination}
@@ -133,7 +132,6 @@ const Table = props => {
           })
         }
       </BootstrapTable>
-      }
     </StyledTable>
   )
 }

--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -47,6 +47,7 @@ export function* initialize() {
       call(loadEntityModel, entityName, entityModel),
       call(loadFormDefinition, formDefinition, formName)
     ])
+    yield call(setSorting)
     yield call(loadData, 1)
   } else {
     yield call(loadData)
@@ -238,12 +239,16 @@ export function* displayEntity(page) {
   yield put(actions.setEntities(entities))
 }
 
-export const FALLBACK_SORTING = [{field: 'update_timestamp', order: 'desc'}]
-export function* setSorting(formDefinition) {
+export const FALLBACK_SORTING_FIELD = 'update_timestamp'
+export function* setSorting() {
+  const {formDefinition, entityModel} = yield select(listSelector)
   const tableSorting = yield call(getSorting, formDefinition)
-  const sorting = tableSorting.length > 0 ? tableSorting : FALLBACK_SORTING
 
-  yield put(actions.setSorting(sorting))
+  if (tableSorting.length > 0) {
+    yield put(actions.setSorting(tableSorting))
+  } else if (entityModel.paths[FALLBACK_SORTING_FIELD]) {
+    yield put(actions.setSorting([{field: FALLBACK_SORTING_FIELD, order: 'desc'}]))
+  }
 }
 
 export function* loadFormDefinition(formDefinition, formName) {
@@ -252,7 +257,6 @@ export function* loadFormDefinition(formDefinition, formName) {
     yield put(actions.setFormDefinition(formDefinition))
   }
 
-  yield call(setSorting, formDefinition)
   const selectable = yield call(getSelectable, formDefinition)
   yield put(actions.setFormSelectable(selectable))
   const endpoint = yield call(getEndpoint, formDefinition)

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -64,6 +64,7 @@ describe('entity-list', () => {
               call(sagas.loadFormDefinition, formDefinition, formName)
             ]))
 
+            expect(gen.next().value).to.eql(call(sagas.setSorting))
             expect(gen.next().value).to.eql(call(sagas.loadData, 1))
             expect(gen.next().value).to.eql(call(sagas.queryChanged))
             expect(gen.next().value).to.eql(put(actions.setInProgress(false)))
@@ -195,11 +196,19 @@ describe('entity-list', () => {
         })
 
         describe('setSorting saga', () => {
+          const entityModel = {
+            paths: {
+              update_timestamp: {}
+            }
+          }
+
+          const formDefinition = {}
           test('should extract sorting of form', () => {
             const sorting = [{field: 'firstname', order: 'asc'}]
             return expectSaga(sagas.setSorting)
               .provide([
-                [matchers.call.fn(getSorting), sorting]
+                [matchers.call.fn(getSorting), sorting],
+                [select(sagas.listSelector), {entityModel, formDefinition}]
               ])
               .put(actions.setSorting(sorting))
               .run()
@@ -208,9 +217,20 @@ describe('entity-list', () => {
           test('should set fallback if not defined in form', () => {
             return expectSaga(sagas.setSorting)
               .provide([
-                [matchers.call.fn(getSorting), []]
+                [matchers.call.fn(getSorting), []],
+                [select(sagas.listSelector), {entityModel, formDefinition}]
               ])
-              .put(actions.setSorting(sagas.FALLBACK_SORTING))
+              .put(actions.setSorting([{field: sagas.FALLBACK_SORTING_FIELD, order: 'desc'}]))
+              .run()
+          })
+
+          test('should not set sorting if fallback does not exist in model', () => {
+            return expectSaga(sagas.setSorting)
+              .provide([
+                [matchers.call.fn(getSorting), []],
+                [select(sagas.listSelector), {entityModel: {paths: {}}, formDefinition}]
+              ])
+              .not.put.like({action: {type: 'list/SET_SORTING'}})
               .run()
           })
         })
@@ -342,14 +362,12 @@ describe('entity-list', () => {
             return expectSaga(sagas.loadFormDefinition, formDefinition, formName)
               .provide([
                 [matchers.call.fn(rest.fetchForm), loadedFormDefinition],
-                [matchers.call.fn(sagas.setSorting)],
                 [matchers.call.fn(getSelectable), selectable],
                 [matchers.call.fn(getEndpoint), endpoint],
                 [matchers.call.fn(getConstriction), constriction]
               ])
               .call(rest.fetchForm, formName, 'list')
               .put(actions.setFormDefinition(loadedFormDefinition))
-              .call(sagas.setSorting, loadedFormDefinition)
               .put(actions.setFormSelectable(selectable))
               .put(actions.setEndpoint(endpoint))
               .put(actions.setConstriction(constriction))


### PR DESCRIPTION
Refs: TOCDEV-1650
Changelog: Fix fallback sorting bug