### PR TITLE
style(app-extension): Include dedicated stylesheet for legacy actions

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -37,7 +37,8 @@ export const sources = [
   {src: '/nice2/javascript/nice2-newclient-actions-setup.debug.js', handler: loadScript},
   {src: '/nice2/dwr-all.js', handler: loadScript},
   {src: '/css/themes/blue-medium.css', handler: loadCss},
-  {src: '/css/nice2-admin.css', handler: loadCss}
+  {src: '/css/nice2-admin.css', handler: loadCss},
+  {src: '/css/nice2-new-client-legacy-actions.css', handler: loadCss}
 ]
 
 export const entityEventCallback = remoteEventsChannel => event => {

--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
@@ -46,6 +46,7 @@ describe('app-extensions', () => {
                 .call(legacyAction.loadScript, '/nice2/dwr-all.js').next()
                 .call(legacyAction.loadCss, '/css/themes/blue-medium.css').next()
                 .call(legacyAction.loadCss, '/css/nice2-admin.css').next()
+                .call(legacyAction.loadCss, '/css/nice2-new-client-legacy-actions.css').next()
                 .isDone()
             })
           })


### PR DESCRIPTION
- Stylesheet is loaded from legacy code base
- The stylesheet will contain all CSS rules that are necessary to
  make legacy actions look good in the new client
- The stylesheet won't be included in the legacy client

Refs: TOCDEV-1581