### PR TITLE
style(tocco-ui): Take `breakWords` into account in HtmlFormatter

### DIFF
--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/HtmlFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/HtmlFormatter.js
@@ -40,11 +40,12 @@ const StyledHtmlFormatter = styled(StyledSpan)`
 `
 
 const HtmlFormatter = props => {
-  return <StyledHtmlFormatter dangerouslySetInnerHTML={{__html: props.value}}/>
+  return <StyledHtmlFormatter dangerouslySetInnerHTML={{__html: props.value}} breakWords={props.breakWords}/>
 }
 
 HtmlFormatter.propTypes = {
-  value: PropTypes.string.isRequired
+  value: PropTypes.string.isRequired,
+  breakWords: PropTypes.bool
 }
 
 export {


### PR DESCRIPTION
- Necessary so that notifications with HTML content are formatted
  properly. Without the `breakWords` property (which is true for the
  notifications) passed to the `StyledHtmlFormatter`, the notification
  content is truncated after a few words, which makes many notifications
  more or less useless.
- The other type formatters respect the `breakWords` prop, too.
  Was it ignored in the HtmlFormatter on purpose?

Refs: TOCDEV-1698