### PR TITLE
fix(admin): fix "legacy actions" that are implemented in React

### DIFF
--- a/packages/admin/src/main.js
+++ b/packages/admin/src/main.js
@@ -1,4 +1,5 @@
 import React, {Suspense} from 'react'
+import ReactDOM from 'react-dom'
 import {reducer as reducerUtil} from 'tocco-util'
 import {
   appFactory,
@@ -26,6 +27,8 @@ const LazyAdmin = () => (
 )
 
 const initApp = (id, input, events, publicPath) => {
+  window.reactRegistry.setReact(React, ReactDOM)
+
   const content = <LazyAdmin/>
 
   const store = appFactory.createStore(reducers, sagas, input, packageName)

--- a/server/index.html
+++ b/server/index.html
@@ -10,6 +10,7 @@
   <script src="/static/node_modules/intl/locale-data/jsonp/de-CH.js"></script>
   <script src="/static/node_modules/intl/locale-data/jsonp/de-DE.js"></script>
   <script src="/static/node_modules/intl/locale-data/jsonp/en.js"></script>
+  <script src="/nice2/javascript/nice2-newclient-react-registry.release.js"></script>
   <style>
     html, body {
       font-size: 10px;


### PR DESCRIPTION
- Those actions are run via the ReactContainer and the `reactRegistry`
  which is available on the global scope now (thanks to the new import
  of nice2-newclient-react-registry.release.js)
- The reactRegistry needs a React and ReactDOM instance to render the
  registered apps. Those are usually found on the global window scope,
  but not if the admin is run locally -> in this case they're imported
  via ES6 imports. The reactRegistry now has a setter for the React
  and ReactDOM instance to use (default is `window.React` resp.
  `window.ReactDOM`).
- Note that in the production environment (i.e. on master.tocco.ch/beta)
  those actions already worked because the React libraries and the
  reactRegistry are included via the nice2-react.release.js file in the
  beta/index.html)
- This commit depends on: https://git.tocco.ch/c/nice2/+/36805

Refs: TOCDEV-1886