### PR TITLE
refactor(app-extension): load targetEntity from form-model

### DIFF
--- a/packages/app-extensions/src/field/editableTypeConfigs/remote.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/remote.js
@@ -9,28 +9,28 @@ const settings = {
 export default {
   dataContainerProps: ({formField, modelField}) => ({
     relationEntities: formField.id,
-    tooltips: modelField.targetEntity,
+    tooltips: formField.targetEntity,
     linkFactory: true
   }),
   getOptions: ({formField, modelField, formName, formData}) => ({
     options: _get(formData, ['relationEntities', formField.id, 'data'], []),
     moreOptionsAvailable: _get(formData, ['relationEntities', formField.id, 'moreEntitiesAvailable'], false),
     isLoading: _get(formData, ['relationEntities', formField.id, 'isLoading'], false),
-    fetchOptions: () => formData.loadRelationEntities(formField.id, modelField.targetEntity, {
+    fetchOptions: () => formData.loadRelationEntities(formField.id, formField.targetEntity, {
       forceReload: true,
       limit: settings.SUGGESTION_LIMIT,
       sorting: [{field: settings.SUGGESTION_ORDER_FIELD, order: 'desc'}],
       formBase: formField.formBase
     }),
-    searchOptions: searchTerm => formData.loadRelationEntities(formField.id, modelField.targetEntity, {
+    searchOptions: searchTerm => formData.loadRelationEntities(formField.id, formField.targetEntity, {
       searchTerm,
       limit: settings.SEARCH_RESULT_LIMIT,
       forceReload: true,
       formBase: formField.formBase
     }),
     openAdvancedSearch: value => formData.openAdvancedSearch(formName, formField, modelField, value),
-    tooltips: _get(formData.tooltips, modelField.targetEntity, null),
-    loadTooltip: id => formData.loadTooltip(modelField.targetEntity, id),
+    tooltips: _get(formData.tooltips, formField.targetEntity, null),
+    loadTooltip: id => formData.loadTooltip(formField.targetEntity, id),
     noResultsText: formData.intl.formatMessage(
       {id: 'client.component.remoteselect.noResultsText'}
     ),
@@ -38,7 +38,7 @@ export default {
       {id: 'client.component.remoteselect.moreOptionsAvailableText'}
     ),
     valueLinkFactory: formData.linkFactory && formData.linkFactory.detail
-      ? (key, content) => formData.linkFactory.detail(modelField.targetEntity, modelField.relationName, key, content)
+      ? (key, content) => formData.linkFactory.detail(formField.targetEntity, modelField.relationName, key, content)
       : null
   })
 

--- a/packages/app-extensions/src/field/editableTypeConfigs/select.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/select.js
@@ -5,17 +5,17 @@ const settings = {
 }
 
 export default {
-  dataContainerProps: ({formField, modelField}) => ({
+  dataContainerProps: ({formField}) => ({
     relationEntities: formField.id,
-    tooltips: modelField.targetEntity
+    tooltips: formField.targetEntity
   }),
   getOptions: ({formField, modelField, formData}) => ({
     options: _get(formData, ['relationEntities', formField.id, 'data'], []),
     isLoading: _get(formData, ['relationEntities', formField.id, 'isLoading'], false),
-    tooltips: _get(formData.tooltips, modelField.targetEntity, null),
+    tooltips: _get(formData.tooltips, formField.targetEntity, null),
     loadTooltip: id => formData.loadTooltip(modelField.targetEntity, id),
     noResultsText: formData.intl.formatMessage({id: 'client.component.remoteselect.noResultsText'}),
-    fetchOptions: () => formData.loadRelationEntities(formField.id, modelField.targetEntity, {
+    fetchOptions: () => formData.loadRelationEntities(formField.id, formField.targetEntity, {
       forceReload: false,
       limit: settings.LIMIT
     })

--- a/packages/app-extensions/src/field/formattedTypeConfigs/remote.js
+++ b/packages/app-extensions/src/field/formattedTypeConfigs/remote.js
@@ -1,8 +1,8 @@
 
 export default {
-  getOptions: ({modelField, formData}) => ({
+  getOptions: ({modelField, formField, formData}) => ({
     linkFactory: formData.linkFactory && formData.linkFactory.detail
-      ? (key, content) => formData.linkFactory.detail(modelField.targetEntity, modelField.relationName, key, content)
+      ? (key, content) => formData.linkFactory.detail(formField.targetEntity, modelField.relationName, key, content)
       : null
   })
 

--- a/packages/app-extensions/src/field/formattedValueFactory.js
+++ b/packages/app-extensions/src/field/formattedValueFactory.js
@@ -3,13 +3,13 @@ import {FormattedValue} from 'tocco-ui'
 
 import formattedTypeConfigs from './formattedTypeConfigs'
 
-const getOptions = (type, modelField, formData) => {
-  return formattedTypeConfigs[type] && formattedTypeConfigs[type].getOptions
-    ? formattedTypeConfigs[type].getOptions({modelField, formData})
+const getOptions = (formField, modelField, formData) => {
+  return formattedTypeConfigs[formField.dataType] && formattedTypeConfigs[formField.dataType].getOptions
+    ? formattedTypeConfigs[formField.dataType].getOptions({modelField, formField, formData})
     : {}
 }
 
 export default type => ({modelField, formField, value, formData, key, breakWords}) => {
-  const options = getOptions(formField.dataType, modelField, formData)
+  const options = getOptions(formField, modelField, formData)
   return <FormattedValue key={key} type={type} value={value} options={options} breakWords={breakWords}/>
 }


### PR DESCRIPTION
Refs: TOCDEV-1816
Changelog: Support multi-path select and remote fields