### PR TITLE
fix(admin): only call `setReact` if reactRegistry and function exist

### DIFF
--- a/packages/admin/src/main.js
+++ b/packages/admin/src/main.js
@@ -27,7 +27,9 @@ const LazyAdmin = () => (
 )
 
 const initApp = (id, input, events, publicPath) => {
-  window.reactRegistry.setReact(React, ReactDOM)
+  if (window.reactRegistry && window.reactRegistry.setReact) {
+    window.reactRegistry.setReact(React, ReactDOM)
+  }
 
   const content = <LazyAdmin/>
 


### PR DESCRIPTION
Quickfix for the storybook. To fix everything properly, the reactRegistry
should be made available on the global scope in the storybook.

Refs: TOCDEV-1886