### PR TITLE
feat(user-qr-action): add action that displays QR code of a user

### DIFF
--- a/packages/user-qr-action/.npmignore
+++ b/packages/user-qr-action/.npmignore
@@ -1,0 +1,5 @@
+src
+node_modules
+tests
+coverage
+.eslintrc

--- a/packages/user-qr-action/.yarnrc
+++ b/packages/user-qr-action/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "chore: publish\n\n- tocco-user-qr-action@%s"
+version-tag-prefix tocco-user-qr-action@

--- a/packages/user-qr-action/README.md
+++ b/packages/user-qr-action/README.md
@@ -1,0 +1,18 @@
+# User Qr Action
+
+Action that displays QR code for a User.
+
+##Embedding
+
+React-registry name: `user-qr-action`
+
+### Inputs
+
+| Name                            | Mandatory   | Description                                                                                                                                                                                               | Type     | Default-Value              |
+|-------------------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| -------- | ---------------------------|
+| `selection`                     | *           | Selection of Users (only type `ID` supported and requires exactly one key)                                                                                                                                | Object   |                            |
+
+
+### Events
+
+None so far.

--- a/packages/user-qr-action/package.json
+++ b/packages/user-qr-action/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tocco-user-qr-action",
+  "version": "0.1.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "compile:prod": "cd ../../ && npm run compile:prod -- --package=user-qr-action",
+    "prepublish": "npm run compile:prod"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "tocco-app-extensions": ">0.1.0",
+    "tocco-test-util": ">0.1.0",
+    "tocco-theme": ">0.1.0",
+    "tocco-ui": ">0.1.0",
+    "tocco-util": ">0.1.0"
+  }
+}

--- a/packages/user-qr-action/src/components/UserQrCode/UserQrCode.js
+++ b/packages/user-qr-action/src/components/UserQrCode/UserQrCode.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {QRCode, LoadingSpinner, Typography} from 'tocco-ui'
+import styled from 'styled-components'
+import {FormattedMessage} from 'react-intl'
+
+import {buildUserMecardString} from '../../utils/qrCodeUtils'
+
+const StyledContainer = styled.div`
+  width: 148px;
+  height: 148px;
+  position: relative;
+`
+
+const StyledContent = styled.div`
+  margin: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`
+
+class UserQrCode extends React.Component {
+  componentDidMount() {
+    this.props.fetchData()
+  }
+
+  render() {
+    const {data} = this.props
+
+    let content
+
+    if (data === undefined) {
+      content = <LoadingSpinner/>
+    } else if (data === null) {
+      content = (
+        <Typography.P>
+          <FormattedMessage id="client.user-qr-action.fetchFailed"/>
+        </Typography.P>
+      )
+    } else {
+      const string = buildUserMecardString(this.props.data)
+      content = <QRCode value={string}/>
+    }
+
+    return (
+      <StyledContainer>
+        <StyledContent>
+          {content}
+        </StyledContent>
+      </StyledContainer>
+    )
+  }
+}
+
+UserQrCode.propTypes = {
+  data: PropTypes.shape({
+    firstname: PropTypes.string.isRequired,
+    lastname: PropTypes.string.isRequired,
+    c_address: PropTypes.string,
+    phone_mobile: PropTypes.string,
+    phone_company: PropTypes.string,
+    phone_private: PropTypes.string,
+    email: PropTypes.string,
+    email_alternative: PropTypes.string,
+    birthdate: PropTypes.string
+  }),
+  fetchData: PropTypes.func.isRequired
+}
+
+export default UserQrCode

--- a/packages/user-qr-action/src/components/UserQrCode/UserQrCode.js
+++ b/packages/user-qr-action/src/components/UserQrCode/UserQrCode.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {QRCode, LoadingSpinner, Typography} from 'tocco-ui'
 import styled from 'styled-components'
@@ -20,37 +20,31 @@ const StyledContent = styled.div`
   transform: translate(-50%, -50%);
 `
 
-class UserQrCode extends React.Component {
-  componentDidMount() {
-    this.props.fetchData()
-  }
+const UserQrCode = ({data, fetchData}) => {
+  useEffect(() => { fetchData() }, [])
 
-  render() {
-    const {data} = this.props
+  let content
 
-    let content
-
-    if (data === undefined) {
-      content = <LoadingSpinner/>
-    } else if (data === null) {
-      content = (
-        <Typography.P>
-          <FormattedMessage id="client.user-qr-action.fetchFailed"/>
-        </Typography.P>
-      )
-    } else {
-      const string = buildUserMecardString(this.props.data)
-      content = <QRCode value={string}/>
-    }
-
-    return (
-      <StyledContainer>
-        <StyledContent>
-          {content}
-        </StyledContent>
-      </StyledContainer>
+  if (data === undefined) {
+    content = <LoadingSpinner/>
+  } else if (data === null) {
+    content = (
+      <Typography.P>
+        <FormattedMessage id="client.user-qr-action.fetchFailed"/>
+      </Typography.P>
     )
+  } else {
+    const string = buildUserMecardString(data)
+    content = <QRCode value={string}/>
   }
+
+  return (
+    <StyledContainer>
+      <StyledContent>
+        {content}
+      </StyledContent>
+    </StyledContainer>
+  )
 }
 
 UserQrCode.propTypes = {

--- a/packages/user-qr-action/src/components/UserQrCode/index.js
+++ b/packages/user-qr-action/src/components/UserQrCode/index.js
@@ -1,0 +1,3 @@
+import UserQrCode from './UserQrCode'
+
+export default UserQrCode

--- a/packages/user-qr-action/src/containers/UserQrCodeContainer.js
+++ b/packages/user-qr-action/src/containers/UserQrCodeContainer.js
@@ -1,0 +1,15 @@
+import {connect} from 'react-redux'
+import {hot} from 'react-hot-loader/root'
+
+import UserQrCode from '../components/UserQrCode'
+import {fetchData} from '../modules/qrCode'
+
+const mapActionCreators = {
+  fetchData
+}
+
+const mapStateToProps = state => ({
+  data: state.qrCode.data
+})
+
+export default hot(connect(mapStateToProps, mapActionCreators)(UserQrCode))

--- a/packages/user-qr-action/src/dev/fetchMocks.js
+++ b/packages/user-qr-action/src/dev/fetchMocks.js
@@ -1,0 +1,7 @@
+import {mockData} from 'tocco-util'
+
+export default function setupFetchMock(packageName, fetchMock) {
+  mockData.setupSystemMock(packageName, fetchMock, require('./textResources.json'))
+
+  fetchMock.spy()
+}

--- a/packages/user-qr-action/src/dev/input.json
+++ b/packages/user-qr-action/src/dev/input.json
@@ -1,0 +1,7 @@
+{
+  "selection": {
+    "entityName": "User",
+    "type": "ID",
+    "ids": [ "1" ]
+  }
+}

--- a/packages/user-qr-action/src/dev/textResources.json
+++ b/packages/user-qr-action/src/dev/textResources.json
@@ -1,0 +1,3 @@
+[
+  "client.user-qr-action.fetchFailed"
+]

--- a/packages/user-qr-action/src/main.js
+++ b/packages/user-qr-action/src/main.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import {reducer as reducerUtil} from 'tocco-util'
+import {appFactory} from 'tocco-app-extensions'
+
+import reducers, {sagas} from './modules/reducers'
+import UserQrCode from './containers/UserQrCodeContainer'
+
+const packageName = 'user-qr-action'
+
+const initApp = (id, input, events, publicPath) => {
+  const content = <UserQrCode selection={input.selection}/>
+
+  const store = appFactory.createStore(reducers, sagas, input, packageName)
+
+  return appFactory.createApp(
+    packageName,
+    content,
+    store,
+    {
+      input,
+      events,
+      actions: [],
+      publicPath,
+      textResourceModules: ['component', 'common', packageName]
+    }
+  )
+}
+
+(() => {
+  if (__DEV__ && __PACKAGE_NAME__ === packageName) {
+    const input = require('./dev/input.json')
+
+    if (!__NO_MOCK__) {
+      const fetchMock = require('fetch-mock')
+      const setupFetchMocks = require('./dev/fetchMocks').default
+      setupFetchMocks(packageName, fetchMock)
+      fetchMock.spy()
+    }
+
+    const app = initApp(packageName, input)
+
+    if (module.hot) {
+      module.hot.accept('./modules/reducers', () => {
+        const reducers = require('./modules/reducers').default
+        reducerUtil.hotReloadReducers(app.store, reducers)
+      })
+    }
+
+    appFactory.renderApp(app.component)
+  } else {
+    appFactory.registerAppInRegistry(packageName, initApp)
+  }
+})()

--- a/packages/user-qr-action/src/modules/qrCode/actions.js
+++ b/packages/user-qr-action/src/modules/qrCode/actions.js
@@ -1,0 +1,13 @@
+export const FETCH_DATA = 'qrCode/FETCH_DATA'
+export const SET_DATA = 'qrCode/SET_DATA'
+
+export const fetchData = () => ({
+  type: FETCH_DATA
+})
+
+export const setData = data => ({
+  type: SET_DATA,
+  payload: {
+    data
+  }
+})

--- a/packages/user-qr-action/src/modules/qrCode/index.js
+++ b/packages/user-qr-action/src/modules/qrCode/index.js
@@ -1,0 +1,7 @@
+import {fetchData} from './actions'
+import reducer from './reducer'
+import sagas from './sagas'
+
+export {fetchData}
+export {sagas}
+export default reducer

--- a/packages/user-qr-action/src/modules/qrCode/reducer.js
+++ b/packages/user-qr-action/src/modules/qrCode/reducer.js
@@ -1,0 +1,16 @@
+import {reducer as reducerUtil} from 'tocco-util'
+
+import * as actions from './actions'
+
+const ACTION_HANDLERS = {
+  [actions.SET_DATA]: reducerUtil.singleTransferReducer('data')
+}
+
+const initialState = {
+  data: undefined
+}
+
+export default function reducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+  return handler ? handler(state, action) : state
+}

--- a/packages/user-qr-action/src/modules/qrCode/reducer.spec.js
+++ b/packages/user-qr-action/src/modules/qrCode/reducer.spec.js
@@ -1,0 +1,32 @@
+import reducer from './reducer'
+import * as actions from './actions'
+
+const INITIAL_STATE = {
+  data: undefined
+}
+
+describe('user-qr-action', () => {
+  describe('modules', () => {
+    describe('reducer', () => {
+      test('should create a valid initial state', () => {
+        expect(reducer(undefined, {})).to.deep.equal(INITIAL_STATE)
+      })
+
+      test('should handle SET_DATA action', () => {
+        const stateBefore = INITIAL_STATE
+
+        const data = {
+          firstname: 'Max',
+          lastname: 'Muster'
+        }
+
+        const expectedStateAfter = {
+          ...INITIAL_STATE,
+          data
+        }
+
+        expect(reducer(stateBefore, actions.setData(data))).to.deep.equal(expectedStateAfter)
+      })
+    })
+  })
+})

--- a/packages/user-qr-action/src/modules/qrCode/sagas.js
+++ b/packages/user-qr-action/src/modules/qrCode/sagas.js
@@ -1,0 +1,66 @@
+import {all, call, put, select, takeEvery} from 'redux-saga/effects'
+import {rest} from 'tocco-app-extensions'
+import {consoleLogger} from 'tocco-util'
+
+import * as actions from './actions'
+
+export const inputSelector = state => state.input
+
+export default function* sagas() {
+  yield all([
+    takeEvery(actions.FETCH_DATA, fetchData)
+  ])
+}
+
+export function* fetchData() {
+  const {selection} = yield select(inputSelector)
+
+  const userKey = getSingleKey(selection)
+
+  const query = {
+    paths: [
+      'firstname',
+      'lastname',
+      'c_address',
+      'phone_mobile',
+      'phone_company',
+      'phone_private',
+      'email',
+      'email_alternative',
+      'birthdate'
+    ]
+  }
+
+  try {
+    const entity = yield call(rest.fetchEntity, 'User', userKey, query)
+
+    let data = null
+
+    if (entity) {
+      data = {}
+      Object.entries(entity.paths).forEach(([path, bean]) => {
+        if (bean && bean.value) {
+          data[path] = bean.value
+        }
+      })
+    }
+
+    yield put(actions.setData(data))
+  } catch (e) {
+    consoleLogger.logError('Failed to fetch data', e)
+    yield put(actions.setData(null))
+  }
+}
+
+export const getSingleKey = selection => {
+  if (selection.entityName !== 'User') {
+    throw new Error('Only selection of User supported')
+  }
+  if (selection.type !== 'ID') {
+    throw new Error('Only ID selection type supported')
+  }
+  if (!selection.ids || selection.ids.length !== 1) {
+    throw new Error('Exactly one user must be selected')
+  }
+  return selection.ids[0]
+}

--- a/packages/user-qr-action/src/modules/qrCode/sagas.spec.js
+++ b/packages/user-qr-action/src/modules/qrCode/sagas.spec.js
@@ -1,0 +1,69 @@
+import {expectSaga} from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import {all, select, takeEvery} from 'redux-saga/effects'
+import {rest} from 'tocco-app-extensions'
+
+import * as actions from './actions'
+import rootSaga, * as sagas from './sagas'
+
+describe('user-qr-action', () => {
+  describe('modules', () => {
+    describe('sagas', () => {
+      test('should fork child sagas', () => {
+        const generator = rootSaga()
+        expect(generator.next().value).to.deep.equal(all([
+          takeEvery(actions.FETCH_DATA, sagas.fetchData)
+        ]))
+        expect(generator.next().done).to.be.true
+      })
+
+      describe('getSingleKey', () => {
+        test('should return the only key of the selection', () => {
+          expect(sagas.getSingleKey({entityName: 'User', type: 'ID', ids: ['1']})).to.equal('1')
+        })
+
+        test('should throw error if not User entity', () => {
+          expect(() => sagas.getSingleKey({entityName: 'Address'}))
+            .to.throw('Only selection of User supported')
+        })
+
+        test('should throw error if not ID selection', () => {
+          expect(() => sagas.getSingleKey({entityName: 'User', type: 'QUERY'}))
+            .to.throw('Only ID selection type supported')
+        })
+
+        test('should throw error if ids not present', () => {
+          expect(() => sagas.getSingleKey({entityName: 'User', type: 'ID', ids: undefined}))
+            .to.throw('Exactly one user must be selected')
+        })
+
+        test('should throw error if ids empty', () => {
+          expect(() => sagas.getSingleKey({entityName: 'User', type: 'ID', ids: []}))
+            .to.throw('Exactly one user must be selected')
+        })
+
+        test('should throw error if ids contains more than 1', () => {
+          expect(() => sagas.getSingleKey({entityName: 'User', type: 'ID', ids: ['1', '2']}))
+            .to.throw('Exactly one user must be selected')
+        })
+      })
+
+      describe('fetchData', () => {
+        const fakeEntity = {paths: {firstname: {value: 'Max'}}}
+        const data = {
+          firstname: 'Max'
+        }
+
+        test('should fetch user data', () =>
+          expectSaga(sagas.fetchData)
+            .provide([
+              [select(sagas.inputSelector), {selection: {entityName: 'User', type: 'ID', ids: ['1']}}],
+              [matchers.call.fn(rest.fetchEntity), fakeEntity]
+            ])
+            .put(actions.setData(data))
+            .run()
+        )
+      })
+    })
+  })
+})

--- a/packages/user-qr-action/src/modules/reducers.js
+++ b/packages/user-qr-action/src/modules/reducers.js
@@ -1,0 +1,9 @@
+import qrCodeReducer, {sagas as qrCodeSagas} from './qrCode'
+
+export default {
+  qrCode: qrCodeReducer
+}
+
+export const sagas = [
+  qrCodeSagas
+]

--- a/packages/user-qr-action/src/utils/qrCodeUtils.js
+++ b/packages/user-qr-action/src/utils/qrCodeUtils.js
@@ -1,0 +1,20 @@
+export const buildUserMecardString = data => {
+  let string = `MECARD:N:${data.lastname},${data.firstname};`
+
+  string = appendField(data, 'c_address', 'ADR', string, address => address.replace(/\s*<br\s?\/?>\s*/gi, ','))
+  string = appendField(data, 'phone_mobile', 'TEL', string)
+  string = appendField(data, 'phone_company', 'TEL', string)
+  string = appendField(data, 'phone_private', 'TEL', string)
+  string = appendField(data, 'email', 'EMAIL', string)
+  string = appendField(data, 'email_alternative', 'EMAIL', string)
+  string = appendField(data, 'birthdate', 'BDAY', string, date => date.replace(/-/gi, ''))
+
+  return string
+}
+
+const appendField = (data, fieldName, outputPrefix, output, handler = fieldData => fieldData) => {
+  if (data[fieldName] && data[fieldName].length > 0) {
+    output += `${outputPrefix}:${handler(data[fieldName])};`
+  }
+  return output
+}

--- a/packages/user-qr-action/src/utils/qrCodeUtils.spec.js
+++ b/packages/user-qr-action/src/utils/qrCodeUtils.spec.js
@@ -1,0 +1,35 @@
+import {buildUserMecardString} from './qrCodeUtils'
+
+describe('user-qr-action', () => {
+  describe('utils', () => {
+    describe('buildUserMecardString', () => {
+      test('should build minimal MECARD string', () => {
+        const data = {
+          firstname: 'Max',
+          lastname: 'Muster'
+        }
+
+        expect(buildUserMecardString(data)).to.equal('MECARD:N:Muster,Max;')
+      })
+
+      test('should build complete MECARD string', () => {
+        const data = {
+          firstname: 'Max',
+          lastname: 'Muster',
+          c_address: 'Riedtlistrasse 27<br>8006 Zürich',
+          phone_mobile: '+41791234567',
+          phone_company: '+41443886000',
+          phone_private: '+41441230099',
+          email: 'max.muster@example.com',
+          email_alternative: 'mm@test.ch',
+          birthdate: '1983-06-13'
+        }
+
+        expect(buildUserMecardString(data))
+          .to.equal(
+            'MECARD:N:Muster,Max;ADR:Riedtlistrasse 27,8006 Zürich;TEL:+41791234567;TEL:+41443886000;'
+          + 'TEL:+41441230099;EMAIL:max.muster@example.com;EMAIL:mm@test.ch;BDAY:19830613;')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Takes selection of the admin as input (only selection for entity name
"User" and with type "ID" supported and requires exactly one selected
key).

Refs: TOCDEV-1888