### PR TITLE
feat(app-extensions): add `getRecord()` to legacy action context

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -196,6 +196,9 @@ export default function* (definition, selection, parent, params, config) {
   entityExplorer.init()
 
   const ctx = new window.nice2.modules.entityexplorer.EntityExplorerActionContext(entityExplorer, null)
+  if (selection.type === 'ID' && selection.ids.length === 1) {
+    ctx.getRecord = () => ({id: selection.ids[0]})
+  }
 
   const situation = {
     entityName: selection.entityName,


### PR DESCRIPTION
- returns an object containing the record id if selection contains
  exactly one element
- this emulates the `getRecord()` function of the GridActionContext
  which is needed for grid actions
  -> for instance the `TriggerBatchjobAction`

Refs: TOCDEV-1984