### PR TITLE
refactor(entity-list): tableV2 improvements

### DIFF
--- a/packages/entity-list/src/components/Table/StyledTable.js
+++ b/packages/entity-list/src/components/Table/StyledTable.js
@@ -110,7 +110,11 @@ export const StyledFullRowProgress = styled.td`
 `
 
 export const StyledFullRow = styled.td`
-  ${StyledFullRowProgress}
+  grid-column: 1 / -1;
+  padding-top: ${scale.space(-1)};
+  height: 50px;
+  text-align: center;
+  border: 0;
   ${declareFont()};
 `
 
@@ -136,7 +140,7 @@ const StyledTable = styled.table`
   display: grid;
   border-collapse: collapse;
   grid-template-columns: ${props =>
-  props.columns.map(column => column.width ? column.width + 'px' : 'minmax(90px, auto)').join(' ')};
+  props.columns.map(column => column.width ? column.width + 'px' : 'minmax(50px, auto)').join(' ')};
   grid-auto-rows: min-content;
   min-width: 100%;
   ${StyledScrollbar}

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -37,7 +37,6 @@ export const getColumnDefinition = table =>
         label: c.label,
         sortable: c.sortable,
         children: c.children.filter(isDisplayableChild),
-        width: c.width,
         widthFixed: c.widthFixed
       }
     ))

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -66,8 +66,8 @@ describe('entity-list', () => {
             const result = forms.getColumnDefinition(formDefinition)
 
             const expectedColumnDefinition = [
-              {label: 'label1', id: 'lb1', children: [field1], sortable: true, widthFixed: false, width: null},
-              {label: 'label2', id: 'lb2', children: [field2], sortable: false, widthFixed: true, width: 500}
+              {label: 'label1', id: 'lb1', children: [field1], sortable: true, widthFixed: false},
+              {label: 'label2', id: 'lb2', children: [field2], sortable: false, widthFixed: true}
             ]
 
             expect(result).to.eql(expectedColumnDefinition)
@@ -111,7 +111,7 @@ describe('entity-list', () => {
             const result = forms.getColumnDefinition(formDefinition)
 
             const expectedcolumnDefinition = [
-              {label: 'label1', id: 'lb1', children: [field1], sortable: true, widthFixed: false, width: null}
+              {label: 'label1', id: 'lb1', children: [field1], sortable: true, widthFixed: false}
             ]
             expect(result).to.eql(expectedcolumnDefinition)
           })

--- a/packages/entity-list/src/util/cellRenderer.js
+++ b/packages/entity-list/src/util/cellRenderer.js
@@ -26,7 +26,7 @@ const getDisplayExpression = (field, entity) => {
       type={'displayExpression'}
       value={null}
     >
-      <FormattedValue type="html" value={entity[field.id]}/>
+      <FormattedValue type="html" breakWords={false} value={entity[field.id]}/>
     </LazyDataCell>
 
   </span>


### PR DESCRIPTION
- ignore form model width (for the moment) since the new client expects a absolute pixel value but the old client works with relative number.
- Decrease cell min-width
- break words false for display expressions in table
- Fix no data found styling