### PR TITLE
refactor(admin): fix duplicate call of path loading

### DIFF
--- a/packages/admin/src/routes/entities/components/EntitiesRoute/EntitiesRoute.js
+++ b/packages/admin/src/routes/entities/components/EntitiesRoute/EntitiesRoute.js
@@ -30,7 +30,11 @@ const StyledBreadcrumbs = styled.div`
 `
 
 const EntitiesRoute = ({match, history, loadCurrentViewInfo}) => {
-  useEffect(() => { loadCurrentViewInfo(history.location) }, [])
+  const location = history.location
+
+  useEffect(() => {
+    loadCurrentViewInfo(location)
+  }, [location])
 
   return (
     <StyledWrapper>

--- a/packages/admin/src/routes/entities/modules/path/sagas.js
+++ b/packages/admin/src/routes/entities/modules/path/sagas.js
@@ -160,19 +160,21 @@ export function* loadCurrentViewInfo({payload: {location}}) {
       yield put(viewPersistor.clearPersistedViews(currentViewInfo.level + 1))
     }
   } else {
-    yield call(handleActionRoute, pathname, pathParts)
+    const actionPathRegex = pathToRegexp('/e/action/:actionId', pathParts)
+    const parseResult = actionPathRegex.exec(pathname)
+
+    if (parseResult !== null) {
+      yield call(handleActionRoute, pathname, parseResult)
+    }
   }
 
   yield put(actions.setBreadcrumbsInfo(breadcrumbs))
 }
 
-function* handleActionRoute(pathname, pathParts) {
-  const actionPathRegex = pathToRegexp('/e/action/:actionId', pathParts)
-  const result = actionPathRegex.exec(pathname)
-
+function* handleActionRoute(pathname, parseResult) {
   yield put(actions.setCurrentViewInfo(pathname,
     {
-      actionId: result[1],
+      actionId: parseResult[1],
       pathname
     }))
 }


### PR DESCRIPTION
- At the moment the useEffect hook was triggered, the history object was already updated. That means that in case of a redirect from /key to key/detail, the detail view got initialized twice. To fix this issue a const was introduce to preserve the location

Refs: TOCDEV-1939