### PR TITLE
feat(app-extension): Use `release` sources for legacy actions

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -33,9 +33,9 @@ export function* loadSequentially(sources) {
 
 export const sources = [
   {src: '/nice2/javascript/lang.release.js', handler: loadScript},
-  {src: '/nice2/javascript/nice2-ext-newclient-actions.debug.js', handler: loadScript},
-  {src: '/nice2/javascript/nice2-admin.debug.js', handler: loadScript},
-  {src: '/nice2/javascript/nice2-newclient-actions-setup.debug.js', handler: loadScript},
+  {src: '/nice2/javascript/nice2-ext-newclient-actions.release.js', handler: loadScript},
+  {src: '/nice2/javascript/nice2-admin.release.js', handler: loadScript},
+  {src: '/nice2/javascript/nice2-newclient-actions-setup.release.js', handler: loadScript},
   {src: '/nice2/dwr-all.js', handler: loadScript},
   {src: '/js/ext-extensions/ckeditor/ckeditor/ckeditor.js', handler: loadScript},
   {src: '/css/themes/blue-medium.css', handler: loadCss},

--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
@@ -37,9 +37,9 @@ describe('app-extensions', () => {
             test('should load the required sources sequentially', () => {
               testSaga(legacyAction.loadSequentially, legacyAction.sources).next()
                 .call(legacyAction.loadScript, '/nice2/javascript/lang.release.js').next()
-                .call(legacyAction.loadScript, '/nice2/javascript/nice2-ext-newclient-actions.debug.js').next()
-                .call(legacyAction.loadScript, '/nice2/javascript/nice2-admin.debug.js').next()
-                .call(legacyAction.loadScript, '/nice2/javascript/nice2-newclient-actions-setup.debug.js').next()
+                .call(legacyAction.loadScript, '/nice2/javascript/nice2-ext-newclient-actions.release.js').next()
+                .call(legacyAction.loadScript, '/nice2/javascript/nice2-admin.release.js').next()
+                .call(legacyAction.loadScript, '/nice2/javascript/nice2-newclient-actions-setup.release.js').next()
                 .call(legacyAction.loadScript, '/nice2/dwr-all.js').next()
                 .call(legacyAction.loadScript, '/js/ext-extensions/ckeditor/ckeditor/ckeditor.js').next()
                 .call(legacyAction.loadCss, '/css/themes/blue-medium.css').next()


### PR DESCRIPTION
- The release sources are compressed and thus load faster
- Now that most of the legacy actions work in the new client and
  there's not a lot to debug anymore, we don't need the debug sources
  anymore

Refs: TOCDEV-2083