### PR TITLE
fix(app-extensions): Use `path` attribute of legacy action definition

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -181,7 +181,7 @@ export function* getScope() {
 export default function* (definition, selection, parent, params, config) {
   yield call(initLegacyActionsEnv)
 
-  const actionDefinition = new window.nice2.netui.actions.model.ClientActionDefinition(definition.id, definition.id)
+  const actionDefinition = new window.nice2.netui.actions.model.ClientActionDefinition(definition.path, definition.id)
   actionDefinition.setEnabled(!definition.readOnly)
   if (_isPlainObject(definition.properties)) {
     const setPropertyEffects = Object.entries(definition.properties)


### PR DESCRIPTION
Since https://git.tocco.ch/c/nice2/+/37586 the path of the action is
stored in new attribute called `path` and not in `id` anymore.

Refs: TOCDEV-2070