### PR TITLE
fix(app-extensions): Don't load legacy action sources twice

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
@@ -34,7 +34,9 @@ describe('app-extensions', () => {
           })
 
           describe('loadSequentially', () => {
-            test('should load the required sources sequentially', () => {
+            test('should load the required sources for the new client sequentially', () => {
+              window.legacyActionEnv = undefined
+
               testSaga(legacyAction.loadSequentially, legacyAction.sources).next()
                 .call(legacyAction.loadScript, '/nice2/javascript/lang.release.js').next()
                 .call(legacyAction.loadScript, '/nice2/javascript/nice2-ext-newclient-actions.release.js').next()
@@ -45,6 +47,23 @@ describe('app-extensions', () => {
                 .call(legacyAction.loadCss, '/css/themes/blue-medium.css').next()
                 .call(legacyAction.loadCss, '/css/nice2-admin.css').next()
                 .call(legacyAction.loadCss, '/css/nice2-new-client-legacy-actions.css').next()
+                .isDone()
+            })
+
+            test('should load the required sources for the legacy admin client sequentially', () => {
+              window.legacyActionEnv = 'legacy-admin'
+
+              testSaga(legacyAction.loadSequentially, legacyAction.sources).next()
+                .call(legacyAction.loadScript, '/nice2/javascript/nice2-newclient-actions-setup.release.js').next()
+                .isDone()
+            })
+
+            test('should load the required sources for public flows sequentially', () => {
+              window.legacyActionEnv = 'legacy-public'
+
+              testSaga(legacyAction.loadSequentially, legacyAction.sources).next()
+                .call(legacyAction.loadScript, '/nice2/javascript/nice2-newclient-actions-public.release.js').next()
+                .call(legacyAction.loadScript, '/nice2/javascript/nice2-newclient-actions-setup.release.js').next()
                 .isDone()
             })
           })


### PR DESCRIPTION
- If a legacy action is executed in the legacy environment
  (e.g. in a new react action that is embedded in the legacy admin
  client (-> e.g. input edit action), or in the react entity-browser
  widget in a CMS page), we shouldn't load all the sources (JS/CSS)
  that are required in the new admin client (because it might break
  JS functionality as well as styling)
- To control which sources should be loaded, the environment provides
  a global variable `legacyActionEnv`. If no variable is set, the
  new admin client environment is assumed.
- Also see https://git.tocco.ch/c/nice2/+/37708

Refs: TOCDEV-2238