### PR TITLE
refactor(app-extension): cleanup readonly mapping

### DIFF
--- a/packages/app-extensions/src/form/FormBuilder.js
+++ b/packages/app-extensions/src/form/FormBuilder.js
@@ -34,15 +34,15 @@ const FormBuilder = props => {
     !mode || !scopes || scopes.length === 0 || scopes.includes(mode)
   )
 
-  const formTraverser = (children, readonly = false) => {
+  const formTraverser = (children, parentReadOnly = false) => {
     const result = []
     for (const child of children) {
       if (child.componentType === componentTypes.LAYOUT) {
-        result.push(createLayoutComponent(child, child.layoutType, readonly))
+        result.push(createLayoutComponent(child, child.layoutType, parentReadOnly))
       } else if (isAction(child.componentType)) {
         result.push(createAction(child))
       } else if (child.componentType === componentTypes.FIELD_SET) {
-        result.push(createFieldSet(child, readonly))
+        result.push(createFieldSet(child, parentReadOnly))
       } else if (componentMapping && componentMapping[child.componentType]) {
         return createCustomComponent(child)
       }
@@ -50,7 +50,7 @@ const FormBuilder = props => {
     return result
   }
 
-  const createFieldSet = (fieldSet, readonly) => {
+  const createFieldSet = (fieldSet, parentReadOnly) => {
     const fieldDefinition = fieldSet.children.find(child => !isAction(child.componentType))
 
     if (!fieldDefinition) {
@@ -106,7 +106,7 @@ const FormBuilder = props => {
     if (shouldRenderField(formDefinitionField, entityField)) {
       return <Field
         key={`field-${fieldName}`}
-        readOnlyForm={readonly}
+        parentReadOnly={parentReadOnly}
         name={transformFieldName(fieldName)}
         id={getFieldId(formName, fieldName)}
         formName={formName}
@@ -139,8 +139,8 @@ const FormBuilder = props => {
     </div>
   }
 
-  const createLayoutComponent = (field, type, readonly) => {
-    let elements = formTraverser(field.children, readonly || field.readonly)
+  const createLayoutComponent = (field, type, parentReadOnly) => {
+    let elements = formTraverser(field.children, parentReadOnly || field.readonly)
 
     if (Array.isArray(elements)) {
       elements = elements.filter(Boolean)

--- a/packages/app-extensions/src/form/FormBuilder.spec.js
+++ b/packages/app-extensions/src/form/FormBuilder.spec.js
@@ -219,7 +219,7 @@ describe('app-extensions', () => {
         const wrapper = shallow(<FormBuilder {...props}/>)
         const field = wrapper.findWhere(e => e.props().id === 'input-detail-not-readonly-field')
         expect(field).to.have.length(1)
-        expect(field.props().readOnlyForm).to.be.true
+        expect(field.props().parentReadOnly).to.be.true
       })
 
       test('should read multi paths entity fields', () => {

--- a/packages/app-extensions/src/form/ReduxFormFieldAdapter.js
+++ b/packages/app-extensions/src/form/ReduxFormFieldAdapter.js
@@ -16,7 +16,7 @@ const ReduxFormFieldAdapter = props => {
     formDefinitionField,
     entityField,
     modelField,
-    readOnlyForm,
+    parentReadOnly,
     formName
   } = props
 
@@ -34,7 +34,7 @@ const ReduxFormFieldAdapter = props => {
     events,
     error,
     entityField,
-    readOnlyForm
+    parentReadOnly
   }
   const resources = {
     mandatoryTitle: props.intl.formatMessage({id: 'client.component.form.mandatoryFieldTitle'})
@@ -62,12 +62,8 @@ ReduxFormFieldAdapter.propTypes = {
   formDefinitionField: PropTypes.object.isRequired,
   entityField: PropTypes.object,
   modelField: PropTypes.object,
-  readOnlyForm: PropTypes.bool,
-  fieldMappingType: PropTypes.string.isRequired,
-  readOnlyFormFieldMapping: PropTypes.objectOf(PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.objectOf(PropTypes.func)
-  ]))
+  parentReadOnly: PropTypes.bool,
+  fieldMappingType: PropTypes.string.isRequired
 }
 
 export default injectIntl(ReduxFormFieldAdapter)

--- a/packages/simple-form/src/components/Form/Form.js
+++ b/packages/simple-form/src/components/Form/Form.js
@@ -36,7 +36,6 @@ class Form extends React.Component {
         formDefinition={this.props.formDefinition}
         formValues={this.props.formValues}
         fieldMappingType={this.props.mappingType ? this.props.mappingType : 'editable'}
-        readOnlyFormFieldMapping={null}
       />
       {!this.props.noButtons
       && <React.Fragment>


### PR DESCRIPTION
- rename readonly param to "parentReadOnly" to make origin more clear
- introduce one function to determine whether a field is rendered with "readOnly" mapping
- remove unused propTypes