### PR TITLE
feat(entity-list): Support `clickable` flag in table form model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 
 install:
   - yarn setup --frozen-lockfile
-  - travis_wait lerna bootstrap --concurrency=1 --mutex network
+  - travis_wait lerna bootstrap --concurrency=1 --mutex network --force-local
 
 script:
   - yarn lint

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -15,7 +15,7 @@
     "tocco-delete": ">=0.1.0",
     "tocco-entity-detail": ">0.1.0",
     "tocco-entity-list": ">0.1.0",
-    "tocco-input-edit": ">=0.1.0",
+    "tocco-input-edit": "*",
     "tocco-login": ">0.1.0",
     "tocco-merge": ">0.1.0",
     "tocco-resource-scheduler": ">0.1.0",

--- a/packages/entity-list/src/components/Table/StyledTable.js
+++ b/packages/entity-list/src/components/Table/StyledTable.js
@@ -64,7 +64,7 @@ export const PaginationContainer = styled.div`
 
 const selectionStyles = css`
   display: contents;
-  cursor: pointer;
+  ${({clickable}) => clickable && 'cursor: pointer;'}
 
   &.selected {
     > ${StyledTableCell} {

--- a/packages/entity-list/src/components/Table/Table.js
+++ b/packages/entity-list/src/components/Table/Table.js
@@ -80,7 +80,7 @@ const Table = props => {
       singleSelectHandler(entity.__key, true, true)
     } else if (e.metaKey || e.ctrlKey) {
       singleSelectHandler(entity.__key)
-    } else {
+    } else if (props.clickable !== false) {
       props.onRowClick(entity.__key)
     }
   }
@@ -158,6 +158,7 @@ const Table = props => {
                     key={`list-row-${entity.__key}`}
                     className={`selectableRow ${isSelected(entity.__key) && 'selected'}`}
                     onClick={trOnClick(entity)}
+                    clickable={props.clickable}
                     data-cy="list-row"
                   >
                     {
@@ -216,6 +217,7 @@ Table.propTypes = {
   setSortingInteractive: PropTypes.func,
   changePage: PropTypes.func.isRequired,
   tableSelectionStyle: selectionStylePropType,
+  clickable: PropTypes.bool,
   onSelectChange: PropTypes.func,
   refresh: PropTypes.func,
   selection: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),

--- a/packages/entity-list/src/containers/TableContainer.js
+++ b/packages/entity-list/src/containers/TableContainer.js
@@ -38,6 +38,7 @@ const mapStateToProps = (state, props) => ({
   limit: state.list.limit,
   inProgress: state.list.inProgress,
   tableSelectionStyle: state.selection.tableSelectionStyle,
+  clickable: state.list.formClickable,
   selection: state.selection.selection,
   parent: state.entityList.parent,
   showLink: state.list.showLink,

--- a/packages/entity-list/src/modules/list/actions.js
+++ b/packages/entity-list/src/modules/list/actions.js
@@ -20,6 +20,7 @@ export const SET_SIMPLE_SEARCH_FIELDS = 'list/SET_SIMPLE_SEARCH_FIELDS'
 export const ON_ROW_CLICK = 'list/ON_ROW_CLICK'
 export const NAVIGATE_TO_CREATE = 'entityList/NAVIGATE_TO_CREATE'
 export const SET_FORM_SELECTABLE = 'list/SET_FORM_SELECTABLE'
+export const SET_FORM_CLICKABLE = 'list/SET_FORM_CLICKABLE'
 export const SET_ENDPOINT = 'list/SET_ENDPOINT'
 export const SET_CONSTRICTION = 'list/SET_CONSTRICTION'
 export const QUERY_CHANGED = 'list/QUERY_CHANGED'
@@ -162,6 +163,13 @@ export const setFormSelectable = formSelectable => ({
   type: SET_FORM_SELECTABLE,
   payload: {
     formSelectable
+  }
+})
+
+export const setFormClickable = formClickable => ({
+  type: SET_FORM_CLICKABLE,
+  payload: {
+    formClickable
   }
 })
 

--- a/packages/entity-list/src/modules/list/reducer.js
+++ b/packages/entity-list/src/modules/list/reducer.js
@@ -67,6 +67,7 @@ const ACTION_HANDLERS = {
   [actions.SET_SHOW_SEARCH_FORM]: reducerUtil.singleTransferReducer('showSearchForm'),
   [actions.SET_SEARCH_FILTERS]: reducerUtil.singleTransferReducer('searchFilters'),
   [actions.SET_FORM_SELECTABLE]: reducerUtil.singleTransferReducer('formSelectable'),
+  [actions.SET_FORM_CLICKABLE]: reducerUtil.singleTransferReducer('formClickable'),
   [actions.SET_ENDPOINT]: reducerUtil.singleTransferReducer('endpoint'),
   [actions.SET_CONSTRICTION]: reducerUtil.singleTransferReducer('constriction'),
   [actions.SET_SHOW_LINK]: reducerUtil.singleTransferReducer('showLink')
@@ -88,6 +89,7 @@ const initialState = {
   searchFilters: [],
   createPermission: false,
   formSelectable: false,
+  formClickable: false,
   showLink: false,
   lazyData: {},
   endpoint: null,

--- a/packages/entity-list/src/modules/list/reducer.spec.js
+++ b/packages/entity-list/src/modules/list/reducer.spec.js
@@ -16,6 +16,7 @@ const EXPECTED_INITIAL_STATE = {
   searchFilters: [],
   createPermission: false,
   formSelectable: false,
+  formClickable: false,
   showLink: false,
   lazyData: {},
   endpoint: null,
@@ -216,6 +217,18 @@ describe('entity-list', () => {
           }
 
           expect(reducer(stateBefore, actions.setFormSelectable(true))).to.deep.equal(expectedStateAfter)
+        })
+
+        test('should handle SET_FORM_CLICKABLE', () => {
+          const stateBefore = {
+            formClickable: false
+          }
+
+          const expectedStateAfter = {
+            formClickable: true
+          }
+
+          expect(reducer(stateBefore, actions.setFormClickable(true))).to.deep.equal(expectedStateAfter)
         })
 
         test('should handle SET_LAZY_DATA', () => {

--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -10,7 +10,7 @@ import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
 import * as selectionActions from '../selection/actions'
 import {getSearchFormValues} from '../searchForm/sagas'
-import {getSorting, getSelectable, getEndpoint, getConstriction, getFields} from '../../util/api/forms'
+import {getSorting, getSelectable, getClickable, getEndpoint, getConstriction, getFields} from '../../util/api/forms'
 import {entitiesListTransformer} from '../../util/api/entities'
 
 export const inputSelector = state => state.input
@@ -270,6 +270,8 @@ export function* loadFormDefinition(formDefinition, formName) {
 
   const selectable = yield call(getSelectable, formDefinition)
   yield put(actions.setFormSelectable(selectable))
+  const clickable = yield call(getClickable, formDefinition)
+  yield put(actions.setFormClickable(clickable))
   const endpoint = yield call(getEndpoint, formDefinition)
   yield put(actions.setEndpoint(endpoint))
   const constriction = yield call(getConstriction, formDefinition)

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -8,7 +8,7 @@ import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
 import * as selectionActions from '../selection/actions'
 import rootSaga, * as sagas from './sagas'
-import {getSorting, getSelectable, getFields, getEndpoint, getConstriction} from '../../util/api/forms'
+import {getSorting, getSelectable, getClickable, getFields, getEndpoint, getConstriction} from '../../util/api/forms'
 import {getSearchFormValues} from '../searchForm/sagas'
 
 const generateState = (entityStore = {}, page) => ({
@@ -373,6 +373,7 @@ describe('entity-list', () => {
             }
 
             const selectable = true
+            const clickable = true
             const endpoint = 'customEndpoint'
             const constriction = 'sampleConstriction'
 
@@ -380,12 +381,14 @@ describe('entity-list', () => {
               .provide([
                 [matchers.call.fn(rest.fetchForm), loadedFormDefinition],
                 [matchers.call.fn(getSelectable), selectable],
+                [matchers.call.fn(getClickable), clickable],
                 [matchers.call.fn(getEndpoint), endpoint],
                 [matchers.call.fn(getConstriction), constriction]
               ])
               .call(rest.fetchForm, formName, 'list')
               .put(actions.setFormDefinition(loadedFormDefinition))
               .put(actions.setFormSelectable(selectable))
+              .put(actions.setFormClickable(clickable))
               .put(actions.setEndpoint(endpoint))
               .put(actions.setConstriction(constriction))
               .run()
@@ -398,6 +401,7 @@ describe('entity-list', () => {
               .provide([
                 [matchers.call.fn(sagas.setSorting)],
                 [matchers.call.fn(getSelectable), false],
+                [matchers.call.fn(getClickable), false],
                 [matchers.call.fn(getEndpoint), null],
                 [matchers.call.fn(getConstriction), null]
               ])

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -15,6 +15,11 @@ export const getSelectable = formDefinition => {
   return table.selectable !== false
 }
 
+export const getClickable = formDefinition => {
+  const table = getTable(formDefinition)
+  return table.clickable !== false
+}
+
 export const getEndpoint = formDefinition => {
   const table = getTable(formDefinition)
   return table.endpoint || null

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -267,18 +267,43 @@ describe('entity-list', () => {
             }]
           })
 
-          test('should return seletable boolean of the form definition', () => {
+          test('should return selectable boolean of the form definition', () => {
             const result = forms.getSelectable(getFormDefinition(true))
             expect(result).to.be.true
           })
 
-          test('should return seletable boolean false of the form definition', () => {
+          test('should return selectable boolean false of the form definition', () => {
             const result = forms.getSelectable(getFormDefinition(false))
             expect(result).to.be.false
           })
 
-          test('should return true if selectable not in defintion', () => {
+          test('should return true if selectable not in definition', () => {
             const result = forms.getSelectable(getFormDefinition(null))
+            expect(result).to.be.true
+          })
+        })
+
+        describe('getClickable', () => {
+          const getFormDefinition = clickable => ({
+            children: [{
+              layoutType: 'table',
+              componentType: 'table',
+              ...(clickable !== null ? {clickable} : {})
+            }]
+          })
+
+          test('should return clickable boolean of the form definition', () => {
+            const result = forms.getClickable(getFormDefinition(true))
+            expect(result).to.be.true
+          })
+
+          test('should return clickable boolean false of the form definition', () => {
+            const result = forms.getClickable(getFormDefinition(false))
+            expect(result).to.be.false
+          })
+
+          test('should return true if clickable not in definition', () => {
+            const result = forms.getClickable(getFormDefinition(null))
             expect(result).to.be.true
           })
         })


### PR DESCRIPTION
By default, a row is clickable. If the `clickable` flag is set on the
table in form model, the rows aren't clickable anymore. However, if
`selectable` is true they still can be selected using the checkbox.

Refs: TOCDEV-2364