### PR TITLE
refactor(tocco-ui): add bg color to search box

### DIFF
--- a/packages/admin/src/components/Navigation/StyledComponents.js
+++ b/packages/admin/src/components/Navigation/StyledComponents.js
@@ -89,4 +89,5 @@ export const StyledNavButton = styled(Button)`
 
 export const StyledSearchBoxWrapper = styled.div`
   height: 50px;
+  padding-bottom: ${scale.space(-0.5)};
 `


### PR DESCRIPTION
Refs: TOCDEV-2417
Changelog: Add background color to search box to prevent scrolling text shining through under it