### PR TITLE
fix(admin): Take `baseRoute` into account for resource scheduler

### DIFF
--- a/packages/admin/src/routes/entities/components/Action/actions/ResourceScheduler.js
+++ b/packages/admin/src/routes/entities/components/Action/actions/ResourceScheduler.js
@@ -5,11 +5,12 @@ import {selection as selectionPropType} from 'tocco-util'
 
 import {goBack} from '../../../../../utils/routing'
 
-const ResourceScheduler = ({match, selection, actionProperties}) => {
+const ResourceScheduler = ({match, selection, actionProperties, history}) => {
   const entityBaseUrl = goBack(match.url, 2)
   return <ResourceSchedulerApp
     onEventClick={({model, key}) => {
-      window.open(`${entityBaseUrl}/${model}/${key}`, '_blank')
+      const url = history.createHref({pathname: `${entityBaseUrl}/${model}/${key}`})
+      window.open(url, '_blank')
     }}
     selection={selection}
     actionProperties={actionProperties}
@@ -23,7 +24,10 @@ ResourceScheduler.propTypes = {
   selection: selectionPropType.propType,
   actionProperties: PropTypes.shape({
     calendarType: PropTypes.string
-  })
+  }),
+  history: PropTypes.shape({
+    createHref: PropTypes.func.isRequired
+  }).isRequired
 }
 
 export default ResourceScheduler


### PR DESCRIPTION
For the deployment on master.tocco.ch, the admin input prop `baseRoute`
(which is used as `basename` for the router) is set to `/beta`.
By using `history#createHref` the URL is prefixed with the basename
which was missing before -> the entities that should be opened when
the user clicks on an event in the scheduler couldn't be displayed
on master.tocco.ch because the URL was wrong.

Refs: TOCDEV-2347