### PR TITLE
refactor(tocco-util): improve tql builder

### DIFF
--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -516,7 +516,7 @@ describe('entity-list', () => {
 
             const expectedResult = {
               filter: ['filter1', 'filter2', 'filter3'],
-              tql: '(foo == "bar") and (relParent.pk == 1 and relGender.pk == 3 and txtFulltext == "full")'
+              tql: '(foo == "bar") and (relParent.pk == 1 and relGender.pk == 3 and txtFulltext ~= "full")'
             }
 
             return expectSaga(sagas.getBasicQuery)

--- a/packages/entity-list/src/util/api/fetchOptions.spec.js
+++ b/packages/entity-list/src/util/api/fetchOptions.spec.js
@@ -11,10 +11,14 @@ describe('entity-list', () => {
               lastname: 'Griffin',
               cool: true
             }
+            const formFields = {
+              firstname: 'string',
+              lastname: 'string',
+              cool: 'boolean'
+            }
 
-            const expectedResult = {tql: 'firstname == "Robihoe" and lastname == "Griffin" and cool == "true"'}
-
-            const result = getFetchOptionsFromSearchForm(searchFormValues)
+            const expectedResult = {tql: 'firstname ~= "Robihoe" and lastname ~= "Griffin" and cool == true'}
+            const result = getFetchOptionsFromSearchForm(searchFormValues, formFields)
             expect(result).to.eql(expectedResult)
           })
 
@@ -24,7 +28,7 @@ describe('entity-list', () => {
               lastname: null
             }
 
-            const expectedResult = {tql: 'firstname == "Robihoe"'}
+            const expectedResult = {tql: 'firstname ~= "Robihoe"'}
 
             const result = getFetchOptionsFromSearchForm(searchFormValues)
             expect(result).to.eql(expectedResult)

--- a/packages/tocco-util/src/tqlBuilder/tqlBuilder.js
+++ b/packages/tocco-util/src/tqlBuilder/tqlBuilder.js
@@ -49,7 +49,9 @@ const typeHandlers = type => {
     case 'time':
       return (path, value, comp) => `${path} ${comp} time:"${moment(value, 'HH:mm').format('HH:mm:ss.sss')}"`
     case 'string':
-      return (path, value, comp) => `${path} ${comp} "${value}"`
+      return (path, value) => `${path} ~= "${value}"`
+    case 'boolean':
+      return (path, value) => value === false ? null : `${path} == ${value}`
     default:
       return (path, value, comp) => `${path} ${comp} ${value}`
   }

--- a/packages/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
+++ b/packages/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
@@ -22,7 +22,7 @@ describe('entity-list', () => {
             const path = 'firstname'
             const fieldType = 'string'
 
-            const expectedResult = 'firstname == "Homer"'
+            const expectedResult = 'firstname ~= "Homer"'
             const result = getTql(path, value, fieldType)
 
             expect(result).to.deep.eql(expectedResult)
@@ -116,10 +116,31 @@ describe('entity-list', () => {
             expect(result).to.deep.eql(expectedResult)
           })
 
+          test('should handle boolean with true value', () => {
+            const value = true
+            const path = 'active'
+            const fieldType = 'boolean'
+
+            const expectedResult = 'active == true'
+            const result = getTql(path, value, fieldType)
+
+            expect(result).to.deep.eql(expectedResult)
+          })
+
+          test('should return null for false boolean value', () => {
+            const value = false
+            const path = 'active'
+            const fieldType = 'boolean'
+
+            const result = getTql(path, value, fieldType)
+
+            expect(result).to.be.null
+          })
+
           test('should handle unknown form types and use fallback', () => {
             expect(getTql('relXY', {key: '23'})).to.deep.eql('relXY.pk == 23')
             expect(getTql('relXY', [{key: '23'}])).to.deep.eql('KEYS("relXY",23)')
-            expect(getTql('asd', 'test')).to.deep.eql('asd == "test"')
+            expect(getTql('asd', 'test')).to.deep.eql('asd ~= "test"')
           })
 
           test('should handle range values', () => {


### PR DESCRIPTION
- change string comparator to "like"
- add boolean handler that does not handle false values to imitate the current clients behavior

Changelog: Handle strings in search with "like" and add boolean handler