### PR TITLE
refactor(tocco-ui): set box sizing on td

### DIFF
--- a/packages/tocco-ui/src/Table/StyledTable.js
+++ b/packages/tocco-ui/src/Table/StyledTable.js
@@ -20,6 +20,7 @@ export const StyledTableCell = styled.td`
   border-bottom: 1px solid ${borderColor};
   align-content: center;
   max-height: 23px;
+  box-sizing: content-box;
 `
 
 export const StyledDnD = styled.div`


### PR DESCRIPTION
Refs: TOCDEV-2371
Changelog: Set box sizing on td to prevent overwrite in external context