### PR TITLE
refactor(app-extensions): change keydownwatcher display

### DIFF
--- a/packages/app-extensions/src/keyDown/Components/KeyDownWatcher/KeyDownWatcher.js
+++ b/packages/app-extensions/src/keyDown/Components/KeyDownWatcher/KeyDownWatcher.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import _pick from 'lodash/pick'
 const StyledDiv = styled.div`
-  display: contents;
+  display: block;
 
   :focus {
     outline: none;


### PR DESCRIPTION
Refs: TOCDEV-1467
Changelog: Change display property of keydownwatcher to block - as it otherwise causes some divs to collapse into each other on safari