### PR TITLE
refactor(app-extensions): use new displays endpoint everywhere

### DIFF
--- a/packages/app-extensions/src/formData/tooltips/sagas.js
+++ b/packages/app-extensions/src/formData/tooltips/sagas.js
@@ -18,8 +18,7 @@ export function* loadToolTip({payload: {entity, id}}) {
     const tooltip = yield select(tooltipSelector, entity, id)
 
     if (tooltip == null) {
-      const response = yield call(rest.requestSaga, `entity/${entity}/${id}/display/tooltip`, {})
-      const {display} = response.body
+      const display = yield call(rest.fetchDisplay, entity, id, 'tooltip')
       yield put(tooltipActions.setToolTip(entity, id, display))
     }
   }

--- a/packages/app-extensions/src/formData/tooltips/sagas.spec.js
+++ b/packages/app-extensions/src/formData/tooltips/sagas.spec.js
@@ -31,7 +31,7 @@ describe('app-extensions', () => {
             )
               .provide([
                 [select(sagas.tooltipSelector, entity, id), null],
-                [matchers.call.fn(rest.requestSaga), {body: {display: tooltip}}]
+                [matchers.call.fn(rest.fetchDisplay), tooltip]
               ])
               .put(tooltipActions.setToolTip(entity, id, tooltip))
               .run()

--- a/packages/app-extensions/src/rest/helpers.spec.js
+++ b/packages/app-extensions/src/rest/helpers.spec.js
@@ -300,6 +300,78 @@ describe('app-extensions', () => {
             .returns(expectedResult)
             .run()
         })
+
+        test('should only load uncached displays and combine results', () => {
+          cache.add('display', 'Gender.1', 'Male')
+
+          const request = {
+            Gender: ['1', '2']
+          }
+
+          const expectedOptions = {
+            method: 'POST',
+            body: {
+              data: [
+                {
+                  model: 'Gender',
+                  keys:
+                    ['2']
+                }
+              ]
+            }
+          }
+
+          const responseFake = {
+            body: {
+              data: [
+                {
+                  model: 'Gender',
+                  values: [
+                    {
+                      key: '2',
+                      display: 'Female'
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+
+          const expectedResult = {
+            Gender: {
+              1: 'Male',
+              2: 'Female'
+            }
+          }
+
+          return expectSaga(helpers.fetchDisplays, request)
+            .provide([
+              [matchers.call.fn(requestSaga), responseFake]
+            ])
+            .call(requestSaga, 'entities/2.0/displays', expectedOptions)
+            .returns(expectedResult)
+            .run()
+        })
+
+        test('should not request anything if all displays are cached', () => {
+          cache.add('display', 'Gender.1', 'Male')
+          cache.add('display', 'Gender.2', 'Female')
+
+          const request = {
+            Gender: ['1', '2']
+          }
+
+          const expectedResult = {
+            Gender: {
+              1: 'Male',
+              2: 'Female'
+            }
+          }
+
+          return expectSaga(helpers.fetchDisplays, request)
+            .returns(expectedResult)
+            .run()
+        })
       })
 
       describe('fetchEntityCount', () => {

--- a/packages/app-extensions/src/rest/helpers.spec.js
+++ b/packages/app-extensions/src/rest/helpers.spec.js
@@ -159,7 +159,19 @@ describe('app-extensions', () => {
 
       describe('fetchDisplay', () => {
         test('should call fetch', () => {
-          const response = {display: 'Test'}
+          const response = {
+            data: [
+              {
+                model: 'User',
+                values: [
+                  {
+                    key: '1',
+                    display: 'Test'
+                  }
+                ]
+              }
+            ]
+          }
 
           return expectSaga(helpers.fetchDisplay, 'User', '1')
             .provide([


### PR DESCRIPTION
Refs: TOCDEV-1567
Changelog: Remove all usages of old display endpoints and use 'entities/2.0/displays'