### PR TITLE
refactor(tocco-ui): fix stated value error display

### DIFF
--- a/packages/tocco-ui/src/StatedValue/StatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.js
@@ -42,7 +42,7 @@ const StatedValue = props => {
     touched
   } = props
 
-  const showError = !immutable && touched && props.error && Object.keys(props.error).length > 0
+  const showError = !immutable && touched && error && Object.keys(error).length > 0
   const labelAlt = `${js.adjustedHTMLString(label)}${mandatory && mandatoryTitle ? `, ${mandatoryTitle}` : ''}`
   const signal = props.signal || detectSignal(dirty, showError)
 
@@ -70,7 +70,7 @@ const StatedValue = props => {
             </StyledStatedValueBox>
             {description
               && <StyledStatedValueDescription>{description}</StyledStatedValueDescription>}
-            {<StyledStatedValueError showError={showError}>
+            {<StyledStatedValueError showError={showError} focused={focused}>
               <ErrorList error={error}/>
             </StyledStatedValueError>
             }

--- a/packages/tocco-ui/src/StatedValue/StatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StatedValue.js
@@ -70,7 +70,7 @@ const StatedValue = props => {
             </StyledStatedValueBox>
             {description
               && <StyledStatedValueDescription>{description}</StyledStatedValueDescription>}
-            {<StyledStatedValueError showError={showError} focused={focused}>
+            {showError && <StyledStatedValueError>
               <ErrorList error={error}/>
             </StyledStatedValueError>
             }

--- a/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
@@ -1,4 +1,4 @@
-import styled, {css} from 'styled-components'
+import styled, {css, keyframes} from 'styled-components'
 
 import {
   colorizeBorder,
@@ -106,17 +106,18 @@ const StyledStatedValueDescription = styled.p`
   }
 `
 
-const StyledStatedValueError = styled.div`
-  &&& {
-    display: none;
-    ${({showError, focused}) => showError && !focused && css`
-      display: block;
-    `};
-
-    li {
-      font-size: ${scale.font(-1)};
-    }
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
   }
+
+  to {
+    opacity: 1;
+  }
+`
+
+const StyledStatedValueError = styled.div`
+  animation: ${fadeIn} 500ms ease-in-out both;
 `
 
 const StyledStatedValueWrapper = styled.div`

--- a/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
@@ -108,14 +108,9 @@ const StyledStatedValueDescription = styled.p`
 
 const StyledStatedValueError = styled.div`
   &&& {
-    max-height: 0;
-    opacity: 0;
-    transition: all .5s ease-in-out;
-    transition-delay: .5s;
-    will-change: max-height, opacity;
-    ${({showError}) => showError && css`
-      max-height: 100px;
-      opacity: 1;
+    display: none;
+    ${({showError, focused}) => showError && !focused && css`
+      display: block;
     `};
 
     li {


### PR DESCRIPTION
Refs: TOCDEV-2413
Changelog: 
- Remove stated value error animation, as it caused a wobble effect
- Add focused prop to styled stated value error to prevent evaluation on every key stroke