### PR TITLE
refactor(input-edit): optimize input edit initialization

### DIFF
--- a/packages/input-edit/src/components/InputEdit/InputEdit.js
+++ b/packages/input-edit/src/components/InputEdit/InputEdit.js
@@ -1,6 +1,5 @@
 import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
-import {LoadMask} from 'tocco-ui'
 import {actions, notifier} from 'tocco-app-extensions'
 import {selection as selectionPropType} from 'tocco-util'
 
@@ -18,64 +17,52 @@ import InputEditInformation from '../InputEditInformation'
 
 const InputEdit = ({
   selection,
-  validation: {valid, message},
   handleNotifications,
-  checkSelection,
+  updateSelection,
   initializeTable,
   initializeSearch,
   initializeInformation,
-  actionDefinitions,
-  notify
+  actionDefinitions
 }) => {
   useEffect(() => {
-    checkSelection()
+    updateSelection()
   }, [selection])
   useEffect(() => {
     initializeTable()
     initializeSearch()
     initializeInformation()
-  }, [selection, valid])
+  }, [selection])
 
-  if (valid === false) {
-    notify('error', 'client.component.input-edit.error.title', message)
-  }
-
-  return <LoadMask required={[valid || message]}>
+  return <>
     {handleNotifications && <notifier.Notifier/>}
-    {valid
-      ? <StyledPaneWrapper>
-        <StyledPanelWrapperLeft>
-          <StyledLeftPane>
-            <StyledInputEditSearchWrapper>
-              <InputEditSearch/>
-            </StyledInputEditSearchWrapper>
-            <InputEditInformation/>
-          </StyledLeftPane>
-        </StyledPanelWrapperLeft>
-        <StyledPanelWrapperRight>
-          <StyledActionsWrapper>
-            {actionDefinitions.map(definition =>
-              <actions.Action
-                key={definition.id}
-                definition={definition}
-                selection={selection}/>
-            )}
-          </StyledActionsWrapper>
-          <InputEditTable/>
-        </StyledPanelWrapperRight>
-      </StyledPaneWrapper>
-      : null}
-  </LoadMask>
+    <StyledPaneWrapper>
+      <StyledPanelWrapperLeft>
+        <StyledLeftPane>
+          <StyledInputEditSearchWrapper>
+            <InputEditSearch/>
+          </StyledInputEditSearchWrapper>
+          <InputEditInformation/>
+        </StyledLeftPane>
+      </StyledPanelWrapperLeft>
+      <StyledPanelWrapperRight>
+        <StyledActionsWrapper>
+          {actionDefinitions.map(definition =>
+            <actions.Action
+              key={definition.id}
+              definition={definition}
+              selection={selection}/>
+          )}
+        </StyledActionsWrapper>
+        <InputEditTable/>
+      </StyledPanelWrapperRight>
+    </StyledPaneWrapper>
+  </>
 }
 
 InputEdit.propTypes = {
   selection: selectionPropType.propType.isRequired,
-  validation: PropTypes.shape({
-    valid: PropTypes.bool,
-    message: PropTypes.string
-  }).isRequired,
   handleNotifications: PropTypes.bool,
-  checkSelection: PropTypes.func.isRequired,
+  updateSelection: PropTypes.func.isRequired,
   initializeTable: PropTypes.func.isRequired,
   initializeSearch: PropTypes.func.isRequired,
   initializeInformation: PropTypes.func.isRequired,

--- a/packages/input-edit/src/components/InputEdit/InputEditContainer.js
+++ b/packages/input-edit/src/components/InputEdit/InputEditContainer.js
@@ -5,10 +5,10 @@ import InputEdit from './InputEdit'
 import {initializeTable} from '../../modules/inputEditTable/actions'
 import {initializeSearch} from '../../modules/inputEditSearch/actions'
 import {initializeInformation} from '../../modules/inputEditInformation/actions'
-import {checkSelection} from '../../modules/inputEdit/actions'
+import {updateSelection} from '../../modules/inputEdit/actions'
 
 const mapActionCreators = {
-  checkSelection,
+  updateSelection,
   initializeTable,
   initializeSearch,
   initializeInformation,
@@ -17,7 +17,6 @@ const mapActionCreators = {
 
 const mapStateToProps = state => ({
   selection: state.inputEdit.selection,
-  validation: state.inputEdit.validation,
   actionDefinitions: state.inputEditTable.actionDefinitions,
   handleNotifications: state.inputEdit.handleNotifications
 })

--- a/packages/input-edit/src/components/InputEditTable/InputEditTable.js
+++ b/packages/input-edit/src/components/InputEditTable/InputEditTable.js
@@ -110,6 +110,10 @@ const InputEditTable = ({
     }, []))
   }
 
+  if (columns.length === 0) {
+    return null
+  }
+
   return <StyledTableWrapper onKeyDown={arrowKeyHandler}>
     <Table
       dataLoadingInProgress={dataLoadingInProgress}

--- a/packages/input-edit/src/modules/inputEdit/actions.js
+++ b/packages/input-edit/src/modules/inputEdit/actions.js
@@ -1,6 +1,5 @@
 export const SET_SELECTION = 'inputEdit/SET_SELECTION'
-export const CHECK_SELECTION = 'inputEdit/CHECK_SELECTION'
-export const SET_VALIDATION = 'inputEdit/SET_VALIDATION'
+export const UPDATE_SELECTION = 'inputEdit/UPDATE_SELECTION'
 export const SET_HANDLE_NOTIFICATIONS = 'inputEdit/SET_HANDLE_NOTIFICATIONS'
 
 export const setSelection = selection => ({
@@ -8,14 +7,9 @@ export const setSelection = selection => ({
   payload: {selection}
 })
 
-export const checkSelection = () => ({
-  type: CHECK_SELECTION,
+export const updateSelection = () => ({
+  type: UPDATE_SELECTION,
   payload: {}
-})
-
-export const setValidation = validation => ({
-  type: SET_VALIDATION,
-  payload: {validation}
 })
 
 export const setHandleNotifications = handleNotifications => ({

--- a/packages/input-edit/src/modules/inputEdit/reducer.js
+++ b/packages/input-edit/src/modules/inputEdit/reducer.js
@@ -1,16 +1,14 @@
 import {reducer as reducerUtil} from 'tocco-util'
 
-import {SET_SELECTION, SET_VALIDATION, SET_HANDLE_NOTIFICATIONS} from './actions'
+import {SET_SELECTION, SET_HANDLE_NOTIFICATIONS} from './actions'
 
 const initialState = {
   selection: null,
-  validation: {},
   handleNotifications: false
 }
 
 const ACTION_HANDLERS = {
   [SET_SELECTION]: reducerUtil.singleTransferReducer('selection'),
-  [SET_VALIDATION]: reducerUtil.singleTransferReducer('validation'),
   [SET_HANDLE_NOTIFICATIONS]: reducerUtil.singleTransferReducer('handleNotifications')
 }
 

--- a/packages/input-edit/src/modules/inputEdit/sagas.js
+++ b/packages/input-edit/src/modules/inputEdit/sagas.js
@@ -1,14 +1,14 @@
 import {actions, actionEmitter, rest} from 'tocco-app-extensions'
 import {all, takeEvery, takeLatest, put, select, call} from 'redux-saga/effects'
 
-import {CHECK_SELECTION, setValidation} from './actions'
+import {UPDATE_SELECTION} from './actions'
 
 const inputEditSelector = state => state.inputEdit
 
 export default function* sagas() {
   yield all([
     takeEvery(actions.actions.ACTION_INVOKE, emit),
-    takeLatest(CHECK_SELECTION, checkSelection)
+    takeLatest(UPDATE_SELECTION, updateInputDatas)
   ])
 }
 
@@ -16,8 +16,7 @@ export function* emit(action) {
   yield put(actionEmitter.emitAction(action))
 }
 
-export function* checkSelection() {
+export function* updateInputDatas() {
   const {selection} = yield select(inputEditSelector)
-  const {body} = yield call(rest.requestSaga, 'inputEdit/selection', {method: 'POST', body: selection})
-  yield put(setValidation(body))
+  yield call(rest.requestSaga, 'inputEdit/update-input-datas', {method: 'POST', body: selection})
 }

--- a/packages/input-edit/src/modules/inputEditInformation/sagas.js
+++ b/packages/input-edit/src/modules/inputEditInformation/sagas.js
@@ -12,9 +12,7 @@ export default function* sagas() {
 }
 
 export function* initialize() {
-  const {selection, validation} = yield select(inputEditSelector)
-  if (validation.valid) {
-    const {body} = yield call(rest.requestSaga, 'inputEdit/information', {method: 'POST', body: selection})
-    yield put(actions.setInformation(body))
-  }
+  const {selection} = yield select(inputEditSelector)
+  const {body} = yield call(rest.requestSaga, 'inputEdit/information', {method: 'POST', body: selection})
+  yield put(actions.setInformation(body))
 }

--- a/packages/input-edit/src/modules/inputEditSearch/actions.js
+++ b/packages/input-edit/src/modules/inputEditSearch/actions.js
@@ -1,6 +1,7 @@
 export const INITIALIZE_SEARCH = 'inputEditSearch/INITIALIZE_SEARCH'
 export const SET_FORM = 'inputEditSearch/SET_FORM'
 export const SET_SEARCH_QUERIES = 'inputEditSearch/SET_SEARCH_QUERIES'
+export const SET_INITIALIZED = 'inputEditSearch/SET_INITIALIZED'
 
 export const initializeSearch = () => ({
   type: INITIALIZE_SEARCH
@@ -14,4 +15,11 @@ export const setForm = form => ({
 export const setSearchQueries = searchQueries => ({
   type: SET_SEARCH_QUERIES,
   payload: {searchQueries}
+})
+
+export const setInitialized = initialized => ({
+  type: SET_INITIALIZED,
+  payload: {
+    initialized
+  }
 })

--- a/packages/input-edit/src/modules/inputEditSearch/reducer.js
+++ b/packages/input-edit/src/modules/inputEditSearch/reducer.js
@@ -4,12 +4,14 @@ import * as actions from './actions'
 
 const initialState = {
   form: {},
+  initialized: false,
   searchQueries: []
 }
 
 const ACTION_HANDLERS = {
   [actions.SET_FORM]: reducerUtil.singleTransferReducer('form'),
-  [actions.SET_SEARCH_QUERIES]: reducerUtil.singleTransferReducer('searchQueries')
+  [actions.SET_SEARCH_QUERIES]: reducerUtil.singleTransferReducer('searchQueries'),
+  [actions.SET_INITIALIZED]: reducerUtil.singleTransferReducer('initialized')
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/input-edit/src/modules/inputEditSearch/sagas.js
+++ b/packages/input-edit/src/modules/inputEditSearch/sagas.js
@@ -15,11 +15,8 @@ export default function* sagas() {
 }
 
 export function* initialize() {
-  const {validation} = yield select(inputEditSelector)
-  if (validation.valid) {
-    const form = yield call(rest.fetchForm, 'Input_edit_data', 'search')
-    yield put(actions.setForm(form))
-  }
+  const form = yield call(rest.fetchForm, 'Input_edit_data', 'search')
+  yield put(actions.setForm(form))
 }
 
 export function* setSearchQueries({payload}) {

--- a/packages/input-edit/src/modules/inputEditSearch/sagas.js
+++ b/packages/input-edit/src/modules/inputEditSearch/sagas.js
@@ -5,6 +5,7 @@ import * as actions from '../inputEditSearch/actions'
 import {loadData} from '../inputEditTable/sagas'
 
 export const inputEditSelector = state => state.inputEdit
+export const inputEditSearchSelector = state => state.inputEditSearch
 
 export default function* sagas() {
   yield all([
@@ -22,5 +23,10 @@ export function* initialize() {
 }
 
 export function* setSearchQueries({payload}) {
-  yield call(loadData, {newSearchQueries: payload.searchQueries})
+  const {initialized} = yield select(inputEditSearchSelector)
+  if (initialized) {
+    yield call(loadData, {newSearchQueries: payload.searchQueries})
+  } else {
+    yield put(actions.setInitialized(true))
+  }
 }

--- a/packages/input-edit/src/modules/inputEditSearch/sagas.spec.js
+++ b/packages/input-edit/src/modules/inputEditSearch/sagas.spec.js
@@ -33,13 +33,25 @@ describe('input-edit', () => {
       })
 
       describe('setSearchQueries', () => {
-        test('should pass search queries to loadData', () => {
+        test('should pass search queries to loadData if initialized', () => {
           const expectedSearchQueries = []
           return expectSaga(sagas.setSearchQueries, {payload: {searchQueries: expectedSearchQueries}})
             .provide([
-              [matchers.call.fn(loadData)]
+              [matchers.call.fn(loadData)],
+              [select(sagas.inputEditSearchSelector), {initialized: true}]
             ])
             .call(loadData, {newSearchQueries: expectedSearchQueries})
+            .run()
+        })
+
+        test('should set initialized true on first call', () => {
+          const expectedSearchQueries = []
+          return expectSaga(sagas.setSearchQueries, {payload: {searchQueries: expectedSearchQueries}})
+            .provide([
+              [matchers.call.fn(loadData)],
+              [select(sagas.inputEditSearchSelector), {initialized: false}]
+            ])
+            .put(actions.setInitialized(true))
             .run()
         })
       })

--- a/packages/input-edit/src/modules/inputEditTable/sagas.js
+++ b/packages/input-edit/src/modules/inputEditTable/sagas.js
@@ -38,25 +38,23 @@ export function* processDataForm(dataForm) {
 
 export function* initialize() {
   yield put(actions.setDataLoadingInProgress(true))
-  const {selection, validation} = yield select(inputEditSelector)
-  if (validation.valid) {
-    const {actionProperties} = yield select(inputSelector)
-    const inputEditDataForm = actionProperties && actionProperties.inputEditDataForm
-      ? actionProperties.inputEditDataForm
-      : 'Input_edit_data'
-    const [editForm, dataForm] = yield all([
-      call(rest.requestSaga, 'inputEdit/form', {method: 'POST', body: selection}),
-      call(rest.fetchForm, inputEditDataForm, 'list')
-    ])
-    yield put(actions.setEditForm({inputEditForm: editForm.body}))
-    yield call(processDataForm, dataForm)
+  const {selection} = yield select(inputEditSelector)
+  const {actionProperties} = yield select(inputSelector)
+  const inputEditDataForm = actionProperties && actionProperties.inputEditDataForm
+    ? actionProperties.inputEditDataForm
+    : 'Input_edit_data'
+  const [editForm, dataForm] = yield all([
+    call(rest.requestSaga, 'inputEdit/form', {method: 'POST', body: selection}),
+    call(rest.fetchForm, inputEditDataForm, 'list')
+  ])
+  yield put(actions.setEditForm({inputEditForm: editForm.body}))
+  yield call(processDataForm, dataForm)
 
-    const {initialized: searchFormInitialized} = yield select(inputEditSearchSelector)
-    if (!searchFormInitialized) {
-      yield take(searchFormActions.SET_INITIALIZED)
-    }
-    yield call(loadData, {})
+  const {initialized: searchFormInitialized} = yield select(inputEditSearchSelector)
+  if (!searchFormInitialized) {
+    yield take(searchFormActions.SET_INITIALIZED)
   }
+  yield call(loadData, {})
 }
 
 export function* loadData({newSorting, newSearchQueries, newPage}) {

--- a/packages/input-edit/src/modules/inputEditTable/sagas.js
+++ b/packages/input-edit/src/modules/inputEditTable/sagas.js
@@ -1,13 +1,15 @@
-import {all, call, put, select, takeEvery, takeLatest} from 'redux-saga/effects'
+import {all, call, put, select, takeEvery, takeLatest, take} from 'redux-saga/effects'
 import {rest} from 'tocco-app-extensions'
 
 import * as actions from './actions'
 import {setTotalCount} from '../inputEditPagination/actions'
+import * as searchFormActions from '../inputEditSearch/actions'
 import {transformResponseData} from './utils'
 
 export const inputSelector = state => state.input
 export const inputEditSelector = state => state.inputEdit
 export const inputEditTableSelector = state => state.inputEditTable
+export const inputEditSearchSelector = state => state.inputEditSearch
 export const searchQueriesSelector = state => state.inputEditSearch.searchQueries
 export const inputEditPaginationSelector = state => state.inputEditPagination
 
@@ -35,6 +37,7 @@ export function* processDataForm(dataForm) {
 }
 
 export function* initialize() {
+  yield put(actions.setDataLoadingInProgress(true))
   const {selection, validation} = yield select(inputEditSelector)
   if (validation.valid) {
     const {actionProperties} = yield select(inputSelector)
@@ -47,6 +50,11 @@ export function* initialize() {
     ])
     yield put(actions.setEditForm({inputEditForm: editForm.body}))
     yield call(processDataForm, dataForm)
+
+    const {initialized: searchFormInitialized} = yield select(inputEditSearchSelector)
+    if (!searchFormInitialized) {
+      yield take(searchFormActions.SET_INITIALIZED)
+    }
     yield call(loadData, {})
   }
 }

--- a/packages/input-edit/src/modules/inputEditTable/sagas.spec.js
+++ b/packages/input-edit/src/modules/inputEditTable/sagas.spec.js
@@ -4,6 +4,7 @@ import {all, select, takeEvery, takeLatest} from 'redux-saga/effects'
 import {rest} from 'tocco-app-extensions'
 
 import * as actions from './actions'
+import * as searchActions from '../inputEditSearch/actions'
 import rootSaga, * as sagas from './sagas'
 import {transformResponseData} from './utils'
 
@@ -73,6 +74,7 @@ describe('input-edit', () => {
           return expectSaga(sagas.initialize)
             .provide([
               [select(sagas.inputSelector), {}],
+              [select(sagas.inputEditSearchSelector), {initialized: true}],
               [select(sagas.inputEditSelector), {selection: [12], validation: {valid: true}}],
               [matchers.call.fn(rest.requestSaga), {
                 body: expectedEditForm
@@ -102,6 +104,7 @@ describe('input-edit', () => {
                   inputEditDataForm: 'PublicInput_edit_data'
                 }
               }],
+              [select(sagas.inputEditSearchSelector), {initialized: false}],
               [select(sagas.inputEditSelector), {selection: [12], validation: {valid: true}}],
               [matchers.call.fn(rest.requestSaga), {
                 body: expectedEditForm
@@ -110,6 +113,7 @@ describe('input-edit', () => {
               [matchers.call.fn(rest.fetchForm), expectedDataForm],
               [matchers.call.fn(sagas.loadData), {}]
             ])
+            .dispatch(searchActions.initializeSearch(true))
             .call(rest.fetchForm, 'PublicInput_edit_data', 'list')
             .run()
         })


### PR DESCRIPTION
- load data only if search form is initialized and prevent loadData to be called twice initially
- return null if columns are empty to calm down loading process

Refs: TOCDEV-2429