### PR TITLE
feat(tocco-util): Allow caching of loaded async route component

### DIFF
--- a/packages/tocco-util/src/route/route.js
+++ b/packages/tocco-util/src/route/route.js
@@ -5,7 +5,14 @@ import sagaUtil from '../saga'
 import asyncRoute from './asyncRoute'
 import {dispatchInput} from './input'
 
-export const loadRoute = (store, input, importRouteDependencies) => props => {
+const loadedComponents = {}
+
+export const loadRoute = (store, input, importRouteDependencies, key) => props => {
+  if (key && loadedComponents[key]) {
+    const Component = loadedComponents[key]
+    return <Component {...props}/>
+  }
+
   const Component = asyncRoute(() =>
     new Promise(resolve => {
       importRouteDependencies().then(imported => {
@@ -35,6 +42,10 @@ export const loadRoute = (store, input, importRouteDependencies) => props => {
       })
     })
   )
+
+  if (key) {
+    loadedComponents[key] = Component
+  }
 
   return <Component {...props}/>
 }

--- a/packages/tocco-util/src/route/route.spec.js
+++ b/packages/tocco-util/src/route/route.spec.js
@@ -1,0 +1,111 @@
+import React from 'react'
+import {mount} from 'enzyme'
+
+import {loadRoute} from './route'
+
+describe('tocco-util', () => {
+  describe('route', () => {
+    describe('route', () => {
+      describe('loadRoute', () => {
+        const InnerComp = () => <div>test</div>
+        const InnerComp2 = () => <div>test</div>
+
+        test('should load and render component', done => {
+          const promise = Promise.resolve({
+            default: {
+              container: InnerComp
+            }
+          })
+
+          const Cmp = loadRoute(null, {}, () => promise)
+
+          const wrapper = mount(<Cmp/>)
+
+          setTimeout(() => {
+            wrapper.update()
+            expect(wrapper.find(InnerComp)).to.have.length(1)
+            done()
+          }, 0)
+        })
+
+        test('should return component class from cache if loaded with key', done => {
+          const promise1 = Promise.resolve({
+            default: {container: InnerComp}
+          })
+          const promise2 = Promise.resolve({
+            default: {container: InnerComp2}
+          })
+
+          const Cmp = loadRoute(null, {}, () => promise1, 'my-route')
+          const Cmp2 = loadRoute(null, {}, () => promise2, 'my-route')
+
+          const wrapper = mount(
+            <div>
+              <Cmp/>
+              <Cmp2/>
+            </div>
+          )
+
+          setTimeout(() => {
+            wrapper.update()
+            expect(wrapper.find(InnerComp)).to.have.length(2)
+            expect(wrapper.find(InnerComp2)).to.have.length(0)
+            done()
+          }, 0)
+        })
+
+        test('should not return component class from cache if loaded without key', done => {
+          const promise1 = Promise.resolve({
+            default: {container: InnerComp}
+          })
+          const promise2 = Promise.resolve({
+            default: {container: InnerComp2}
+          })
+
+          const Cmp = loadRoute(null, {}, () => promise1)
+          const Cmp2 = loadRoute(null, {}, () => promise2)
+
+          const wrapper = mount(
+            <div>
+              <Cmp/>
+              <Cmp2/>
+            </div>
+          )
+
+          setTimeout(() => {
+            wrapper.update()
+            expect(wrapper.find(InnerComp)).to.have.length(1)
+            expect(wrapper.find(InnerComp2)).to.have.length(1)
+            done()
+          }, 0)
+        })
+
+        test('should not return component class from cache if loaded with different key', done => {
+          const promise1 = Promise.resolve({
+            default: {container: InnerComp}
+          })
+          const promise2 = Promise.resolve({
+            default: {container: InnerComp2}
+          })
+
+          const Cmp = loadRoute(null, {}, () => promise1, 'my-route-1')
+          const Cmp2 = loadRoute(null, {}, () => promise2, 'my-route-2')
+
+          const wrapper = mount(
+            <div>
+              <Cmp/>
+              <Cmp2/>
+            </div>
+          )
+
+          setTimeout(() => {
+            wrapper.update()
+            expect(wrapper.find(InnerComp)).to.have.length(1)
+            expect(wrapper.find(InnerComp2)).to.have.length(1)
+            done()
+          }, 0)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
If caching of a route should be enabled, a key for the cache can be
passed to `loadRoute` as the 4th argument.

In this case the already loaded component will be returned which might
eliminate unnecessary rerenders of the same route.

Refs: TOCDEV-2560