### PR TITLE
DMS

### DIFF
--- a/packages/admin/src/components/Admin/Admin.js
+++ b/packages/admin/src/components/Admin/Admin.js
@@ -11,6 +11,7 @@ import {viewPersistor} from 'tocco-util'
 import Navigation from '../Navigation'
 import DashboardRoute from '../../routes/dashboard'
 import EntitiesRoute from '../../routes/entities'
+import DocsRoute from '../../routes/docs'
 import Settings from '../../routes/settings'
 import Header from '../Header'
 import {
@@ -87,6 +88,7 @@ const Admin = ({
             <Route exact={true} path="/dashboard" component={DashboardRoute}/>
             <Route path="/e" component={EntitiesRoute}/>
             <Route path="/s" component={Settings}/>
+            <Route path="/docs" component={DocsRoute}/>
             <Route render={({match}) => <Redirect to={`${match.url.replace(/\/$/, '')}/dashboard`}/>}/>
           </Switch>
         </StyledContent>

--- a/packages/admin/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/packages/admin/src/components/Breadcrumbs/Breadcrumbs.js
@@ -4,7 +4,7 @@ import {Icon, Typography} from 'tocco-ui'
 import {Helmet} from 'react-helmet'
 
 import {
-  StyledBreadcumbs,
+  StyledBreadcrumbs,
   StyledBreadcrumbsLink,
   StyledBreadcrumbsTitle
 } from './StyledBreadcrumbs'
@@ -16,7 +16,7 @@ const getTitle = breadcrumbsInfo =>
     .reverse()
     .join(' - ')
 
-const Breadcrumbs = ({breadcrumbsInfo, currentViewTitle}) => {
+const Breadcrumbs = ({pathPrefix, breadcrumbsInfo, currentViewTitle}) => {
   const breadcrumbs = [
     ...(breadcrumbsInfo || []),
     ...(currentViewTitle ? [{display: currentViewTitle}] : [])
@@ -24,7 +24,7 @@ const Breadcrumbs = ({breadcrumbsInfo, currentViewTitle}) => {
 
   if (breadcrumbs.length === 0) return null
 
-  return <StyledBreadcumbs>
+  return <StyledBreadcrumbs>
     <Helmet defer={false}>
       <title>{getTitle(breadcrumbsInfo)}</title>
     </Helmet>
@@ -36,7 +36,7 @@ const Breadcrumbs = ({breadcrumbsInfo, currentViewTitle}) => {
           <Comp
             neutral="true"
             {...(idx === breadcrumbs.length - 1 && {active: 'true'})}
-            to={`/e/${b.path}`}
+            to={`${pathPrefix}/${b.path}`}
           >
             {b.type === 'list' && <Icon icon="list-ul" />}  {display}
           </Comp>
@@ -48,10 +48,15 @@ const Breadcrumbs = ({breadcrumbsInfo, currentViewTitle}) => {
             curr]
         )}
     </div>
-  </StyledBreadcumbs>
+  </StyledBreadcrumbs>
+}
+
+Breadcrumbs.defaultProps = {
+  pathPrefix: ''
 }
 
 Breadcrumbs.propTypes = {
+  pathPrefix: PropTypes.string,
   match: PropTypes.object,
   breadcrumbsInfo: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/admin/src/components/Breadcrumbs/StyledBreadcrumbs.js
+++ b/packages/admin/src/components/Breadcrumbs/StyledBreadcrumbs.js
@@ -2,9 +2,9 @@
 import styled from 'styled-components'
 import {theme} from 'tocco-ui'
 
-import {StyledLink} from '../../../../components/StyledLink'
+import {StyledLink} from '../StyledLink'
 
-export const StyledBreadcumbs = styled.div`
+export const StyledBreadcrumbs = styled.div`
   background-color: ${theme.color('backgroundBreadcrumbs')};
   width: 100%;
   padding: .8rem 1.7rem;

--- a/packages/admin/src/components/Breadcrumbs/index.js
+++ b/packages/admin/src/components/Breadcrumbs/index.js
@@ -1,0 +1,1 @@
+export {default} from './Breadcrumbs'

--- a/packages/admin/src/routes/docs/components/DocsRoute/DocsRoute.js
+++ b/packages/admin/src/routes/docs/components/DocsRoute/DocsRoute.js
@@ -1,0 +1,87 @@
+import React, {useEffect, useReducer} from 'react'
+import PropTypes from 'prop-types'
+import {Route, Switch} from 'react-router-dom'
+import styled from 'styled-components'
+import {StyledScrollbar, scale} from 'tocco-ui'
+
+import DocsView from '../DocsView'
+import DocumentView from '../DocumentView'
+import Breadcrumbs from '../../containers/BreadcrumbsContainer'
+
+const StyledWrapper = styled.div`
+  display: grid;
+  grid-template-rows: auto  1fr;
+  grid-template-areas:
+    'breadcrumbs'
+    'content';
+  height: 100%;
+  width: 100%;
+`
+
+const StyledContent = styled.div`
+  grid-area: content;
+  overflow-x: hidden;
+  padding-right: ${scale.space(-1)};
+  ${StyledScrollbar}
+`
+
+const StyledBreadcrumbs = styled.div`
+  grid-area: breadcrumbs;
+`
+
+const DocsRoute = ({history, searchMode, setSearchMode, loadBreadcrumbs}) => {
+  // eslint-disable-next-line no-unused-vars
+  const [docsViewNumber, forceDocsViewUpdate] = useReducer(x => x + 1, 0)
+
+  useEffect(() => {
+    if (searchMode === true && history.location.pathname === '/docs/') {
+      // this means the user clicked on the root item in the breadcrumbs navigation
+      // -> reset search mode to false and rerender the <DocsView>
+      setSearchMode(false)
+      forceDocsViewUpdate()
+    }
+
+    loadBreadcrumbs(history.location.pathname)
+  })
+
+  const handleSearchChange = e => {
+    setSearchMode(e.query && e.query.hasUserChanges)
+  }
+
+  return (
+    <StyledWrapper>
+      <StyledBreadcrumbs>
+        <Breadcrumbs/>
+      </StyledBreadcrumbs>
+      <StyledContent>
+        <Switch>
+          <Route
+            exact
+            path={'/docs/doc/:key/detail'}
+            component={DocumentView}
+          />
+          <Route
+            exact
+            path={['/docs/:model/:key/list', '/docs', '/docs/search']}
+            render={({match}) => (
+              <DocsView
+                key={`docs-view-${docsViewNumber}`}
+                history={history}
+                match={match}
+                onSearchChange={handleSearchChange}
+              />)}
+          />
+        </Switch>
+      </StyledContent>
+    </StyledWrapper>
+  )
+}
+
+DocsRoute.propTypes = {
+  loadBreadcrumbs: PropTypes.func.isRequired,
+  setSearchMode: PropTypes.func.isRequired,
+  history: PropTypes.object.isRequired,
+  searchMode: PropTypes.bool.isRequired
+}
+
+export default DocsRoute

--- a/packages/admin/src/routes/docs/components/DocsRoute/DocsRouteContainer.js
+++ b/packages/admin/src/routes/docs/components/DocsRoute/DocsRouteContainer.js
@@ -1,0 +1,17 @@
+import {connect} from 'react-redux'
+import {injectIntl} from 'react-intl'
+import {hot} from 'react-hot-loader/root'
+
+import DocsRoute from './DocsRoute'
+import {loadBreadcrumbs, setSearchMode} from '../../modules/path/actions'
+
+const mapStateToProps = state => ({
+  searchMode: state.docs.path.searchMode
+})
+
+const mapActionCreators = {
+  loadBreadcrumbs,
+  setSearchMode
+}
+
+export default hot(connect(mapStateToProps, mapActionCreators)(injectIntl(DocsRoute)))

--- a/packages/admin/src/routes/docs/components/DocsRoute/index.js
+++ b/packages/admin/src/routes/docs/components/DocsRoute/index.js
@@ -1,0 +1,1 @@
+export {default} from './DocsRouteContainer'

--- a/packages/admin/src/routes/docs/components/DocsView/DocsView.js
+++ b/packages/admin/src/routes/docs/components/DocsView/DocsView.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import EntityListApp from 'tocco-entity-list/src/main'
+
+const getParent = match => {
+  if (match.params && match.params.model) {
+    const model = match.params.model.charAt(0).toUpperCase() + match.params.model.slice(1)
+    const key = match.params.key
+    const fullKey = `${model}/${key}`
+    return {
+      model: 'Docs_list_item',
+      key: fullKey // e.g. "Domain/118"
+    }
+  }
+  return null
+}
+
+const DocsView = props => {
+  const {history, match, onSearchChange} = props
+
+  const handleRowClick = ({id}) => {
+    const [model, key] = id.split('/')
+    let newLocation
+    switch (model) {
+      case 'Domain':
+        newLocation = `/docs/domain/${key}/list`
+        break
+      case 'Folder':
+        newLocation = `/docs/folder/${key}/list`
+        break
+      case 'Resource':
+        newLocation = `/docs/doc/${key}/detail`
+        break
+      default:
+        throw new Error(`Unexpected model: ${model}`)
+    }
+    history.push(newLocation)
+  }
+
+  const handleSearchChange = e => {
+    const path = e.query.hasUserChanges ? '/docs/search' : match.url
+    history.push(path)
+    onSearchChange(e)
+  }
+
+  const parent = getParent(match)
+
+  return (
+    <EntityListApp
+      id="documents"
+      entityName="Docs_list_item"
+      formName="Docs_list_item"
+      onRowClick={handleRowClick}
+      searchFormPosition="left"
+      searchFormType="admin"
+      parent={parent}
+      onSearchChange={handleSearchChange}
+    />
+  )
+}
+
+DocsView.propTypes = {
+  match: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+  onSearchChange: PropTypes.func.isRequired
+}
+
+export default DocsView

--- a/packages/admin/src/routes/docs/components/DocsView/index.js
+++ b/packages/admin/src/routes/docs/components/DocsView/index.js
@@ -1,0 +1,1 @@
+export {default} from './DocsView'

--- a/packages/admin/src/routes/docs/components/DocumentView/DocumentView.js
+++ b/packages/admin/src/routes/docs/components/DocumentView/DocumentView.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import EntityDetailApp from 'tocco-entity-detail/src/main'
+
+const DocumentView = props => (
+  <EntityDetailApp
+    entityName="Resource"
+    entityId={props.match.params.key}
+    formName="Resource"
+    mode="update"
+  />
+)
+
+DocumentView.propTypes = {
+  match: PropTypes.object.isRequired,
+  history: PropTypes.object
+}
+
+export default DocumentView

--- a/packages/admin/src/routes/docs/components/DocumentView/index.js
+++ b/packages/admin/src/routes/docs/components/DocumentView/index.js
@@ -1,0 +1,1 @@
+export {default} from './DocumentView'

--- a/packages/admin/src/routes/docs/containers/BreadcrumbsContainer.js
+++ b/packages/admin/src/routes/docs/containers/BreadcrumbsContainer.js
@@ -1,0 +1,14 @@
+import {connect} from 'react-redux'
+import {injectIntl} from 'react-intl'
+
+import Breadcrumbs from '../../../components/Breadcrumbs'
+
+const mapActionCreators = {
+}
+
+const mapStateToProps = state => ({
+  pathPrefix: '/docs',
+  breadcrumbsInfo: state.docs.path.breadcrumbs
+})
+
+export default connect(mapStateToProps, mapActionCreators)(injectIntl(Breadcrumbs))

--- a/packages/admin/src/routes/docs/index.js
+++ b/packages/admin/src/routes/docs/index.js
@@ -1,0 +1,13 @@
+import {route} from 'tocco-util'
+import React, {useMemo} from 'react'
+import {useStore} from 'react-redux'
+
+const Route = props => {
+  const store = useStore()
+  const Component = useMemo(() => {
+    return route.loadRoute(store, {}, () => (import('./route')), 'docs')
+  }, [])
+  return <Component {...props}/>
+}
+
+export default Route

--- a/packages/admin/src/routes/docs/modules/path/actions.js
+++ b/packages/admin/src/routes/docs/modules/path/actions.js
@@ -1,0 +1,24 @@
+export const LOAD_BREADCRUMBS = 'docs/path/LOAD_BREADCRUMBS'
+export const SET_BREADCRUMBS = 'docs/path/SET_BREADCRUMBS'
+export const SET_SEARCH_MODE = 'docs/path/SET_SEARCH_MODE'
+
+export const loadBreadcrumbs = location => ({
+  type: LOAD_BREADCRUMBS,
+  payload: {
+    location
+  }
+})
+
+export const setBreadcrumbs = breadcrumbs => ({
+  type: SET_BREADCRUMBS,
+  payload: {
+    breadcrumbs
+  }
+})
+
+export const setSearchMode = searchMode => ({
+  type: SET_SEARCH_MODE,
+  payload: {
+    searchMode
+  }
+})

--- a/packages/admin/src/routes/docs/modules/path/index.js
+++ b/packages/admin/src/routes/docs/modules/path/index.js
@@ -1,0 +1,12 @@
+import {fork, all} from 'redux-saga/effects'
+
+import moduleSagas from './sagas'
+import reducer from './reducer'
+
+export function* sagas() {
+  yield all([
+    fork(moduleSagas)
+  ])
+}
+
+export default reducer

--- a/packages/admin/src/routes/docs/modules/path/reducer.js
+++ b/packages/admin/src/routes/docs/modules/path/reducer.js
@@ -1,0 +1,18 @@
+import {reducer as reducerUtil} from 'tocco-util'
+
+import * as actions from './actions'
+
+const ACTION_HANDLERS = {
+  [actions.SET_BREADCRUMBS]: reducerUtil.singleTransferReducer('breadcrumbs'),
+  [actions.SET_SEARCH_MODE]: reducerUtil.singleTransferReducer('searchMode')
+}
+
+const initialState = {
+  breadcrumbs: [],
+  searchMode: false
+}
+
+export default function reducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+  return handler ? handler(state, action) : state
+}

--- a/packages/admin/src/routes/docs/modules/path/reducer.spec.js
+++ b/packages/admin/src/routes/docs/modules/path/reducer.spec.js
@@ -1,0 +1,42 @@
+import reducer from './reducer'
+import * as actions from './actions'
+
+const INITIAL_STATE = {
+  breadcrumbs: [],
+  searchMode: false
+}
+
+describe('admin', () => {
+  describe('routes', () => {
+    describe('docs', () => {
+      describe('modules', () => {
+        describe('path', () => {
+          describe('reducer', () => {
+            test('should create a valid initial state', () => {
+              expect(reducer(undefined, {})).to.deep.equal(INITIAL_STATE)
+            })
+
+            test('should handle SET_BREADCRUMBS action', () => {
+              const breadcrumbs = [{display: 'item 1'}, {display: 'item 2'}]
+              const expectedStateAfter = {
+                ...INITIAL_STATE,
+                breadcrumbs
+              }
+
+              expect(reducer(INITIAL_STATE, actions.setBreadcrumbs(breadcrumbs))).to.deep.equal(expectedStateAfter)
+            })
+
+            test('should handle SET_SEARCH_MODE action', () => {
+              const expectedStateAfter = {
+                ...INITIAL_STATE,
+                searchMode: true
+              }
+
+              expect(reducer(INITIAL_STATE, actions.setSearchMode(true))).to.deep.equal(expectedStateAfter)
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/admin/src/routes/docs/modules/path/sagas.js
+++ b/packages/admin/src/routes/docs/modules/path/sagas.js
@@ -1,0 +1,74 @@
+import {rest} from 'tocco-app-extensions'
+import {takeLatest, all, call, put, select} from 'redux-saga/effects'
+
+import * as actions from './actions'
+
+export const textResourceSelector = (state, key) => state.intl.messages[key] || key
+export const docsPathSelector = state => state.docs.path
+
+const DOC_PATH_REGEX = /^\/docs\/doc\/(\d+)\/detail$/
+const PARENT_PATH_REGEX = /^\/docs\/(domain|folder)\/(\d+)\/list$/
+
+export const getResourceNode = pathname => {
+  const docMatches = DOC_PATH_REGEX.exec(pathname)
+  return docMatches && docMatches.length >= 2 ? {
+    model: 'Resource',
+    key: docMatches[1]
+  } : null
+}
+
+export const getParentNode = pathname => {
+  const parentMatches = PARENT_PATH_REGEX.exec(pathname)
+  if (parentMatches && parentMatches.length >= 3) {
+    const model = parentMatches[1].charAt(0).toUpperCase() + parentMatches[1].slice(1)
+    const key = parentMatches[2]
+    return {
+      model,
+      key
+    }
+  }
+  return null
+}
+
+export const getNode = pathname => {
+  let node = getResourceNode(pathname)
+  if (!node) {
+    node = getParentNode(pathname)
+  }
+  return node
+}
+
+export function* getSearchBreadcrumbs() {
+  return [{
+    display: yield select(textResourceSelector, 'client.admin.docs.breadcrumbs.start'),
+    path: '',
+    type: 'list'
+  }, {
+    display: yield select(textResourceSelector, 'client.admin.breadcrumbs.searchResults'),
+    path: '',
+    type: 'list'
+  }]
+}
+
+export function* loadBreadcrumbs({payload: {location}}) {
+  const node = getNode(location)
+  const pathState = yield select(docsPathSelector)
+
+  let breadcrumbs
+
+  if (pathState.searchMode && (!node || node.model !== 'Resource')) {
+    breadcrumbs = yield call(getSearchBreadcrumbs)
+  } else {
+    const url = node ? `documents/${node.model}/${node.key}/breadcrumbs` : 'documents/breadcrumbs'
+    const result = yield call(rest.requestSaga, url)
+    breadcrumbs = result.body.breadcrumbs
+  }
+
+  yield put(actions.setBreadcrumbs(breadcrumbs))
+}
+
+export default function* mainSagas() {
+  yield all([
+    takeLatest(actions.LOAD_BREADCRUMBS, loadBreadcrumbs)
+  ])
+}

--- a/packages/admin/src/routes/docs/modules/path/sagas.spec.js
+++ b/packages/admin/src/routes/docs/modules/path/sagas.spec.js
@@ -1,0 +1,83 @@
+import {expectSaga, testSaga} from 'redux-saga-test-plan'
+import {select, call, takeLatest} from 'redux-saga/effects'
+import {rest} from 'tocco-app-extensions'
+
+import * as sagas from './sagas'
+import * as actions from './actions'
+
+describe('admin', () => {
+  describe('routes', () => {
+    describe('docs', () => {
+      describe('modules', () => {
+        describe('path', () => {
+          describe('sagas', () => {
+            describe('main saga', () => {
+              test('should fork sagas', () => {
+                const saga = testSaga(sagas.default)
+                saga.next().all([
+                  takeLatest(actions.LOAD_BREADCRUMBS, sagas.loadBreadcrumbs)
+                ])
+              })
+            })
+
+            describe('loadBreadcrumbs', () => {
+              test('should load root breadcrumbs', () => {
+                const pathname = '/docs'
+                const breadcrumbs = [{display: 'root'}]
+
+                return expectSaga(sagas.loadBreadcrumbs, actions.loadBreadcrumbs(pathname))
+                  .provide([
+                    [select(sagas.docsPathSelector), {}],
+                    [call(rest.requestSaga, 'documents/breadcrumbs'), {
+                      body: {breadcrumbs}
+                    }]
+                  ])
+                  .put(actions.setBreadcrumbs(breadcrumbs))
+                  .run()
+              })
+
+              test('should load breadcrumbs of node', () => {
+                const pathname = '/docs/folder/45/list'
+                const breadcrumbs = [{display: 'root'}, {display: 'item 1'}, {display: 'item 2'}]
+
+                return expectSaga(sagas.loadBreadcrumbs, actions.loadBreadcrumbs(pathname))
+                  .provide([
+                    [select(sagas.docsPathSelector), {}],
+                    [call(rest.requestSaga, 'documents/Folder/45/breadcrumbs'), {
+                      body: {breadcrumbs}
+                    }]
+                  ])
+                  .put(actions.setBreadcrumbs(breadcrumbs))
+                  .run()
+              })
+
+              test('should load search breadcrumbs', () => {
+                const pathname = '/docs/folder/45/list'
+                const breadcrumbs = [{
+                  display: 'Dokument',
+                  path: '',
+                  type: 'list'
+                }, {
+                  display: 'Suchresultate',
+                  path: '',
+                  type: 'list'
+                }]
+
+                return expectSaga(sagas.loadBreadcrumbs, actions.loadBreadcrumbs(pathname))
+                  .provide([
+                    [select(sagas.docsPathSelector), {
+                      searchMode: true
+                    }],
+                    [select(sagas.textResourceSelector, 'client.admin.docs.breadcrumbs.start'), 'Dokument'],
+                    [select(sagas.textResourceSelector, 'client.admin.breadcrumbs.searchResults'), 'Suchresultate']
+                  ])
+                  .put(actions.setBreadcrumbs(breadcrumbs))
+                  .run()
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/admin/src/routes/docs/route.js
+++ b/packages/admin/src/routes/docs/route.js
@@ -1,0 +1,13 @@
+import {combineReducers} from 'redux'
+
+import DocsRoute from './components/DocsRoute'
+import path from './modules/path'
+import sagas from './modules/path/sagas'
+
+export default {
+  container: DocsRoute,
+  reducers: {
+    docs: combineReducers({path})
+  },
+  sagas: [sagas]
+}

--- a/packages/admin/src/routes/entities/components/Action/LazyAction.js
+++ b/packages/admin/src/routes/entities/components/Action/LazyAction.js
@@ -10,7 +10,8 @@ const actions = {
   'input-edit': lazy(() => import(/* webpackChunkName: "actions" */'./actions/InputEdit')),
   'resourcescheduler': lazy(() => import(/* webpackChunkName: "actions" */'./actions/ResourceScheduler')),
   'show-output-jobs-action': lazy(() => import(/* webpackChunkName: "actions" */'./actions/ShowOutputJobsAction')),
-  'delete': lazy(() => import(/* webpackChunkName: "actions" */'./actions/Delete'))
+  'delete': lazy(() => import(/* webpackChunkName: "actions" */'./actions/Delete')),
+  'documents': lazy(() => import(/* webpackChunkName: "actions" */'./actions/Documents'))
 }
 
 const renderLoader = () => <LoadMask/>

--- a/packages/admin/src/routes/entities/components/Action/actions/Documents.js
+++ b/packages/admin/src/routes/entities/components/Action/actions/Documents.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import {Redirect} from 'react-router-dom'
+
+const Documents = () => <Redirect to={{pathname: '/docs'}}/>
+
+export default Documents

--- a/packages/admin/src/routes/entities/components/Breadcrumbs/BreadcrumbsContainer.js
+++ b/packages/admin/src/routes/entities/components/Breadcrumbs/BreadcrumbsContainer.js
@@ -1,13 +1,14 @@
 import {connect} from 'react-redux'
 import {injectIntl} from 'react-intl'
 
-import Breadcrumbs from './Breadcrumbs'
+import Breadcrumbs from '../../../../components/Breadcrumbs'
 
 const mapActionCreators = {
 
 }
 
 const mapStateToProps = (state, props) => ({
+  pathPrefix: '/e',
   breadcrumbsInfo: state.entities.path.breadcrumbsInfo,
   currentViewTitle: state.entities.path.currentViewTitle
 })

--- a/packages/entity-list/README.md
+++ b/packages/entity-list/README.md
@@ -41,3 +41,4 @@ React-registry name: `entity-list`
 | `onNavigateToAction`| `definition` (action definition), `selection`(selection object) | Is called when an action is called with the fullscreen flag.
 | `onSelectChange`    | An array containing the ids of the new selection | This event is fired when the selection changes
 | `onStoreCreate`     | The created store | This event is fired when the store for the app is created. Note that the event will neved be fired if a store is passed to the app via the `store` input property.
+| `onSearchChange`    | The search params | This event is fired when the search is changed

--- a/packages/entity-list/src/input.js
+++ b/packages/entity-list/src/input.js
@@ -17,7 +17,7 @@ import {
 } from './modules/list/actions'
 import {setSelection} from './modules/selection/actions'
 
-const isDefined = value => !(value === undefined || value === null)
+const isDefined = value => value !== undefined
 
 export const getDispatchActions = (input, init) =>
   actionSettings.reduce((acc, actionSetting) => {

--- a/packages/entity-list/src/main.js
+++ b/packages/entity-list/src/main.js
@@ -31,7 +31,8 @@ const EXTERNAL_EVENTS = [
   'onNavigateToAction',
   'emitAction',
   'onSelectChange',
-  'onStoreCreate'
+  'onStoreCreate',
+  'onSearchChange'
 ]
 
 const initApp = (id, input, events = {}, publicPath) => {

--- a/packages/entity-list/src/modules/list/actions.js
+++ b/packages/entity-list/src/modules/list/actions.js
@@ -22,6 +22,7 @@ export const NAVIGATE_TO_CREATE = 'entityList/NAVIGATE_TO_CREATE'
 export const SET_FORM_SELECTABLE = 'list/SET_FORM_SELECTABLE'
 export const SET_FORM_CLICKABLE = 'list/SET_FORM_CLICKABLE'
 export const SET_ENDPOINT = 'list/SET_ENDPOINT'
+export const SET_SEARCH_ENDPOINT = 'list/SET_SEARCH_ENDPOINT'
 export const SET_CONSTRICTION = 'list/SET_CONSTRICTION'
 export const QUERY_CHANGED = 'list/QUERY_CHANGED'
 export const SET_SHOW_LINK = 'list/SET_SHOW_LINK'
@@ -177,6 +178,13 @@ export const setEndpoint = endpoint => ({
   type: SET_ENDPOINT,
   payload: {
     endpoint
+  }
+})
+
+export const setSearchEndpoint = searchEndpoint => ({
+  type: SET_SEARCH_ENDPOINT,
+  payload: {
+    searchEndpoint
   }
 })
 

--- a/packages/entity-list/src/modules/list/reducer.js
+++ b/packages/entity-list/src/modules/list/reducer.js
@@ -69,6 +69,7 @@ const ACTION_HANDLERS = {
   [actions.SET_FORM_SELECTABLE]: reducerUtil.singleTransferReducer('formSelectable'),
   [actions.SET_FORM_CLICKABLE]: reducerUtil.singleTransferReducer('formClickable'),
   [actions.SET_ENDPOINT]: reducerUtil.singleTransferReducer('endpoint'),
+  [actions.SET_SEARCH_ENDPOINT]: reducerUtil.singleTransferReducer('searchEndpoint'),
   [actions.SET_CONSTRICTION]: reducerUtil.singleTransferReducer('constriction'),
   [actions.SET_SHOW_LINK]: reducerUtil.singleTransferReducer('showLink')
 
@@ -93,6 +94,7 @@ const initialState = {
   showLink: false,
   lazyData: {},
   endpoint: null,
+  searchEndpoint: null,
   constriction: null
 }
 

--- a/packages/entity-list/src/modules/list/reducer.spec.js
+++ b/packages/entity-list/src/modules/list/reducer.spec.js
@@ -20,6 +20,7 @@ const EXPECTED_INITIAL_STATE = {
   showLink: false,
   lazyData: {},
   endpoint: null,
+  searchEndpoint: null,
   constriction: null
 }
 
@@ -313,6 +314,20 @@ describe('entity-list', () => {
 
           expect(reducer(expectedStateAfter, actions.setSortingInteractive('firstname', true)))
             .to.deep.equal(expectedStateAfter2)
+        })
+
+        test('should handle SET_SEARCH_ENDPOINT', () => {
+          const newSearchEndpoint = '/foo/bar'
+
+          const stateBefore = {
+            searchEndpoint: null
+          }
+
+          const expectedStateAfter = {
+            searchEndpoint: newSearchEndpoint
+          }
+
+          expect(reducer(stateBefore, actions.setSearchEndpoint(newSearchEndpoint))).to.deep.equal(expectedStateAfter)
         })
       })
     })

--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -75,6 +75,7 @@ export function* initialize() {
 export function* queryChanged() {
   const query = yield call(getBasicQuery)
   yield put(selectionActions.setQuery(query))
+  yield put(externalEvents.fireExternalEvent('onSearchChange', {query: query}))
 }
 
 export function* loadData(page) {

--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -9,6 +9,7 @@ import {getFetchOptionsFromSearchForm} from '../../util/api/fetchOptions'
 import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
 import * as selectionActions from '../selection/actions'
+import * as entityListActions from '../entityList/actions'
 import {getSearchFormValues} from '../searchForm/sagas'
 import {getSorting, getSelectable, getClickable, getEndpoint, getConstriction, getFields} from '../../util/api/forms'
 import {entitiesListTransformer} from '../../util/api/entities'
@@ -35,6 +36,7 @@ export default function* sagas() {
     takeLatest(actions.NAVIGATE_TO_ACTION, navigateToAction),
     takeLatest(selectionActions.RELOAD_DATA, loadData, 1),
     takeLatest(actions.ON_ROW_CLICK, onRowClick),
+    takeLatest(entityListActions.SET_PARENT, setParent),
     takeEvery(remoteEvents.REMOTE_EVENT, remoteEvent)
   ])
 }
@@ -115,8 +117,9 @@ export function* getBasicQuery(regardSelection = true) {
 }
 
 export function* prepareEndpointUrl(endpoint) {
-  const {parent} = yield select(inputSelector)
-  return parent ? endpoint.replace('{parentKey}', parent.key) : endpoint
+  const {parent} = yield select(entityListSelector)
+  const parentKey = parent ? parent.key : ''
+  return parent ? endpoint.replace('{parentKey}', parentKey) : endpoint
 }
 
 export function* countEntities() {
@@ -149,6 +152,10 @@ export function* changePage({payload}) {
   yield put(actions.setCurrentPage(page))
   yield call(requestEntities, page)
   yield put(actions.setInProgress(false))
+}
+
+export function* setParent() {
+  yield call(reloadData)
 }
 
 export function* reloadData() {

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -7,6 +7,7 @@ import {api} from 'tocco-util'
 import * as actions from './actions'
 import * as searchFormActions from '../searchForm/actions'
 import * as selectionActions from '../selection/actions'
+import * as entityListActions from '../entityList/actions'
 import rootSaga, * as sagas from './sagas'
 import {getSorting, getSelectable, getClickable, getFields, getEndpoint, getConstriction} from '../../util/api/forms'
 import {getSearchFormValues} from '../searchForm/sagas'
@@ -41,6 +42,7 @@ describe('entity-list', () => {
               takeLatest(actions.NAVIGATE_TO_ACTION, sagas.navigateToAction),
               takeLatest(selectionActions.RELOAD_DATA, sagas.loadData, 1),
               takeLatest(actions.ON_ROW_CLICK, sagas.onRowClick),
+              takeLatest(entityListActions.SET_PARENT, sagas.setParent),
               takeEvery(remoteEvents.REMOTE_EVENT, sagas.remoteEvent)
             ]))
             expect(generator.next().done).to.be.true
@@ -336,6 +338,7 @@ describe('entity-list', () => {
                 [select(sagas.selectionSelector), {showSelectedRecords}],
                 [select(sagas.inputSelector), {entityName}],
                 [select(sagas.listSelector), {endpoint}],
+                [select(sagas.entityListSelector), {}],
                 [matchers.call.fn(sagas.getBasicQuery), {}],
                 [matchers.call.fn(rest.fetchEntityCount), entityCount]
               ])
@@ -357,6 +360,7 @@ describe('entity-list', () => {
                 [select(sagas.selectionSelector), {showSelectedRecords, selection}],
                 [select(sagas.inputSelector), {entityName}],
                 [select(sagas.listSelector), {endpoint}],
+                [select(sagas.entityListSelector), {}],
                 [matchers.call.fn(sagas.getBasicQuery), {}],
                 [matchers.call.fn(rest.fetchEntityCount), entityCount]
               ])
@@ -471,25 +475,25 @@ describe('entity-list', () => {
 
         describe('prepareEndpointUrl', () => {
           test('should replace parentKey if parent exists', () => {
-            const input = {parent: {key: 123}}
+            const entityList = {parent: {key: 123}}
             const endpoint = 'nice2/rest/entities/2.0/User/{parentKey}/test'
             const expectedResult = 'nice2/rest/entities/2.0/User/123/test'
 
             return expectSaga(sagas.prepareEndpointUrl, endpoint)
               .provide([
-                [select(sagas.inputSelector), input]
+                [select(sagas.entityListSelector), entityList]
               ])
               .returns(expectedResult)
               .run()
           })
 
           test('should return endpoint as it is if parent is undefined', () => {
-            const input = {parent: null}
+            const entityList = {parent: null}
             const endpoint = 'nice2/rest/entities/2.0/User/{parentKey}/test'
 
             return expectSaga(sagas.prepareEndpointUrl, endpoint)
               .provide([
-                [select(sagas.inputSelector), input]
+                [select(sagas.entityListSelector), entityList]
               ])
               .returns(endpoint)
               .run()

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -838,6 +838,20 @@ describe('entity-list', () => {
               .run()
           })
         })
+
+        describe('queryChanged saga', () => {
+          test('should set query and call external event onSearchChange', () => {
+            const query = {tql: 'firstname == "Max"'}
+
+            return expectSaga(sagas.queryChanged)
+              .provide([
+                [call(sagas.getBasicQuery), query]
+              ])
+              .put(selectionActions.setQuery(query))
+              .put(externalEvents.fireExternalEvent('onSearchChange', {query}))
+              .run()
+          })
+        })
       })
     })
   })

--- a/packages/entity-list/src/util/api/forms.js
+++ b/packages/entity-list/src/util/api/forms.js
@@ -30,6 +30,11 @@ export const getEndpoint = formDefinition => {
   return table.endpoint || null
 }
 
+export const getSearchEndpoint = formDefinition => {
+  const table = getTable(formDefinition)
+  return table.searchEndpoint || null
+}
+
 export const getConstriction = formDefinition => {
   const table = getTable(formDefinition)
   return table.constriction || null

--- a/packages/entity-list/src/util/api/forms.spec.js
+++ b/packages/entity-list/src/util/api/forms.spec.js
@@ -382,6 +382,32 @@ describe('entity-list', () => {
           })
         })
 
+        describe('getSearchEndpoint', () => {
+          const getFormDefinition = searchEndpoint => ({
+            children: [{
+              layoutType: 'table',
+              componentType: 'table',
+              ...(searchEndpoint !== null ? {searchEndpoint} : {})
+            }]
+          })
+
+          test('should return search endpoint', () => {
+            const searchEndpoint = 'nice2/rest/xc'
+            const result = forms.getSearchEndpoint(getFormDefinition(searchEndpoint))
+            expect(result).to.eql(searchEndpoint)
+          })
+
+          test('should return null if search endpoint is not defined', () => {
+            const result = forms.getSearchEndpoint(getFormDefinition(null))
+            expect(result).to.be.null
+          })
+
+          test('should return null if search endpoint is empty', () => {
+            const result = forms.getSearchEndpoint(getFormDefinition(''))
+            expect(result).to.be.null
+          })
+        })
+
         describe('getConstriction', () => {
           const getFormDefinition = constriction => ({
             children: [{


### PR DESCRIPTION
It was already possible to set the initial parent of the entity list
via the `parent` input argument.

However, when the entity-list was rerendered with a different parent,
this change was ignored.

To take these changes into account, we use the parent from the
`entityList` state which contains the updated input argument to
determine the REST endpoint and we also call the `reloadData` saga
whenever the parent is updated.

We also have to consider `null` as a defined value in input.js,
otherwise it's not possible to reset the current parent to null.

Refs: TOCDEV-2560