### PR TITLE
refactor(tocco-ui): change link color

### DIFF
--- a/packages/tocco-ui/src/Typography/styledTypography.js
+++ b/packages/tocco-ui/src/Typography/styledTypography.js
@@ -17,17 +17,17 @@ export const declareTypograhpy = (props, mode) => {
     line-height: ${theme.lineHeight('regular')(props)};
 
     a {
-      color: ${theme.color('primary')(props)};
+      color: ${theme.color('secondary')(props)};
       text-decoration: none;
 
       &:hover,
       &:focus {
-        color: ${props => shadeColor(_get(props.theme, 'colors.primary'), 1)}
+        color: ${shadeColor(_get(props.theme, 'colors.secondary'), 1)};
         text-decoration: underline;
       }
 
       &:active {
-        color: ${props => shadeColor(_get(props.theme, 'colors.primary'), 2)}
+        color: ${shadeColor(_get(props.theme, 'colors.secondary'), 2)};
       }
     }
 


### PR DESCRIPTION
Refs: TOCDEV-2821
Changelog: Change typography link color to secondary (blue)