### PR TITLE
fix(scheduler): improve querySelector with boundary

### DIFF
--- a/packages/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -82,7 +82,7 @@ const FullCalendar = ({
   }, [JSON.stringify(resources)])
 
   const addDeselectAllButton = () => {
-    const firstHeaderNode = document.querySelectorAll('.fc-widget-header')[0]
+    const firstHeaderNode = wrapperEl.current.querySelectorAll('.fc-widget-header')[0]
     if (firstHeaderNode) {
       const checkbox = document.createElement('INPUT')
       checkbox.type = 'checkbox'


### PR DESCRIPTION
- this makes sure, if multiple calendars are in the dom (multiple nice tabs opened), the right one is selected

Refs: TOCDEV-2552
Changelog: Fix deselect all bug