### PR TITLE
fix(admin): Fix navigation between search/tree/document view

### DIFF
--- a/packages/admin/src/routes/docs/components/DocsRoute/DocsRoute.js
+++ b/packages/admin/src/routes/docs/components/DocsRoute/DocsRoute.js
@@ -45,8 +45,16 @@ const DocsRoute = ({history, searchMode, setSearchMode, loadBreadcrumbs}) => {
   })
 
   const handleSearchChange = e => {
-    setSearchMode(e.query && e.query.hasUserChanges)
+    const hasUserChanges = e.query && e.query.hasUserChanges
+    if (history.location.pathname !== '/docs/search' && hasUserChanges) {
+      history.push('/docs/search')
+    } else if (history.location.pathname === '/docs/search' && !hasUserChanges) {
+      history.push('/docs')
+    }
+    setSearchMode(hasUserChanges)
   }
+
+  const key = `docs-view-${docsViewNumber}`
 
   return (
     <StyledWrapper>
@@ -65,7 +73,8 @@ const DocsRoute = ({history, searchMode, setSearchMode, loadBreadcrumbs}) => {
             path={['/docs/:model/:key/list', '/docs', '/docs/search']}
             render={({match}) => (
               <DocsView
-                key={`docs-view-${docsViewNumber}`}
+                key={key}
+                storeKey={key}
                 history={history}
                 match={match}
                 onSearchChange={handleSearchChange}

--- a/packages/admin/src/routes/docs/components/DocsView/DocsView.js
+++ b/packages/admin/src/routes/docs/components/DocsView/DocsView.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import EntityListApp from 'tocco-entity-list/src/main'
+import {viewPersistor} from 'tocco-util'
 
 const getParent = match => {
   if (match.params && match.params.model) {
@@ -16,7 +17,7 @@ const getParent = match => {
 }
 
 const DocsView = props => {
-  const {history, match, onSearchChange} = props
+  const {storeKey, history, match, onSearchChange} = props
 
   const handleRowClick = ({id}) => {
     const [model, key] = id.split('/')
@@ -37,12 +38,6 @@ const DocsView = props => {
     history.push(newLocation)
   }
 
-  const handleSearchChange = e => {
-    const path = e.query.hasUserChanges ? '/docs/search' : match.url
-    history.push(path)
-    onSearchChange(e)
-  }
-
   const parent = getParent(match)
 
   return (
@@ -54,12 +49,17 @@ const DocsView = props => {
       searchFormPosition="left"
       searchFormType="admin"
       parent={parent}
-      onSearchChange={handleSearchChange}
+      onSearchChange={onSearchChange}
+      store={viewPersistor.viewInfoSelector(storeKey).store}
+      onStoreCreate={store => {
+        viewPersistor.persistViewInfo(storeKey, {store})
+      }}
     />
   )
 }
 
 DocsView.propTypes = {
+  storeKey: PropTypes.string.isRequired,
   match: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   onSearchChange: PropTypes.func.isRequired


### PR DESCRIPTION
There were several issues when navigating around:
- When the user searched and then navigated to a search result (to
  a document) and then returned to the search results using the
  back button, the list view was reset to the list of domains.
  We want to return to the search results instead. This is achieved
  by reusing the existing store (using the viewPersistor).
- There proper URL should always be up to date according to the current
  view (/docs vs. docs/search). This was fixed by cleaning up the
  `onSearchChange` event handlers.

Refs: TOCDEV-2881