### PR TITLE
feat(entity-list): don't use default filter in list with parent

### DIFF
--- a/packages/entity-list/src/modules/searchForm/sagas.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.js
@@ -113,8 +113,10 @@ export function* submitSearchFrom() {
 export function* loadSearchFilter(entityName) {
   const searchFilters = yield call(rest.fetchSearchFilters, entityName)
 
+  const {parent} = yield select(entityListSelector)
+  const listHasNoParent = !parent
   yield put(actions.setSearchFilters(searchFilters.map(searchFilter =>
-    ({...searchFilter, ...(searchFilter.defaultFilter && {active: true})}))
+    ({...searchFilter, ...(listHasNoParent && searchFilter.defaultFilter && {active: true})}))
   ))
 }
 

--- a/packages/entity-list/src/modules/searchForm/sagas.spec.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.spec.js
@@ -248,9 +248,10 @@ describe('entity-list', () => {
 
             return expectSaga(sagas.loadSearchFilter, 'User')
               .provide([
-                [matchers.call.fn(rest.fetchSearchFilters), searchFilters]
+                [matchers.call.fn(rest.fetchSearchFilters), searchFilters],
+                [select(sagas.entityListSelector), {}]
               ])
-              .dispatch(actions.setSearchFilters(expectedDispatch))
+              .put(actions.setSearchFilters(expectedDispatch))
               .run()
           })
           test('should not set searchfilter when parent exists', () => {

--- a/packages/entity-list/src/modules/searchForm/sagas.spec.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.spec.js
@@ -253,6 +253,25 @@ describe('entity-list', () => {
               .dispatch(actions.setSearchFilters(expectedDispatch))
               .run()
           })
+          test('should not set searchfilter when parent exists', () => {
+            const searchFilters = [
+              {uniqueId: 'active', label: 'Active', defaultFilter: 'true'},
+              {uniqueId: 'inactive', label: 'Inactive'}
+            ]
+
+            const expectedDispatch = [
+              {uniqueId: 'active', label: 'Active', defaultFilter: 'true'},
+              {uniqueId: 'inactive', label: 'Inactive'}
+            ]
+
+            return expectSaga(sagas.loadSearchFilter, 'User')
+              .provide([
+                [matchers.call.fn(rest.fetchSearchFilters), searchFilters],
+                [select(sagas.entityListSelector), {parent: {}}]
+              ])
+              .put(actions.setSearchFilters(expectedDispatch))
+              .run()
+          })
         })
       })
     })


### PR DESCRIPTION
Refs: TOCDEV-2575
Changelog: Default search filter is disabled when opening the relations view of an entity as its own list