### PR TITLE
refactor(tocco-ui): set load mask height

### DIFF
--- a/packages/tocco-ui/src/LoadMask/StyledLoadMask.js
+++ b/packages/tocco-ui/src/LoadMask/StyledLoadMask.js
@@ -23,6 +23,7 @@ const StyledLoadMask = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
+  height: 100%;
   ${({isInitialized}) => !isInitialized && css`
     && {
       flex-flow: column nowrap;


### PR DESCRIPTION
Refs: TOCDEV-2787
Changelog: Reset load mask height to 100%