### PR TITLE
refactor(entity-list): reset preferences to empty values

### DIFF
--- a/packages/entity-list/src/modules/preferences/reducer.js
+++ b/packages/entity-list/src/modules/preferences/reducer.js
@@ -4,13 +4,19 @@ import * as actions from './actions'
 
 const resetSorting = state => ({
   ...state,
-  sorting: initialState.sorting
+  sorting: []
 })
 
 const resetColumns = state => ({
   ...state,
-  columns: initialState.columns,
-  positions: initialState.positions
+  positions: {},
+  columns: {}
+})
+
+const resetPreferences = state => ({
+  positions: {},
+  sorting: [],
+  columns: {}
 })
 
 const ACTION_HANDLERS = {
@@ -19,13 +25,13 @@ const ACTION_HANDLERS = {
   [actions.SET_COLUMNS]: reducerUtil.singleTransferReducer('columns'),
   [actions.RESET_SORTING]: resetSorting,
   [actions.RESET_COLUMNS]: resetColumns,
-  [actions.RESET_PREFERENCES]: () => initialState
+  [actions.RESET_PREFERENCES]: resetPreferences
 }
 
 const initialState = {
   positions: null,
   sorting: null,
-  columns: {}
+  columns: null
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/entity-list/src/modules/preferences/reducer.spec.js
+++ b/packages/entity-list/src/modules/preferences/reducer.spec.js
@@ -4,7 +4,7 @@ import * as actions from './actions'
 const EXPECTED_INITIAL_STATE = {
   positions: null,
   sorting: null,
-  columns: {}
+  columns: null
 }
 
 describe('entity-list', () => {
@@ -44,7 +44,7 @@ describe('entity-list', () => {
             field: 'field',
             order: 'order'
           }
-          expect(reducer({sorting: previousSorting}, actions.resetSorting()).sorting).to.be.null
+          expect(reducer({sorting: previousSorting}, actions.resetSorting()).sorting).to.eql([])
         })
 
         test('should clear column preferences', () => {
@@ -54,8 +54,8 @@ describe('entity-list', () => {
             sorting: ['field']
           }
           const newState = reducer(previousState, actions.resetColumns())
-          expect(newState.positions).to.be.null
-          expect(newState.columns).to.be.empty
+          expect(newState.positions).to.eql({})
+          expect(newState.columns).to.eql({})
           expect(newState.sorting).to.be.deep.eq(previousState.sorting)
         })
       })


### PR DESCRIPTION
- resetting to null resulting in a infinite waiting for the preferences to be loaded in getPreferencesSorting.

Refs: TOCDEV-2894
Changelog: Fix table reset