### PR TITLE
feat(tocco-ui): add title to column headers

### DIFF
--- a/packages/tocco-ui/src/Table/TableHeader.js
+++ b/packages/tocco-ui/src/Table/TableHeader.js
@@ -11,7 +11,7 @@ import useResize from './useResize'
 const ThContent = ({column, data}) =>
   column.HeaderRenderer
     ? <column.HeaderRenderer column={column} data={data} />
-    : <div dangerouslySetInnerHTML={{__html: column.label}}/>
+    : <div dangerouslySetInnerHTML={{__html: column.label}} title={column.label}/>
 
 ThContent.propTypes = {
   data: dataPropType,


### PR DESCRIPTION
Refs: TOCDEV-2062
Changelog: Use column label as titles when hovering over headers