### PR TITLE
refactor(entity-list): add preferences defined check

### DIFF
--- a/packages/entity-list/src/components/ListView/ListView.js
+++ b/packages/entity-list/src/components/ListView/ListView.js
@@ -29,7 +29,7 @@ const ListView = ({
   const msg = (id, values = {}) => intl.formatMessage({id}, values)
 
   const List = useMemo(() => {
-    if (formDefinition) {
+    if (formDefinition && columnDisplayPreferences) {
       const table = getTable(formDefinition)
       const columnsDefinitions = getColumnDefinition(table, sorting, parent, intl, columnDisplayPreferences)
 

--- a/packages/entity-list/src/components/ListView/ListView.spec.js
+++ b/packages/entity-list/src/components/ListView/ListView.spec.js
@@ -35,7 +35,8 @@ const props = {
   selection: [],
   refresh: EMPTY_FUNC,
   currentPageIds: ['1', '4'],
-  showSelectionController: true
+  showSelectionController: true,
+  columnDisplayPreferences: {}
 }
 
 describe('entity-list', () => {


### PR DESCRIPTION
- Otherwise it could be, that preferences are not loaded at this point.
  Hence a null pointer would occur.