### PR TITLE
refactor(tocco-ui): disable pointer event on desktop

### DIFF
--- a/packages/tocco-ui/src/EditableValue/StyledEditableValue.js
+++ b/packages/tocco-ui/src/EditableValue/StyledEditableValue.js
@@ -23,7 +23,6 @@ const StyledInputCss = css`
   background-color: transparent;
   border: 0;
   cursor: ${({immutable}) => immutable ? 'not-allowed' : 'default'};
-  pointer-events: ${({immutable}) => immutable ? 'none' : 'auto'};
   flex-grow: 1;
   min-height: 2.6rem;
   min-width: 0;
@@ -70,6 +69,11 @@ const StyledInputCss = css`
     ::-webkit-date-and-time-value {
       ${({immutable}) => immutable && 'margin: unset;'}
     }
+  }
+
+  // allow pointer event only on touch devices
+  @media (pointer: coarse) {
+    pointer-events: ${({immutable}) => immutable ? 'none' : 'auto'};
   }
 `
 


### PR DESCRIPTION
Refs: TOCDEV-2837
Changelog: Disable pointer events on Desktop as text can't be copied otherwise in Firefox