### PR TITLE
refactor(admin, entity-browser): introduce navigationStrategy

### DIFF
--- a/packages/admin/src/routes/entities/components/CreateView/CreateView.js
+++ b/packages/admin/src/routes/entities/components/CreateView/CreateView.js
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 import {theme, StyledScrollbar, scale} from 'tocco-ui'
 
 import {currentViewPropType} from '../../utils/propTypes'
+import navigationStrategy from '../../utils/navigationStrategy'
 
 const StyledEntityDetailAppWrapper = styled.div`
   margin: 0;
@@ -27,7 +28,8 @@ const CreateView = props => {
     intl,
     dispatchEmittedAction
   } = props
-
+  const {location} = history
+  const stateDefaultValues = _get(location, 'state.defaultValues', [])
   const [touched, setTouched] = useState(false)
 
   const mode = 'create'
@@ -44,7 +46,8 @@ const CreateView = props => {
     ...((reverseRelation && parentKey)
       ? [{id: reverseRelation, value: isMultiReverseRelation ? [parentKey] : parentKey}]
       : []
-    )
+    ),
+    ...stateDefaultValues
   ]
 
   const handleEntityCreated = ({id}) => {
@@ -68,6 +71,7 @@ const CreateView = props => {
       emitAction={action => {
         dispatchEmittedAction(action)
       }}
+      navigationStrategy={navigationStrategy(history, match)}
       onEntityCreated={handleEntityCreated}
       onTouchedChange={handleToucheChanged}
     />

--- a/packages/admin/src/routes/entities/components/EditView/EditView.js
+++ b/packages/admin/src/routes/entities/components/EditView/EditView.js
@@ -4,14 +4,13 @@ import EntityDetailApp from 'tocco-entity-detail/src/main'
 import {Prompt} from 'react-router'
 import {intlShape} from 'react-intl'
 import queryString from 'query-string'
-import {queryString as queryStringUtil} from 'tocco-util'
 import styled from 'styled-components'
 import {StyledScrollbar, theme, scale} from 'tocco-ui'
 
 import {goBack} from '../../../../utils/routing'
-import StyledLink from '../../../../components/StyledLink/StyledLink'
 import Action from '../Action'
 import {currentViewPropType} from '../../utils/propTypes'
+import navigationStrategy from '../../utils/navigationStrategy'
 
 export const StyledEntityDetailAppWrapper = styled.div`
   margin: 0;
@@ -45,31 +44,25 @@ const EditView = props => {
     setTouched(touched)
   }
 
-  const handleNavigateToCreate = relationName => {
+  const navigateToCreateRelative = (relationName, state) => {
     if (relationName) {
-      history.push(`${match.url}/${relationName}/create`)
+      const entityBaseUrl = goBack(match.url, 1)
+      history.push({
+        pathname: `${entityBaseUrl}/${relationName}/create`,
+        state
+      })
     } else {
       const entityBaseUrl = goBack(match.url, 2)
-      history.push(entityBaseUrl + '/create')
+      history.push({
+        pathname: entityBaseUrl + '/create',
+        state
+      })
     }
   }
 
   const handleEntityDeleted = () => {
     const entityBaseUrl = goBack(match.url, 2)
     history.push(entityBaseUrl)
-  }
-
-  const handleNavigateToAction = ({definition, selection}) => {
-    const entityBaseUrl = goBack(match.url)
-    const search = queryStringUtil.toQueryString({
-      selection,
-      actionProperties: definition.properties
-    })
-    history.push({
-      pathname: entityBaseUrl + '/action/' + definition.appId,
-      state: {definition, selection},
-      search
-    })
   }
 
   const handleSubGridRowClick = ({id, relationName}) => {
@@ -98,12 +91,7 @@ const EditView = props => {
       mode={mode}
       emitAction={emitAction}
       onTouchedChange = {handleToucheChanged}
-      linkFactory={{
-        detail: (entity, relation, key, children) =>
-          <StyledLink to={`/e/${entity}/${key}`} target="_blank">{children}</StyledLink>
-      }}
-      onNavigateToCreate={handleNavigateToCreate}
-      onNavigateToAction={handleNavigateToAction}
+      navigationStrategy={{...navigationStrategy(history, match), navigateToCreateRelative}}
       onEntityDeleted={handleEntityDeleted}
       actionAppComponent={Action}
       onSubGridRowClick={handleSubGridRowClick}

--- a/packages/admin/src/routes/entities/components/ListView/ListView.js
+++ b/packages/admin/src/routes/entities/components/ListView/ListView.js
@@ -2,13 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import EntityListApp from 'tocco-entity-list/src/main'
 import queryString from 'query-string'
-import {queryString as queryStringUtil, viewPersistor} from 'tocco-util'
+import {viewPersistor} from 'tocco-util'
 
-import StyledLink from '../../../../components/StyledLink/StyledLink'
-import {goBack} from '../../../../utils/routing'
 import Action from '../Action/LazyAction'
 import {currentViewPropType} from '../../utils/propTypes'
 import ErrorView from '../../../../components/ErrorView'
+import navigationStrategy from '../../utils/navigationStrategy'
 
 const ListView = ({match, history, currentViewInfo, emitAction}) => {
   if (currentViewInfo && currentViewInfo.error) {
@@ -23,28 +22,6 @@ const ListView = ({match, history, currentViewInfo, emitAction}) => {
 
   const handleRowClick = ({id}) => {
     history.push(match.url.replace(/list$/, '') + id)
-  }
-
-  const handleNavigateToCreate = relationName => {
-    if (relationName) {
-      history.push(`${match.url}/${relationName}/create`)
-    } else {
-      const entityBaseUrl = goBack(match.url)
-      history.push(entityBaseUrl + '/create')
-    }
-  }
-
-  const handleNavigateToAction = ({definition, selection}) => {
-    const entityBaseUrl = goBack(match.url)
-    const search = queryStringUtil.toQueryString({
-      selection,
-      actionProperties: definition.properties
-    })
-    history.push({
-      pathname: entityBaseUrl + '/action/' + definition.appId,
-      state: {definition, selection},
-      search
-    })
   }
 
   return (
@@ -63,20 +40,13 @@ const ListView = ({match, history, currentViewInfo, emitAction}) => {
         }
       })}
       showLink={true}
-      linkFactory={{
-        detail: (entity, relation, key, children) =>
-          entity
-            ? <StyledLink to={`/e/${entity}/${key}`} target="_blank">{children}</StyledLink>
-            : <StyledLink to={key}>{children}</StyledLink>
-      }}
-      onNavigateToCreate={handleNavigateToCreate}
+      navigationStrategy={navigationStrategy(history, match)}
       searchFormPosition="left"
       searchFormType="admin"
       store={viewPersistor.viewInfoSelector(history.location.pathname).store}
       onStoreCreate={store => {
         viewPersistor.persistViewInfo(history.location.pathname, {store}, currentViewInfo.level)
       }}
-      onNavigateToAction={handleNavigateToAction}
       actionAppComponent={Action}
       tql={queryParams.tql}
     />

--- a/packages/admin/src/routes/entities/components/RelationsView/RelationsView.js
+++ b/packages/admin/src/routes/entities/components/RelationsView/RelationsView.js
@@ -17,6 +17,7 @@ import {StyledLink} from '../../../../components/StyledLink'
 import {goBack} from '../../../../utils/routing'
 import {currentViewPropType} from '../../utils/propTypes'
 import {getRelation, setRelation} from '../../utils/relationPersistor'
+import navigationStrategy from '../../utils/navigationStrategy'
 
 const RelationsView = ({
   history,
@@ -107,15 +108,11 @@ const RelationsView = ({
           parent={{
             key: currentViewInfo.key,
             reverseRelationName: selectedRelation.reverseRelationName,
-            model: currentViewInfo.model.name
+            model: currentViewInfo.model.name,
+            relationName: selectedRelation.relationName
           }}
           showLink={true}
-          linkFactory={{
-            detail: (entity, relation, key, children) =>
-              entity
-                ? <StyledLink to={`/e/${entity}/${key}`} target="_blank">{children}</StyledLink>
-                : <StyledLink to={selectedRelation.relationName + '/' + key}>{children}</StyledLink>
-          }}
+          navigationStrategy={navigationStrategy(history, match)}
           onRowClick={({id}) => {
             const entityBaseUrl = match.url.replace(/detail$/, '')
             history.push(`${entityBaseUrl}${selectedRelation.relationName}/${id}`)

--- a/packages/admin/src/routes/entities/utils/navigationStrategy.js
+++ b/packages/admin/src/routes/entities/utils/navigationStrategy.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {queryString as queryStringUtil} from 'tocco-util'
+
+import StyledLink from '../../../components/StyledLink/StyledLink'
+import {goBack} from '../../../utils/routing'
+
+const DetailLinkRelative = ({entityKey, children, relation}) =>
+  <StyledLink to={`${relation ? relation + '/' : ''}${entityKey}`}>{children}</StyledLink>
+
+const DetailLink = ({entityName, entityKey, children}) =>
+  <StyledLink to={`/e/${entityName}/${entityKey}`} target="_blank">{children}</StyledLink>
+
+const ListLink = ({entityName, entityKeys, children}) => {
+  const queryString = entityKeys && entityKeys.length > 0 && 'tql=KEYS(' + entityKeys.join(',') + ')'
+  return (
+    <StyledLink
+      to={{pathname: `/e/${entityName}/list`, search: `?${queryString}`}}
+      target="_blank"
+    >
+      {children}
+    </StyledLink>
+  )
+}
+
+ListLink.propTypes = {
+  entityName: PropTypes.string.isRequired,
+  children: PropTypes.any.isRequired,
+  entityKeys: PropTypes.arrayOf(PropTypes.string)
+}
+
+export default (history, match) => {
+  const navigateToCreateRelative = (relationName, state) => {
+    if (relationName) {
+      history.push({
+        pathname: `${match.url}/${relationName}/create`,
+        state
+      })
+    } else {
+      const entityBaseUrl = goBack(match.url)
+
+      history.push({
+        pathname: entityBaseUrl + '/create',
+        state
+      })
+    }
+  }
+
+  const navigateToActionRelative = (definition, selection) => {
+    const entityBaseUrl = goBack(match.url)
+    const search = queryStringUtil.toQueryString({
+      selection,
+      actionProperties: definition.properties
+    })
+    history.push({
+      pathname: entityBaseUrl + '/action/' + definition.appId,
+      state: {definition, selection},
+      search
+    })
+  }
+
+  return {
+    DetailLink,
+    ListLink,
+    DetailLinkRelative,
+    navigateToCreateRelative,
+    navigateToActionRelative
+  }
+}
+
+DetailLinkRelative.propTypes = {
+  entityKey: PropTypes.string.isRequired,
+  children: PropTypes.element.isRequired,
+  relation: PropTypes.string
+}
+
+DetailLink.propTypes = {
+  entityName: PropTypes.string.isRequired,
+  entityKey: PropTypes.string.isRequired,
+  children: PropTypes.any.isRequired
+}

--- a/packages/app-extensions/README.md
+++ b/packages/app-extensions/README.md
@@ -55,14 +55,12 @@ Import:
 Initialization:
 
 ```javascript
- formData.addToStore(store, {listApp, linkFactory})
+ formData.addToStore(store, {listApp, navigationStrategy})
 ```
 
 config, the second parameter, is an object an can have the following properties:
 * listApp: Entity-List App component. Is used to connect the remote field with a list search.
-* linkFactory: An object consisting of different types of link factories. Form components such as remote field can use
-  these factories to create a link around the values for navigation purposes.
-   e.g. {detail: (entity, relation, key, children) => <a ../>}
+* navigationStrategy: See tocco-util > navigationStrategy for more information
 
 
 #### formField

--- a/packages/app-extensions/src/actions/modules/actionHandlers/customAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/customAction.js
@@ -64,6 +64,7 @@ export function* handleCustomActionModal({definition, selection, config}) {
         appId={definition.appId}
         actionProperties={definition.properties}
         selection={selection}
+        navigationStrategy={config.navigationStrategy || {}}
         onSuccess={onSuccess}
         onError={onError}
         onCancel={onCancel}

--- a/packages/app-extensions/src/field/editableTypeConfigs/remote.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/remote.js
@@ -1,4 +1,5 @@
 import _get from 'lodash/get'
+import React from 'react'
 
 const settings = {
   SEARCH_RESULT_LIMIT: 50,
@@ -10,7 +11,7 @@ export default {
   dataContainerProps: ({formField}) => ({
     relationEntities: formField.id,
     tooltips: formField.targetEntity,
-    linkFactory: true
+    navigationStrategy: true
   }),
   getOptions: ({formField, formName, formData}) => ({
     options: _get(formData, ['relationEntities', formField.id, 'data'], []),
@@ -37,9 +38,14 @@ export default {
     moreOptionsAvailableText: formData.intl.formatMessage(
       {id: 'client.component.remoteselect.moreOptionsAvailableText'}
     ),
-    valueLinkFactory: formData.linkFactory && formData.linkFactory.detail
-      ? (key, content) => formData.linkFactory.detail(formField.targetEntity, formField.relationName, key, content)
+    DetailLink: formData.navigationStrategy && formData.navigationStrategy.DetailLink
+      ? ({entityKey, children}) =>
+        <formData.navigationStrategy.DetailLink
+          entityName={formField.targetEntity}
+          entityKey={entityKey}
+        >
+          {children}
+        </formData.navigationStrategy.DetailLink>
       : null
   })
-
 }

--- a/packages/app-extensions/src/field/formattedTypeConfigs/remote.js
+++ b/packages/app-extensions/src/field/formattedTypeConfigs/remote.js
@@ -1,8 +1,14 @@
-
+import React from 'react'
 export default {
   getOptions: ({formField, formData}) => ({
-    linkFactory: formData.linkFactory && formData.linkFactory.detail
-      ? (key, content) => formData.linkFactory.detail(formField.targetEntity, formField.relationName, key, content)
+    DetailLink: formData.navigationStrategy && formData.navigationStrategy.DetailLink
+      ? ({entityKey, children}) =>
+        <formData.navigationStrategy.DetailLink
+          entityName={formField.targetEntity}
+          entityKey={entityKey}
+        >
+          {children}
+        </formData.navigationStrategy.DetailLink>
       : null
   })
 

--- a/packages/app-extensions/src/formData/FormDataContainer.js
+++ b/packages/app-extensions/src/formData/FormDataContainer.js
@@ -30,30 +30,31 @@ FormData.propTypes = {
 
 const mapStateToProps = (
   state,
-  {formValues, tooltips, locations, relationEntities, searchFilters, isDirty, errors, linkFactory}
-) => {
-  return {
-    ...(relationEntities ? {relationEntities: _pick(state.formData.relationEntities.data, relationEntities)} : {}),
-    ...(tooltips ? {tooltips: _pick(state.formData.tooltips.data, tooltips)} : {}),
-    ...(searchFilters ? {searchFilters: _pick(state.formData.searchFilters, searchFilters)} : {}),
-    ...(locations ? {locations: _pick(state.formData.locations, locations)} : {}),
-    ...(formValues && state.form[formValues.formName]
-      ? {formValues: _pick(state.form[formValues.formName].values, formValues.fields)} : {}),
-    ...(isDirty && state.form[isDirty.formName]
-      ? {isDirty: isDirtySelector(isDirty.formName)(state, ...isDirty.fields)} : {}),
-    ...(errors && state.form[errors.formName]
-      ? {
-        errors: _reduce(
-          _merge(
-            _pick(getFormSubmitErrors(errors.formName)(state), errors.fields),
-            _pick(getFormSyncErrors(errors.formName)(state), errors.fields),
-            _pick(getFormAsyncErrors(errors.formName)(state), errors.fields)
-          ),
-          (result, value) => ({...result, ...value}), null)
-      } : null),
-    ...(linkFactory && state.formData.linkFactory ? {linkFactory: state.formData.linkFactory.linkFactory} : {})
-  }
-}
+  {formValues, tooltips, locations, relationEntities, searchFilters, isDirty, errors, navigationStrategy}
+) => ({
+  ...(relationEntities ? {relationEntities: _pick(state.formData.relationEntities.data, relationEntities)} : {}),
+  ...(tooltips ? {tooltips: _pick(state.formData.tooltips.data, tooltips)} : {}),
+  ...(searchFilters ? {searchFilters: _pick(state.formData.searchFilters, searchFilters)} : {}),
+  ...(locations ? {locations: _pick(state.formData.locations, locations)} : {}),
+  ...(formValues && state.form[formValues.formName]
+    ? {formValues: _pick(state.form[formValues.formName].values, formValues.fields)} : {}),
+  ...(isDirty && state.form[isDirty.formName]
+    ? {isDirty: isDirtySelector(isDirty.formName)(state, ...isDirty.fields)} : {}),
+  ...(errors && state.form[errors.formName]
+    ? {
+      errors: _reduce(
+        _merge(
+          _pick(getFormSubmitErrors(errors.formName)(state), errors.fields),
+          _pick(getFormSyncErrors(errors.formName)(state), errors.fields),
+          _pick(getFormAsyncErrors(errors.formName)(state), errors.fields)
+        ),
+        (result, value) => ({...result, ...value}), null)
+    } : null),
+  ...(navigationStrategy && state.formData.navigationStrategy
+    ? {navigationStrategy: state.formData.navigationStrategy.navigationStrategy}
+    : {}
+  )
+})
 
 const mapActionCreators = {
   loadRelationEntities: loadRelationEntities,

--- a/packages/app-extensions/src/formData/formData.js
+++ b/packages/app-extensions/src/formData/formData.js
@@ -15,8 +15,8 @@ import searchFilterSagas from './searchFilters/sagas'
 import {setRelationEntities} from './relationEntities/actions'
 import locationSagas from './locations/sagas'
 import locations from './locations/reducer'
-import linkFactory from './linkFactory/reducer'
-import {setLinkFactory} from './linkFactory/actions'
+import navigationStrategy from './navigationStrategy/reducer'
+import {setNavigationStrategy} from './navigationStrategy/actions'
 
 export const relationEntitiesSelector = store => store.formData.relationEntities.data
 export const tooltipSelector = store => store.formData.tooltips.data
@@ -29,7 +29,7 @@ export const addToStore = (store, config) => {
       tooltips,
       searchFilters,
       locations,
-      linkFactory
+      navigationStrategy
     })
   })
 
@@ -41,8 +41,8 @@ export const addToStore = (store, config) => {
   store.sagaMiddleware.run(searchFilterSagas)
   store.sagaMiddleware.run(locationSagas)
 
-  if (config.linkFactory) {
-    store.dispatch(setLinkFactory(config.linkFactory))
+  if (config.navigationStrategy) {
+    store.dispatch(setNavigationStrategy(config.navigationStrategy))
   }
 
   const relationEntitiesData = _get(config, 'data.relationEntities', null)

--- a/packages/app-extensions/src/formData/linkFactory/actions.js
+++ b/packages/app-extensions/src/formData/linkFactory/actions.js
@@ -1,8 +1,0 @@
-export const SET_LINK_FACTORY = 'formData/SET_LINK_FACTORY'
-
-export const setLinkFactory = linkFactory => ({
-  type: SET_LINK_FACTORY,
-  payload: {
-    linkFactory
-  }
-})

--- a/packages/app-extensions/src/formData/navigationStrategy/actions.js
+++ b/packages/app-extensions/src/formData/navigationStrategy/actions.js
@@ -1,0 +1,8 @@
+export const SET_NAVIGATION_STRATEGY = 'formData/SET_NAVIGATION_STRATEGY'
+
+export const setNavigationStrategy = navigationStrategy => ({
+  type: SET_NAVIGATION_STRATEGY,
+  payload: {
+    navigationStrategy
+  }
+})

--- a/packages/app-extensions/src/formData/navigationStrategy/reducer.js
+++ b/packages/app-extensions/src/formData/navigationStrategy/reducer.js
@@ -1,18 +1,18 @@
 import * as actions from './actions'
 
-export const setLinkFactory = (state, {payload: {linkFactory}}) => (
-  {
+export const setNavigationStrategy = (state, {payload: {navigationStrategy}}) => {
+  return {
     ...state,
-    linkFactory
+    navigationStrategy
   }
-)
+}
 
 const ACTION_HANDLERS = {
-  [actions.SET_LINK_FACTORY]: setLinkFactory
+  [actions.SET_NAVIGATION_STRATEGY]: setNavigationStrategy
 }
 
 const initialState = {
-  linkFactory: null
+  navigationStrategy: null
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/delete/src/components/DeleteProgress/DeleteProgress.js
+++ b/packages/delete/src/components/DeleteProgress/DeleteProgress.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import {LoadingSpinner, Typography} from 'tocco-ui'
 import {FormattedMessage, intlShape} from 'react-intl'
+import {navigationStrategy} from 'tocco-util'
 
 import {deleteInfoPropType} from '../../utils/deleteRequestParser'
 import InfoPart from '../InfoPart'
 
-const DeleteProgress = ({dialogInfo, intl}) => {
+const DeleteProgress = ({dialogInfo, navigationStrategy}) => {
   return <>
     <LoadingSpinner size="30px"/>
     <Typography.P><FormattedMessage id="client.delete.deleteInProgress"/></Typography.P>
@@ -16,13 +17,15 @@ const DeleteProgress = ({dialogInfo, intl}) => {
       keys={dialogInfo.keysDeletable}
       relatedEntities={dialogInfo.relatedDeletable}
       maxCountLink={100}
+      navigationStrategy={navigationStrategy}
     />
   </>
 }
 
 DeleteProgress.propTypes = {
   dialogInfo: deleteInfoPropType.isRequired,
-  intl: intlShape.isRequired
+  intl: intlShape.isRequired,
+  navigationStrategy: navigationStrategy.propTypes
 }
 
 export default DeleteProgress

--- a/packages/delete/src/components/DeleteProgress/DeleteProgressContainer.js
+++ b/packages/delete/src/components/DeleteProgress/DeleteProgressContainer.js
@@ -9,7 +9,8 @@ const mapActionCreators = {
 }
 
 const mapStateToProps = (state, props) => ({
-  dialogInfo: state.del.dialogInfo
+  dialogInfo: state.del.dialogInfo,
+  navigationStrategy: state.input.navigationStrategy
 })
 
 export default connect(mapStateToProps, mapActionCreators)(injectIntl(DeleteProgress))

--- a/packages/delete/src/components/Dialog/Dialog.js
+++ b/packages/delete/src/components/Dialog/Dialog.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Button, Typography, SignalBox} from 'tocco-ui'
+import {navigationStrategy} from 'tocco-util'
 import {FormattedMessage} from 'react-intl'
 
 import {deleteInfoPropType} from '../../utils/deleteRequestParser'
 import InfoPart from '../InfoPart'
 
-const Dialog = ({dialogInfo, doDelete, onCancel}) =>
+const Dialog = ({dialogInfo, doDelete, onCancel, navigationStrategy}) =>
   <>
     <Typography.P><FormattedMessage id="client.delete.confirmText"/></Typography.P>
     <InfoPart
@@ -16,6 +17,7 @@ const Dialog = ({dialogInfo, doDelete, onCancel}) =>
       keys={dialogInfo.keysDeletable}
       relatedEntities={dialogInfo.relatedDeletable}
       maxCountLink={100}
+      navigationStrategy={navigationStrategy}
     />
     {dialogInfo.keysNotDeletable.length > 0
     && <div style={{paddingTop: '20px'}}>
@@ -27,6 +29,7 @@ const Dialog = ({dialogInfo, doDelete, onCancel}) =>
         keys={dialogInfo.keysNotDeletable}
         relatedEntities={dialogInfo.relatedNotDeletable}
         maxCountLink={100}
+        navigationStrategy={navigationStrategy}
       />
     </div>
     }
@@ -57,7 +60,8 @@ const Dialog = ({dialogInfo, doDelete, onCancel}) =>
 Dialog.propTypes = {
   onCancel: PropTypes.func.isRequired,
   doDelete: PropTypes.func.isRequired,
-  dialogInfo: deleteInfoPropType.isRequired
+  dialogInfo: deleteInfoPropType.isRequired,
+  navigationStrategy: navigationStrategy.propTypes
 }
 
 export default Dialog

--- a/packages/delete/src/components/Dialog/DialogContainer.js
+++ b/packages/delete/src/components/Dialog/DialogContainer.js
@@ -10,7 +10,8 @@ const mapActionCreators = {
 }
 
 const mapStateToProps = (state, props) => ({
-  dialogInfo: state.del.dialogInfo
+  dialogInfo: state.del.dialogInfo,
+  navigationStrategy: state.input.navigationStrategy
 })
 
 export default connect(mapStateToProps, mapActionCreators)(injectIntl(Dialog))

--- a/packages/delete/src/components/InfoPart/InfoPart.js
+++ b/packages/delete/src/components/InfoPart/InfoPart.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import {Typography, RouterLink} from 'tocco-ui'
+import {Typography} from 'tocco-ui'
+import {navigationStrategy} from 'tocco-util'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
@@ -10,13 +11,17 @@ const NonBreakingText = styled.span`
   white-space: nowrap;
 `
 
-const InfoPart = ({entityName, entityLabel, keys, relatedEntities, maxCountLink}) => {
-  const primaryTql = 'KEYS(' + keys.join(',') + ')'
+const InfoPart = ({entityName, entityLabel, keys, relatedEntities, maxCountLink, navigationStrategy}) => {
   return <Typography.Span>
     <Typography.B>
       {entityLabel} ({
-        keys.length > 0
-          ? <RouterLink to={`/e/${entityName}/list?tql=${primaryTql}`} target="_blank">{keys.length}</RouterLink>
+        keys.length > 0 && navigationStrategy.ListLink
+          ? <navigationStrategy.ListLink
+            entityName={entityName}
+            entityKeys={keys}
+          >
+            {keys.length}
+          </navigationStrategy.ListLink>
           : <Typography.Span>{keys.length}</Typography.Span>
       })
     </Typography.B>
@@ -26,13 +31,15 @@ const InfoPart = ({entityName, entityLabel, keys, relatedEntities, maxCountLink}
         <span> / </span>
         {Object.keys(relatedEntities).map(entityName => {
           const relatedEntity = relatedEntities[entityName]
-          const tql = 'KEYS(' + relatedEntity.keys.slice(0, maxCountLink).join(',') + ')'
           const linkText = [...relatedEntity.keys, ...relatedEntity.keysOtherBu].length
 
-          const Count = relatedEntity.keys.length > 0
-            ? <RouterLink to={`/e/${entityName}/list?tql=${tql}`} target="_blank">
+          const Count = relatedEntity.keys.length > 0 && navigationStrategy.ListLink
+            ? <navigationStrategy.ListLink
+              entityName={entityName}
+              keys={relatedEntity.keys.slice(0, maxCountLink)}
+            >
               {linkText}
-            </RouterLink>
+            </navigationStrategy.ListLink>
             : <Typography.Span>{linkText}</Typography.Span>
 
           const Content = <LinkPopOver relatedEntity={relatedEntity} maxCountLink={maxCountLink}>{Count}</LinkPopOver>
@@ -53,7 +60,8 @@ InfoPart.propTypes = {
   entityLabel: PropTypes.string.isRequired,
   keys: PropTypes.arrayOf(PropTypes.string),
   relatedEntities: PropTypes.objectOf(relatedPropType).isRequired,
-  maxCountLink: PropTypes.number
+  maxCountLink: PropTypes.number,
+  navigationStrategy: navigationStrategy.propTypes
 }
 
 export default InfoPart

--- a/packages/delete/src/components/InfoPart/InfoPart.spec.js
+++ b/packages/delete/src/components/InfoPart/InfoPart.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react'
 import {mount} from 'enzyme'
 import {RouterLink} from 'tocco-ui'
@@ -28,6 +29,10 @@ describe('delete', () => {
                 }
               }}
               maxCountLink={100}
+              navigationStrategy={{
+                ListLink: ({entityName, children}) =>
+                  <RouterLink to={`${entityName}/list`}>{children}</RouterLink>
+              }}
             />
           </MemoryRouter>
         )

--- a/packages/entity-browser/src/routes/detail/components/EntityDetail/EntityDetail.js
+++ b/packages/entity-browser/src/routes/detail/components/EntityDetail/EntityDetail.js
@@ -15,7 +15,7 @@ DetailLinkRelative.propTypes = {
   currentKey: PropTypes.string.isRequired,
   entityKey: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
-  relation: PropTypes.string
+  relation: PropTypes.string.isRequired
 }
 
 class EntityDetail extends React.Component {

--- a/packages/entity-browser/src/routes/detail/components/EntityDetail/EntityDetail.js
+++ b/packages/entity-browser/src/routes/detail/components/EntityDetail/EntityDetail.js
@@ -2,11 +2,21 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {Prompt} from 'react-router-dom'
 import {intlShape} from 'react-intl'
-import {Button} from 'tocco-ui'
+import {Button, RouterLink} from 'tocco-ui'
 import EntityDetailApp from 'tocco-entity-detail/src/main'
 import {queryString as queryStringUtil} from 'tocco-util'
 
 import {StyledEntityDetailBackButton} from './StyledEntityDetail'
+
+const DetailLinkRelative = ({currentKey, entityKey, children, relation}) =>
+  <RouterLink to={`${currentKey}/${relation}/${entityKey}`}>{children}</RouterLink>
+
+DetailLinkRelative.propTypes = {
+  currentKey: PropTypes.string.isRequired,
+  entityKey: PropTypes.string.isRequired,
+  children: PropTypes.element.isRequired,
+  relation: PropTypes.string
+}
 
 class EntityDetail extends React.Component {
   constructor(props) {
@@ -23,7 +33,7 @@ class EntityDetail extends React.Component {
     this.props.router.history.push(`${this.props.router.match.url}/${relationName}/${id}`)
   }
 
-  handleNavigateToCreate = relationName => {
+  navigateToCreate = relationName => {
     if (relationName) {
       this.props.router.history.push(`${this.props.router.match.url}/${relationName}/`)
     } else {
@@ -40,7 +50,7 @@ class EntityDetail extends React.Component {
     this.props.router.history.push(`${url}${id}`)
   }
 
-  handleNavigateToAction = ({definition, selection}) => {
+  navigateToAction = (definition, selection) => {
     const search = queryStringUtil.toQueryString({
       selection,
       actionProperties: definition.properties
@@ -67,12 +77,16 @@ class EntityDetail extends React.Component {
       entityId={entityId}
       formName={formName}
       mode={mode}
+      navigationStrategy={{
+        DetailLinkRelative: props => <DetailLinkRelative {...props} currentKey={entityId}/>,
+        navigateToCreateRelative: this.navigateToCreate,
+        navigateToActionRelative: this.navigateToAction
+      }}
       onSubGridRowClick={this.handleSubGridRowClick}
-      onNavigateToCreate={this.handleNavigateToCreate}
+
       onEntityCreated={this.handleEntityCreated}
       onEntityDeleted={this.handleGoBack}
       onTouchedChange={this.handleTouchedChange}
-      onNavigateToAction={this.handleNavigateToAction}
       emitAction={action => {
         this.props.dispatchEmittedAction(action)
       }}

--- a/packages/entity-detail/README.md
+++ b/packages/entity-detail/README.md
@@ -13,16 +13,14 @@ React-registry name: `entity-detail`
 | `formName`             |           | Detail-form that should be loaded (without scope)
 | `mode`                 |           | Determines if the detail is in `create` or `update` mode
 | `defaultValues`        |           | Array of object with attributes id, value. Only for Create mode. e.g. [{id: 'lastname', value: 'Simpson}, {id:'relGender', value: '1'}]
-| `linkFactory`          |           | Object consisting of various link factories. For more information see formData documentation.
 | `actionAppComponent`   |           | Component to render custom actions. Needs the appId and selection object property.
+| `navigationStrategy`   |           | Object consisting of various link factories. For more information see tocco-util/navigationStrategy documentation.
 
 ### Events
 
 | Name                        | Payload                                                                                                            | Description
 |-----------------------------|--------------------------------------------------------------------------------------------------------------------|-------------
 | `onSubGridRowClick`         | `id` (id of the clicked record), `gridName` (name of the sub grid), `relationName` (name of the sub grid relation) | Is fired when a row of a sub grid is clicked
-| `onNavigateToCreate`        | `relationName` (Optional. If not defined, the create button of the current entity was clicked)                     | Is fired when a "create" button gets clicked
-| `onNavigateToAction`        | `definition` (action definition), `selection`(selection object)                                                    | Is called when an action is fired with the fullscreen flag
 | `onEntityCreated`           | `id` (of the newly created record)                                                                                 | Is fired when a a record got created
 | `onEntityDeleted`           |                                                                                                                    | Is fired when the loaded record got deleted
 | `onTouchedChange`           | `touched` (boolean flag which indicates if the form is touched)                                                    | This event is fired when the touched state changes

--- a/packages/entity-detail/src/components/SubGrid/SubGrid.js
+++ b/packages/entity-detail/src/components/SubGrid/SubGrid.js
@@ -19,6 +19,8 @@ const SubGrid = props => {
         formName={formBase}
         limit={props.limit}
         searchFormType={props.showSearchForm ? 'basic' : 'none'}
+        navigationStrategy={props.navigationStrategy}
+        showLink={true}
         onRowClick={e => {
           if (props.onRowClick) {
             props.onRowClick({
@@ -34,7 +36,8 @@ const SubGrid = props => {
         parent={{
           key: props.entityKey,
           reverseRelationName: props.formField.reverseRelation,
-          model: props.entityName
+          model: props.entityName,
+          relationName: props.formField.path
         }}
         emitAction={props.emitAction}
         store={viewPersistor.viewInfoSelector(subgridPersistorId).store}
@@ -65,7 +68,8 @@ SubGrid.propTypes = {
   appId: PropTypes.string,
   showSearchForm: PropTypes.bool,
   limit: PropTypes.number,
-  emitAction: PropTypes.func.isRequired
+  emitAction: PropTypes.func.isRequired,
+  navigationStrategy: PropTypes.objectOf(PropTypes.func)
 }
 
 export default SubGrid

--- a/packages/entity-detail/src/containers/SubGridContainer.js
+++ b/packages/entity-detail/src/containers/SubGridContainer.js
@@ -8,7 +8,8 @@ const mapStateToProps = (state, props) => ({
   appId: state.entityDetail.appId,
   entityKey: state.entityDetail.entity.key,
   entityName: state.entityDetail.entity.model,
-  detailFormName: state.entityDetail.formDefinition.id
+  detailFormName: state.entityDetail.formDefinition.id,
+  navigationStrategy: state.input.navigationStrategy
 })
 
 const mapActionCreators = {

--- a/packages/entity-detail/src/main.js
+++ b/packages/entity-detail/src/main.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {reducer as reducerUtil} from 'tocco-util'
+import {reducer as reducerUtil, navigationStrategy} from 'tocco-util'
 import {hot} from 'react-hot-loader/root'
 import {
   appFactory,
@@ -28,9 +28,7 @@ const EXTERNAL_EVENTS = [
   'onEntityCreated',
   'onEntityDeleted',
   'onTouchedChange',
-  'emitAction',
-  'onNavigateToCreate',
-  'onNavigateToAction'
+  'emitAction'
 ]
 
 const initApp = (id, input, events = {}, publicPath) => {
@@ -46,10 +44,11 @@ const initApp = (id, input, events = {}, publicPath) => {
       formApp: SimpleFormApp,
       listApp: EntityListApp,
       customActions,
-      appComponent: input.actionAppComponent
+      appComponent: input.actionAppComponent,
+      navigationStrategy: input.navigationStrategy
     }
   )
-  formData.addToStore(store, {listApp: EntityListApp, linkFactory: input.linkFactory})
+  formData.addToStore(store, {listApp: EntityListApp, navigationStrategy: input.navigationStrategy})
   keyDown.addToStore(store, shortcuts)
 
   const dispatchActions = getDispatchActions(input)
@@ -127,8 +126,7 @@ EntityDetailApp.propTypes = {
     propTypes[event] = PropTypes.func
     return propTypes
   }, {}),
-  onNavigateToAction: PropTypes.func,
-  onNavigateToCreate: PropTypes.func,
+  navigationStrategy: navigationStrategy.propTypes,
   actionAppComponent: PropTypes.func
 }
 

--- a/packages/entity-detail/src/modules/entityDetail/sagas.js
+++ b/packages/entity-detail/src/modules/entityDetail/sagas.js
@@ -26,6 +26,8 @@ export const entityDetailSelector = state => state.entityDetail
 
 const FORM_ID = 'detailForm'
 
+export const inputSelector = state => state.input
+
 export default function* sagas() {
   yield all([
     takeLatest(actions.LOAD_DETAIL_VIEW, loadDetailView),
@@ -321,12 +323,14 @@ export function* loadData(reset = true) {
 }
 
 export function* navigateToCreate({payload}) {
-  yield put(externalEvents.fireExternalEvent('onNavigateToCreate', payload.relationName))
+  const {navigationStrategy} = yield select(inputSelector)
+  yield call(navigationStrategy.navigateToCreateRelative, payload.relationName)
 }
 
 export function* navigateToAction({payload}) {
   const {definition, selection} = payload
-  yield put(externalEvents.fireExternalEvent('onNavigateToAction', {definition, selection}))
+  const {navigationStrategy} = yield select(inputSelector)
+  yield call(navigationStrategy.navigateToActionRelative, definition, selection)
 }
 
 export const isCurrentEntity = (event, entityName, entityId) =>

--- a/packages/entity-detail/src/modules/entityDetail/sagas.spec.js
+++ b/packages/entity-detail/src/modules/entityDetail/sagas.spec.js
@@ -384,13 +384,20 @@ describe('entity-detail', () => {
         })
 
         describe('navigateToCreate saga', () => {
-          test('should call external event onNavigateToCreate', () => {
+          test('should call navigationStrategy', () => {
             const payload = {
               relationName: 'relUser'
             }
 
+            const navigationStrategy = {
+              navigateToCreateRelative: () => {}
+            }
+
             return expectSaga(sagas.navigateToCreate, {payload})
-              .put(externalEvents.fireExternalEvent('onNavigateToCreate', payload.relationName))
+              .provide([
+                [select(sagas.inputSelector), {navigationStrategy}]
+              ])
+              .call(navigationStrategy.navigateToCreateRelative, payload.relationName)
               .run()
           })
         })
@@ -402,8 +409,15 @@ describe('entity-detail', () => {
               definition: {appId: 'input-edit'}
             }
 
+            const navigationStrategy = {
+              navigateToActionRelative: () => {}
+            }
+
             return expectSaga(sagas.navigateToAction, {payload})
-              .put.actionType('externalEvents/FIRE_EXTERNAL_EVENT')
+              .provide([
+                [select(sagas.inputSelector), {navigationStrategy}]
+              ])
+              .call(navigationStrategy.navigateToActionRelative, payload.definition, payload.selection)
               .run()
           })
         })

--- a/packages/entity-list/README.md
+++ b/packages/entity-list/README.md
@@ -26,20 +26,17 @@ React-registry name: `entity-list`
 | `selection`                     |             | Array of keys. The whole selection can be preset with this property.                                                                                                                                      | Array    |                            |
 | `selectOnRowClick`              |             | If true, a click on the row (outside the checkbox) toggles the selection of that particular row.                                                                                                          | Bool     |                            |
 | `store`                         |             | The store to use for the app. If not set, a new store is created and emitted via the `onStoreCreate` event.                                                                                               | Bool     |                            |
-| `parent`                        |             | Object with key and reverseRelationName of a parent entity. If set, the result gets filtered to only show related entities.                                                                               | Object   |                            |
-| `linkFactory`                   |             | Object consisting of various link factories. For more information see formData documentation.                                                                                                             | Object   |                            |
+| `parent`                        |             | Object with key and reverseRelationName of a parent entity. If set, the result gets filtered to only show related entities.                                                                               | Object   |                            |                                                                                                    | Object   |                            |
 | `showLink`                      |             | If true a link is shown in each row to open the record. A detail Link factory needs to be provided.                                                                                                       | Bool     | false                      |
 | `actionAppComponent`            |             | Component to render custom actions. Needs the appId and selection object property.                                                                                                                        | React Component |                     |
 | `cellRenderers`                 |             | Map of custom cell renderers which might be specified in list form definition (`client-renderer` attribute)                                                                                                                       | React Component |                     |
-
+| `navigationStrategy`   |           | Object consisting of various link factories. For more information see tocco-util/navigationStrategy documentation.
 
 ### Events
 
 | Name                | Payload                       | Description
 |---------------------|-------------------------------|-------------
 | `onRowClick`        | `id` (The id of the record)   | This event is fired when a list row is clicked
-| `onNavigateToCreate`| `relationName` (Optional. If defined, a related create button was clicked. From a subgrid for example.) | This event is fired when the "new" button is clicked
-| `onNavigateToAction`| `definition` (action definition), `selection`(selection object) | Is called when an action is called with the fullscreen flag.
 | `onSelectChange`    | An array containing the ids of the new selection | This event is fired when the selection changes
 | `onStoreCreate`     | The created store | This event is fired when the store for the app is created. Note that the event will neved be fired if a store is passed to the app via the `store` input property.
 | `onSearchChange`    | The search params | This event is fired when the search is changed

--- a/packages/entity-list/src/components/Table/Table.js
+++ b/packages/entity-list/src/components/Table/Table.js
@@ -10,7 +10,7 @@ const Table = props =>
   <UiTable
     data={props.entities}
     columns={[
-      ...(props.showLink && props.linkFactory ? [navigationCell(props.linkFactory)] : []),
+      ...(props.showLink && props.navigationStrategy ? [navigationCell(props.navigationStrategy, props.parent)] : []),
       ...props.columnDefinitions.sort((a, b) =>
         _get(props.positions, [a.id]) - _get(props.positions, [b.id])
       )
@@ -48,10 +48,11 @@ Table.propTypes = {
   parent: PropTypes.shape({
     key: PropTypes.string.isRequired,
     model: PropTypes.string.isRequired,
-    reverseRelationName: PropTypes.string
+    reverseRelationName: PropTypes.string,
+    relation: PropTypes.string
   }),
   showLink: PropTypes.bool,
-  linkFactory: PropTypes.objectOf(PropTypes.func),
+  navigationStrategy: PropTypes.objectOf(PropTypes.func),
   changePosition: PropTypes.func.isRequired,
   positions: PropTypes.objectOf(PropTypes.number)
 }

--- a/packages/entity-list/src/components/Table/navigationCell.js
+++ b/packages/entity-list/src/components/Table/navigationCell.js
@@ -4,29 +4,37 @@ import {Icon} from 'tocco-ui'
 
 import NavigationCellHeader from './NavigationCellHeader'
 
-const CellRenderer = ({rowData, linkFactory}) =>
+const CellRenderer = ({rowData, navigationStrategy, parent}) =>
   <span
     onClick={e => e.stopPropagation()}
     data-cy="list-navigation-arrow"
   >
-    {linkFactory.detail(null, null, rowData.__key, <Icon icon="arrow-right"/>)}
+    <navigationStrategy.DetailLinkRelative
+      entityKey={rowData.__key}
+      {...(parent && parent.relationName && {relation: parent.relationName})}
+    >
+      <Icon icon="arrow-right"/>
+    </navigationStrategy.DetailLinkRelative>
   </span>
 
 CellRenderer.propTypes = {
   rowData: PropTypes.shape({
     __key: PropTypes.string.isRequired
   }).isRequired,
-  linkFactory: PropTypes.shape({
-    detail: PropTypes.func.isRequired
-  }).isRequired
+  navigationStrategy: PropTypes.shape({
+    DetailLinkRelative: PropTypes.func.isRequired
+  }).isRequired,
+  parent: PropTypes.shape({
+    relationName: PropTypes.string
+  })
 }
 
-export const navigationCell = linkFactory => ({
+export const navigationCell = (navigationStrategy, parent) => ({
   id: 'navigation-column',
   fixedPosition: true,
   width: 30,
   resizable: false,
   dynamic: false,
   HeaderRenderer: NavigationCellHeader,
-  CellRenderer: props => <CellRenderer {...props} linkFactory={linkFactory}/>
+  CellRenderer: props => <CellRenderer {...props} navigationStrategy={navigationStrategy} parent={parent}/>
 })

--- a/packages/entity-list/src/containers/TableContainer.js
+++ b/packages/entity-list/src/containers/TableContainer.js
@@ -39,7 +39,7 @@ const mapStateToProps = (state, props) => ({
   selection: state.selection.selection,
   parent: state.entityList.parent,
   showLink: state.list.showLink,
-  linkFactory: state.formData.linkFactory.linkFactory,
+  navigationStrategy: state.input.navigationStrategy,
   positions: state.preferences.positions
 })
 

--- a/packages/entity-list/src/customActions.js
+++ b/packages/entity-list/src/customActions.js
@@ -2,11 +2,11 @@ import {put} from 'redux-saga/effects'
 
 import {navigateToCreate, navigateToAction} from './modules/list/actions'
 
-export default {
+export default input => ({
   new: function* () {
-    yield put(navigateToCreate())
+    yield put(navigateToCreate(input.parent && input.parent.relationName))
   },
   fullscreen: function* (definition, selection) {
     yield put(navigateToAction(definition, selection))
   }
-}
+})

--- a/packages/entity-list/src/main.js
+++ b/packages/entity-list/src/main.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {reducer as reducerUtil} from 'tocco-util'
+import {reducer as reducerUtil, navigationStrategy} from 'tocco-util'
 import {
   appFactory,
   notifier,
@@ -27,8 +27,6 @@ const packageName = 'entity-list'
 
 const EXTERNAL_EVENTS = [
   'onRowClick',
-  'onNavigateToCreate',
-  'onNavigateToAction',
   'emitAction',
   'onSelectChange',
   'onStoreCreate',
@@ -51,10 +49,11 @@ const initApp = (id, input, events = {}, publicPath) => {
     actions.addToStore(store, {
       formApp: SimpleFormApp,
       listApp: EntityListApp,
-      customActions,
-      appComponent: input.actionAppComponent
+      customActions: customActions(input),
+      appComponent: input.actionAppComponent,
+      navigationStrategy: input.navigationStrategy
     })
-    formData.addToStore(store, {listApp: EntityListApp, linkFactory: input.linkFactory})
+    formData.addToStore(store, {listApp: EntityListApp, navigationStrategy: input.navigationStrategy})
 
     dispatchActions = getDispatchActions(input, true)
 
@@ -166,9 +165,8 @@ EntityListApp.propTypes = {
     id: PropTypes.string,
     value: PropTypes.string
   }),
-  onNavigateToAction: PropTypes.func,
-  onNavigateToCreate: PropTypes.func,
-  actionAppComponent: PropTypes.func
+  actionAppComponent: PropTypes.func,
+  navigationStrategy: navigationStrategy.propTypes
 }
 
 export default hot(EntityListApp)

--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -335,12 +335,14 @@ export function* onRowClick({payload}) {
 }
 
 export function* navigateToCreate({payload}) {
-  yield put(externalEvents.fireExternalEvent('onNavigateToCreate', payload.relationName))
+  const {navigationStrategy} = yield select(inputSelector)
+  yield call(navigationStrategy.navigateToCreateRelative, payload.relationName)
 }
 
 export function* navigateToAction({payload}) {
   const {definition, selection} = payload
-  yield put(externalEvents.fireExternalEvent('onNavigateToAction', {definition, selection}))
+  const {navigationStrategy} = yield select(inputSelector)
+  yield call(navigationStrategy.navigateToActionRelative, definition, selection)
 }
 
 export const containsEntityOfModel = (event, entityName) =>

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -674,13 +674,20 @@ describe('entity-list', () => {
         })
 
         describe('navigateToCreate saga', () => {
-          test('should call external event onNavigateToCreate', () => {
+          test('should call navigationStrategy', () => {
             const payload = {
               relationName: 'relUser'
             }
 
+            const navigationStrategy = {
+              navigateToCreateRelative: () => {}
+            }
+
             return expectSaga(sagas.navigateToCreate, {payload})
-              .put(externalEvents.fireExternalEvent('onNavigateToCreate', payload.relationName))
+              .provide([
+                [select(sagas.inputSelector), {navigationStrategy}]
+              ])
+              .call(navigationStrategy.navigateToCreateRelative, payload.relationName)
               .run()
           })
         })
@@ -743,8 +750,15 @@ describe('entity-list', () => {
               definition: {appId: 'input-edit'}
             }
 
+            const navigationStrategy = {
+              navigateToActionRelative: () => {}
+            }
+
             return expectSaga(sagas.navigateToAction, {payload})
-              .put.actionType('externalEvents/FIRE_EXTERNAL_EVENT')
+              .provide([
+                [select(sagas.inputSelector), {navigationStrategy}]
+              ])
+              .call(navigationStrategy.navigateToActionRelative, payload.definition, payload.selection)
               .run()
           })
         })

--- a/packages/entity-list/src/util/cellRenderer.spec.js
+++ b/packages/entity-list/src/util/cellRenderer.spec.js
@@ -11,7 +11,7 @@ import cellRenderer from './cellRenderer'
 describe('entity-list', () => {
   describe('util', () => {
     const getStore = () => createStore(() => ({
-      formData: {linkFactory: {}},
+      formData: {navigationStrategy: {}},
       entityList: {formName: 'User'},
       list: {lazyData: {}}
     }))

--- a/packages/entity-list/src/util/fieldFactory.js
+++ b/packages/entity-list/src/util/fieldFactory.js
@@ -18,7 +18,7 @@ export default (fieldDefinition, entity, intl) => {
   const values = !isMultiType && Array.isArray(pathValue) ? pathValue : [pathValue]
   return <span key={id} style={{marginRight: '2px'}}>
     {values.map((v, idx) =>
-      <formData.FormDataContainer key={`formDataContainer-${entity.__key}-${path}`} linkFactory={true}>
+      <formData.FormDataContainer key={`formDataContainer-${entity.__key}-${path}`} navigationStrategy={true}>
         <FormattedValueWrapper type={dataType} value={v} intl={intl} formField={fieldDefinition}/>
       </formData.FormDataContainer>
     ).reduce((prev, curr, idx) => [prev, <MultiSeparator key={'sep' + idx}/>, curr])
@@ -49,7 +49,7 @@ FormattedValueWrapper.propTypes = {
   value: PropTypes.any,
   type: PropTypes.string.isRequired,
   formData: PropTypes.shape({
-    linkFactory: PropTypes.object
+    navigationStrategy: PropTypes.object
   }),
   intl: intlShape.isRequired,
   formField: PropTypes.object.isRequired

--- a/packages/entity-list/src/util/fieldFactory.spec.js
+++ b/packages/entity-list/src/util/fieldFactory.spec.js
@@ -9,7 +9,7 @@ import fieldFactory, {MultiSeparator} from './fieldFactory'
 describe('entity-list', () => {
   describe('util', () => {
     const getStore = () => createStore(() => ({
-      formData: {linkFactory: {}},
+      formData: {navigationStrategy: {}},
       entityList: {formName: 'User'},
       list: {lazyData: {}}
     }))

--- a/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/MultiRemoteSelect.js
@@ -38,7 +38,7 @@ MultiRemoteSelect.propTypes = {
     moreOptionsAvailableText: PropTypes.string,
     tooltips: PropTypes.objectOf(PropTypes.string),
     loadTooltip: PropTypes.func,
-    valueLinkFactory: PropTypes.func
+    DetailLink: PropTypes.elementType
   }),
   immutable: PropTypes.bool,
   id: PropTypes.string

--- a/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
@@ -36,7 +36,7 @@ RemoteSelect.propTypes = {
     openAdvancedSearch: PropTypes.func,
     tooltips: PropTypes.objectOf(PropTypes.string),
     loadTooltip: PropTypes.func,
-    valueLinkFactory: PropTypes.func
+    DetailLink: PropTypes.func
   }),
   immutable: PropTypes.bool,
   id: PropTypes.string

--- a/packages/tocco-ui/src/FormattedValue/FormattedValue.stories.js
+++ b/packages/tocco-ui/src/FormattedValue/FormattedValue.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react'
 import {storiesOf} from '@storybook/react'
 import {withKnobs, date, boolean, number, object, text, select} from '@storybook/addon-knobs'
@@ -167,7 +168,8 @@ storiesOf('Tocco-UI | FormattedValue', module)
         {key: '1', display: 'apple'}
       )}
       options={{
-        linkFactory: (key, children) => <a href={`/${key}`} target="_blank" rel="noopener noreferrer">{children}</a>
+        DetailLink: ({entityKey, children}) =>
+          <a href={`/${entityKey}`} target="_blank" rel="noopener noreferrer">{children}</a>
       }}
     />
   )
@@ -180,7 +182,8 @@ storiesOf('Tocco-UI | FormattedValue', module)
         [{key: '1', display: 'apple'}, {key: '2', display: 'khaki'}]
       )}
       options={{
-        linkFactory: (key, children) => <a href={`/${key}`} target="_blank" rel="noopener noreferrer">{children}</a>
+        DetailLink: ({entityKey, children}) =>
+          <a href={`/${entityKey}`} target="_blank" rel="noopener noreferrer">{children}</a>
       }}
     />
   )

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.js
@@ -9,8 +9,13 @@ const MultiSelectFormatter = ({value, options, breakWords}) => {
   return <Typography.Span breakWords={breakWords}>
     {value && value.length > 0
       ? value
-        .map(v => options && options.linkFactory
-          ? <span onClick={e => e.stopPropagation()}>{options.linkFactory(v.key, v.display)}</span>
+        .map(v => options && options.DetailLink
+          ? <span onClick={e => {
+            e.stopPropagation()
+            e.preventDefault()
+          }}>
+            <options.DetailLink entityKey={v.key}>{v.display}
+            </options.DetailLink></span>
           : v.display
         )
         .reduce((prev, curr, idx) => [prev, <MultiSeparator key={'sep' + idx}/>, curr])
@@ -21,7 +26,7 @@ const MultiSelectFormatter = ({value, options, breakWords}) => {
 MultiSelectFormatter.propTypes = {
   value: PropTypes.array,
   options: PropTypes.shape({
-    linkFactory: PropTypes.func
+    DetailLink: PropTypes.func
   }),
   breakWords: PropTypes.bool
 }

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react'
 import {mount} from 'enzyme'
 
@@ -20,7 +21,7 @@ describe('tocco-ui', () => {
           const wrapper = mount(<MultiSelectFormatter
             value={value}
             breakWords={true}
-            options={{linkFactory: (key, children) => <a>{children}</a>}}
+            options={{DetailLink: ({key, children}) => <a>{children}</a>}}
           />)
           expect(wrapper.find('a')).to.have.length(2)
         })

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/SingleSelectFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/SingleSelectFormatter.js
@@ -8,8 +8,10 @@ const SingleSelectFormatter = ({value, options, breakWords}) => {
   value = js.getOrFirst(value)
   const display = <Typography.Span breakWords={breakWords}>{value.display}</Typography.Span>
 
-  return options && options.linkFactory
-    ? <span onClick={e => e.stopPropagation()}>{options.linkFactory(value.key, display)}</span>
+  return options && options.DetailLink
+    ? <span onClick={e => e.stopPropagation()}>
+      <options.DetailLink entityKey={value.key}>{display}</options.DetailLink>
+    </span>
     : display
 }
 
@@ -24,7 +26,7 @@ SingleSelectFormatter.propTypes = {
     PropTypes.arrayOf(valuePropType)
   ]),
   options: PropTypes.shape({
-    linkFactory: PropTypes.func
+    DetailLink: PropTypes.func
   }),
   breakWords: PropTypes.bool
 }

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/SingleSelectFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/SingleSelectFormatter.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react'
 import {mount} from 'enzyme'
 
@@ -17,7 +18,7 @@ describe('tocco-ui', () => {
         test('should render Link if factory provided', () => {
           const value = {key: '3', display: 'Selected'}
           const wrapper = mount(<SingleSelectFormatter
-            value={value} options={{linkFactory: (key, children) => <a>{children}</a>}}/>)
+            value={value} options={{DetailLink: ({key, children}) => <a>{children}</a>}}/>)
           expect(wrapper.find('a')).to.have.length(1)
         })
       })

--- a/packages/tocco-ui/src/Select/MultiValueLabel.js
+++ b/packages/tocco-ui/src/Select/MultiValueLabel.js
@@ -8,12 +8,15 @@ import ClickableWrapper from './ClickableWrapper'
 
 export const MultiValueLabel = props => {
   const {data} = props
-  const {tooltips, loadTooltip, valueLinkFactory} = props.selectProps
+  const {tooltips, loadTooltip, DetailLink} = props.selectProps
   const tooltip = _get(tooltips, data.key, null)
 
-  const content = valueLinkFactory
-    ? <ClickableWrapper onMouseDown={e => e.stopPropagation()}>
-      {valueLinkFactory(data.key, <components.MultiValueLabel {...props}/>)}
+  const content = DetailLink
+    ? <ClickableWrapper onMouseDown={e => {
+      e.stopPropagation()
+      e.preventDefault()
+    }} >
+      <DetailLink entityKey={data.key}><components.MultiValueLabel {...props}/></DetailLink>
     </ClickableWrapper>
     : <components.MultiValueLabel {...props}/>
 
@@ -31,7 +34,7 @@ MultiValueLabel.propTypes = {
   selectProps: PropTypes.shape({
     tooltips: PropTypes.objectOf(PropTypes.string),
     loadTooltip: PropTypes.func,
-    valueLinkFactory: PropTypes.func
+    DetailLink: PropTypes.elementType
   })
 }
 

--- a/packages/tocco-ui/src/Select/Select.js
+++ b/packages/tocco-ui/src/Select/Select.js
@@ -36,7 +36,7 @@ const Select = ({
   theme,
   tooltips,
   value,
-  valueLinkFactory
+  DetailLink
 }) => {
   const selectComponent = useRef(null)
   const selectWrapper = useRef(null)
@@ -112,7 +112,7 @@ const Select = ({
           theme={themeSelect => reactSelectTheme(themeSelect, theme)}
           loadTooltip={loadTooltip}
           tooltips={tooltips}
-          valueLinkFactory={valueLinkFactory}
+          DetailLink={DetailLink}
           openAdvancedSearch={openAdvancedSearch}
           moreOptionsAvailable={moreOptionsAvailable}
           moreOptionsAvailableText={moreOptionsAvailableText}
@@ -180,13 +180,13 @@ Select.propTypes = {
    */
   openAdvancedSearch: PropTypes.func,
   /**
-   * Function that can wrap the value. This allows to render a <Link> around the value label for navigation purposes.
-   * First parameter is the key of the value, the second parameter is the value node itself.
+   * Component that allows to render a <Link> around the value label for navigation purposes.
+   * First parameter is the key of the value, the second parameter is the value node itself / child.
    *
    * e.g.
-   * (key, children) => <a href={`/${key}`} target="_blank" rel="noopener noreferrer">{children}</a>
+   * ({entityKey, children}) => <a href={`/${key}`} target="_blank" rel="noopener noreferrer">{children}</a>
    */
-  valueLinkFactory: PropTypes.func,
+  DetailLink: PropTypes.func,
   /**
    * Theme provided by styled-components ThemeProvider.
    */

--- a/packages/tocco-ui/src/Select/Select.stories.js
+++ b/packages/tocco-ui/src/Select/Select.stories.js
@@ -97,8 +97,8 @@ export class SelectStory extends React.Component {
           searchOptions={this.searchOptions}
           tooltips={this.state.tooltips}
           value={this.state.valueMulti}
-          valueLinkFactory={(key, children) =>
-            <a href={`/${key}`} target="_blank" rel="noopener noreferrer" >{children}</a>
+          DetailLink= {({entityKey, children}) =>
+            <a href={`/${entityKey}`} target="_blank" rel="noopener noreferrer" >{children}</a>
           }
         />
       </div>

--- a/packages/tocco-ui/src/Select/SingleValue.js
+++ b/packages/tocco-ui/src/Select/SingleValue.js
@@ -15,12 +15,14 @@ const StyledSingleValueWrapper = styled.div`
 
 export const SingleValue = props => {
   const {data, selectProps, isDisabled, children} = props
-  const {tooltips, loadTooltip, valueLinkFactory} = selectProps
+  const {tooltips, loadTooltip, DetailLink} = selectProps
   const tooltip = _get(tooltips, data.key, null)
-
-  const content = valueLinkFactory
-    ? <ClickableWrapper onMouseDown={e => e.stopPropagation()}>
-      {valueLinkFactory(data.key, children)}
+  const content = DetailLink
+    ? <ClickableWrapper onMouseDown={e => {
+      e.stopPropagation()
+      e.preventDefault()
+    }} >
+      <DetailLink entityKey={data.key}>{children}</DetailLink>
     </ClickableWrapper>
     : children
 
@@ -45,7 +47,7 @@ SingleValue.propTypes = {
   selectProps: PropTypes.shape({
     tooltips: PropTypes.objectOf(PropTypes.string),
     loadTooltip: PropTypes.func,
-    valueLinkFactory: PropTypes.func
+    DetailLink: PropTypes.func
   })
 }
 

--- a/packages/tocco-util/src/navigationStrategy/index.js
+++ b/packages/tocco-util/src/navigationStrategy/index.js
@@ -1,0 +1,3 @@
+import {propTypes} from './navigationStrategy'
+
+export default {propTypes}

--- a/packages/tocco-util/src/navigationStrategy/navigationStrategy.js
+++ b/packages/tocco-util/src/navigationStrategy/navigationStrategy.js
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types'
+
+/**
+ * navigationStrategy is an object that consists of react elements and functions to help navigate in an app. It can be
+ * used to be passed down from a root app componenet, that has knowledge of the routing (e.g. admin or entity-browser).
+ * For example a remote field (tocco-ui) does not know how to compose a link to open a detail view. But it should
+ * be able to create a link for a value. The root app, in this case tocco-admin, can create a navigationStrategy object
+ * with a DetailLink attribute. The navigation strategy can be set on the entity-detail oder entity-list app where its
+ * passed down to the select component. React element attributes (e.g DetailLink) help to render visual links and
+ * functions are for programmatically navigations.
+*/
+
+export const propTypes = PropTypes.shape({
+  /**
+   * Displays a link to a detail view.
+   * Required properties:
+   *  entityName {string}
+   *  entityKey {string}
+   *  children {element}
+   */
+  DetailLink: PropTypes.elementType,
+  /**
+   * Displays a link to a list.
+   * Required properties:
+   *  entityName {string}
+   *  children {element}
+   * Optional properties:
+   *  entityKeys {[string]} to filter the list
+   */
+  ListLink: PropTypes.elementType,
+  /**
+   * Displays a link to a detail relative to the current path. e.g. to open a detail in a list view
+   * Properties:
+   *  entityKey {string}
+   *  children {element}
+   * Optional properties:
+   *  relationName {string} to link a related entity
+   */
+  DetailLinkRelative: PropTypes.elementType,
+  /**
+   * Navigates to the corresponding create view.
+   * Params:
+   *  relationName {string} can be undefined. For navigating to a related entities create page
+   *  state {object} any state that will be passed to the create view (e.g. for default values)
+   */
+  navigateToCreateRelative: PropTypes.func,
+  /**
+   * Navigates to a fullscreen action.
+   * Params:
+   *  actionDefinition {object}
+   *  selection {object}
+   */
+  navigateToActionRelative: PropTypes.func
+})


### PR DESCRIPTION
- Change entity-list and detail to work with navigation strategy and replace linkFactory.
- Pass navigationStrategy to custom actions
- Add navigationStrategy propTypes and documentation to tocco-util
- Refactor delete action and move navigation to navigationStrategy
- Define and pass navigationStrategy in admin and entity-browser
- Adjust tocco-ui Remote component

Refs: TOCDEV-2786
Changelog: Introduce navigationStrategy