### PR TITLE
refactor(tocco-ui): remove obsolete margin

### DIFF
--- a/packages/tocco-ui/src/Menu/StyledComponents.js
+++ b/packages/tocco-ui/src/Menu/StyledComponents.js
@@ -36,8 +36,4 @@ export const StyledItemLabel = styled.div`
     calc(${scale.space(-0.5)} + ${({level}) => (level || 0) * 5 + 'px'});
   font-weight: ${({isGroup}) => isGroup ? theme.fontWeight('bold') : theme.fontWeight('regular')};
   box-shadow: none;
-
-  span > * {
-    margin-right: 4px;
-  }
 `


### PR DESCRIPTION
Refs: TOCDEV-2965
Changelog: Remove obsolete right margin inside menu item