### PR TITLE
chore: fix ci parallel problem

### DIFF
--- a/deployment/deploy_storybook_gitlab.sh
+++ b/deployment/deploy_storybook_gitlab.sh
@@ -28,4 +28,5 @@ git add -A
 rev=$(git rev-parse --short HEAD)
 git diff-index --quiet HEAD || git commit -m "rebuild storybook at ${rev}"
 
+git pull --rebase origin $PAGES_BRANCH
 git push -q git@github.com:tocco/tocco-client.git HEAD:$PAGES_BRANCH


### PR DESCRIPTION
this pull potentially fixes a problem, where the branch is not up to date when pushing.
This can happen if another ci pushed to the gh-pages branch after the current job did
clone the project.