### PR TITLE
fix(entity-list): fix sorting of search filters

### DIFF
--- a/packages/entity-list/src/components/SearchFilterList/utils.js
+++ b/packages/entity-list/src/components/SearchFilterList/utils.js
@@ -1,5 +1,5 @@
 export const searchFilterCompare = (a, b) => {
-  return a.defaultFilter
-    ? -1
+  return a.defaultFilter || b.defaultFilter
+    ? a.defaultFilter ? -1 : 1
     : (a.sorting === null) - (b.sorting === null) || a.sorting - b.sorting
 }


### PR DESCRIPTION
- a default filter is always listed before all other search filters

Refs: TOCDEV-2804