### PR TITLE
fix(entity-detail): Fix writing to fields in related entities

### DIFF
--- a/packages/entity-detail/src/modules/entityDetail/sagas.js
+++ b/packages/entity-detail/src/modules/entityDetail/sagas.js
@@ -191,7 +191,8 @@ export function* submitValidate() {
 export function* getEntityForSubmit() {
   const {formValues, dirtyFields} = yield call(getCurrentEntityState)
   const flattenEntity = yield call(form.formValuesToFlattenEntity, formValues)
-  return yield call(api.toEntity, flattenEntity, dirtyFields)
+  const dirtyFieldNames = dirtyFields.map(fieldName => form.transformFieldNameBack(fieldName))
+  return yield call(api.toEntity, flattenEntity, dirtyFieldNames)
 }
 
 export function* getPaths() {

--- a/packages/entity-detail/src/modules/entityDetail/sagas.spec.js
+++ b/packages/entity-detail/src/modules/entityDetail/sagas.spec.js
@@ -200,8 +200,19 @@ describe('entity-detail', () => {
 
         describe('getEntityForSubmit saga', () => {
           test('should return entity', () => {
-            const formValues = {__key: '3', __model: 'User', firstname: 'test'}
+            const formValues = {
+              '__key': '3',
+              '__model': 'User',
+              'firstname': 'test',
+              'relAddress': {
+                key: '29242',
+                model: 'Address',
+                version: 2
+              },
+              'relAddress--city': 'Bern'
+            }
             const initialValues = {firstname: 'tst'}
+            const dirtyFields = ['firstname', 'relAddress--city']
 
             const mode = 'update'
 
@@ -209,12 +220,21 @@ describe('entity-detail', () => {
               model: 'User',
               key: '3',
               version: undefined,
-              paths: {firstname: 'test'}
+              paths: {
+                firstname: 'test',
+                relAddress: {
+                  key: '29242',
+                  version: 2,
+                  paths: {
+                    city: 'Bern'
+                  }
+                }
+              }
             }
 
             return expectSaga(sagas.getEntityForSubmit)
               .provide([
-                [matchers.call.fn(sagas.getCurrentEntityState), {mode, initialValues, formValues}]
+                [matchers.call.fn(sagas.getCurrentEntityState), {mode, initialValues, formValues, dirtyFields}]
               ])
               .returns(expectedReturn)
               .run()


### PR DESCRIPTION
Cause of the bug:
Fields in related entities are contained in the flat entity
representation in the format '{relation name}.{field name}',
but the format in the list of the dirty fields is
'{relation name}--{field name}'.
Therefore, those fields are never considered dirty and thus those
fields are never added to the request.

Fix:
We have to convert the dirty field names back to
'{relation name}.{field name}' before calling `api.toEntity`.

Example (there aren't many of them):
One example where we want to write to a field in a related entity is
`relContent.description` (among other fields on `relContent`) in
`relResource_detail`.

Refs: TOCDEV-3118