### PR TITLE
feat(tocco-ui): expand DateTimeEdit

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
@@ -12,6 +12,7 @@ import {
   StyledDateAbstractOuterWrapper
 } from './StyledDateAbstract'
 import {GlobalDatePickerStyles} from '../../DatePicker/GlobalDatePickerStyles'
+import Ball from '../../Ball'
 
 class DateAbstract extends React.Component {
   Flatpickr = null
@@ -130,6 +131,7 @@ class DateAbstract extends React.Component {
       const altValue = this.flatpickr.altInput.value
       this.props.onBlur(altValue, this.flatpickr.selectedDates, r => this.flatpickr.setDate(r, true))
     }
+    this.flatpickr.close()
   }
 
   render() {
@@ -150,13 +152,17 @@ class DateAbstract extends React.Component {
               this.flatpickr.open()
             })
           }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              this.handleOnBlur()
+            }
+          }}
         >
           <StyledDateAbstractWrapper
             data-wrap
             onBlur={this.handleOnBlur}
             immutable={this.props.immutable}
             ref={this.wrapper}
-
           >
             <StyledDateAbstractInput
               {...this.props.immutable ? {disabled: 'disabled'} : {}}
@@ -170,6 +176,13 @@ class DateAbstract extends React.Component {
               immutable={this.props.immutable}
               value={this.state.altInput}
             />
+            <Ball
+              icon="times"
+              data-clear
+              tabIndex={-1}
+              onMouseDown={e => {
+                e.preventDefault()
+              }}/>
           </StyledDateAbstractWrapper>
         </StyledDateAbstractOuterWrapper>
       </>

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateTimeEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateTimeEdit.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, {useMemo} from 'react'
 import {injectIntl, intlShape} from 'react-intl'
 import moment from 'moment'
 
@@ -7,13 +7,28 @@ import DateAbstract from './DateAbstract'
 import {atMostOne, momentJStoToFlatpickrFormat} from '../utils'
 
 export const DateTimeEdit = props => {
-  const altDateFormat = momentJStoToFlatpickrFormat(moment().locale(props.intl.locale)._locale.longDateFormat('L'))
-  const altTimeFormat = momentJStoToFlatpickrFormat(moment().locale(props.intl.locale)._locale.longDateFormat('LT'))
+  const momentDateFormat = moment().locale(props.intl.locale)._locale.longDateFormat('L')
+  const momentTimeFormat = moment().locale(props.intl.locale)._locale.longDateFormat('LT')
+  const altDateFormat = momentJStoToFlatpickrFormat(momentDateFormat)
+  const altTimeFormat = momentJStoToFlatpickrFormat(momentTimeFormat)
+
+  const parseDate = useMemo(() => s => {
+    const momentDate = moment(s, ['D.M.YYYY H:m', momentDateFormat, momentTimeFormat])
+    return momentDate.isValid() ? momentDate.toDate() : null
+  }, [])
+
+  const onBlur = (dateString, values, setValue) => {
+    const parsed = parseDate(dateString)
+    if (values[0] - parsed !== 0) {
+      setValue(parsed)
+    }
+  }
 
   const flatpickrOptions = {
     enableTime: true,
     time_24hr: true,
-    allowInput: false,
+    allowInput: true,
+    parseDate: parseDate,
     altFormat: `${altDateFormat} ${altTimeFormat}`,
     dateFormat: 'Y-m-d\\TH:i:S.000\\Z',
     ...(props.options ? props.options.flatpickrOptions : {})
@@ -25,6 +40,7 @@ export const DateTimeEdit = props => {
     <DateAbstract
       value={[props.value]}
       onChange={handleChange}
+      onBlur={onBlur}
       immutable={props.immutable}
       options={{...props.options, flatpickrOptions}}
       events={props.events}

--- a/packages/tocco-util/src/js/object.js
+++ b/packages/tocco-util/src/js/object.js
@@ -1,12 +1,14 @@
 import _transform from 'lodash/transform'
 import _isEqual from 'lodash/isEqual'
-import _isObject from 'lodash/isObject'
+
+const isObject = v =>
+  typeof v === 'object' && v !== null
 
 export const difference = (object, base) => {
   const changes = (object, base) =>
     _transform(object, (result, value, key) => {
       if (!_isEqual(value, base[key])) {
-        result[key] = (_isObject(value) && _isObject(base[key])) ? changes(value, base[key]) : value
+        result[key] = (isObject(value) && isObject(base[key])) ? changes(value, base[key]) : value
       }
     })
 

--- a/packages/tocco-util/src/js/object.spec.js
+++ b/packages/tocco-util/src/js/object.spec.js
@@ -41,6 +41,22 @@ describe('tocco-util', () => {
         const diff = difference(obj, base)
         expect(diff).to.eql({address: {city: {zipcode: '8006'}}})
       })
+
+      test('should handle function values', () => {
+        const func1 = () => {}
+        const func2 = () => {}
+
+        const obj = {
+          func: func1
+        }
+
+        const base = {
+          func: func2
+        }
+
+        const diff = difference(obj, base)
+        expect(diff.func).to.eql(func1)
+      })
     })
   })
 })


### PR DESCRIPTION
- parse manually entered dates
- add button to clear field
- handle Enter key the same as Tab

Refs: TOCDEV-3091
Changelog: Added clear button to Date and DateTime fields. DateTime fields can now parse typed out dates as inputs.