### PR TITLE
fix(app-extension): Fix uploading documents via relation path

### DIFF
--- a/packages/app-extensions/src/formData/upload/sagas.js
+++ b/packages/app-extensions/src/formData/upload/sagas.js
@@ -4,6 +4,7 @@ import {all, call, put, takeEvery} from 'redux-saga/effects'
 import {documentToFormValueTransformer, uploadRequest} from './documents'
 import * as actions from './actions'
 import errorLogging from '../../errorLogging'
+import form from '../../form'
 
 export default function* sagas() {
   yield all([
@@ -19,7 +20,7 @@ export function* uploadDocument({payload}) {
 
     if (uploadResponse.success) {
       const documentFormValue = yield call(documentToFormValueTransformer, uploadResponse, file)
-      yield put(formActions.change(formName, field, documentFormValue))
+      yield put(formActions.change(formName, form.transformFieldName(field), documentFormValue))
     } else {
       throw new Error(`upload not successful: ${JSON.stringify(uploadResponse)}`)
     }

--- a/packages/app-extensions/src/formData/upload/sagas.spec.js
+++ b/packages/app-extensions/src/formData/upload/sagas.spec.js
@@ -22,7 +22,8 @@ describe('app-extensions', () => {
         describe('uploadDocument saga', () => {
           test('should call upload and dispatch value', () => {
             const file = {}
-            const field = 'preview_picture'
+            const field = 'relData.preview_picture'
+            const fieldTransformed = 'relData--preview_picture'
             const uploadResponse = {
               success: true
             }
@@ -33,7 +34,7 @@ describe('app-extensions', () => {
             expect(gen.next().value).to.eql(call(uploadRequest, file))
             expect(gen.next(uploadResponse).value).to.eql(call(documentToFormValueTransformer, uploadResponse, file))
             expect(gen.next(documentFormValue).value).to.eql(
-              put(formActions.change(formName, field, documentFormValue))
+              put(formActions.change(formName, fieldTransformed, documentFormValue))
             )
 
             expect(gen.next().done).to.be.true


### PR DESCRIPTION
If the field is of a related entity (path: '{relation name}.{field name}'),
we have to transform the path before putting the redux-form `change`
action to update the field --> the field IDs in the redux form cannot
contain dots, which is why we have to transform them to `--`.

Refs: TOCDEV-3118