### PR TITLE
fix(app-extension): Fix legacy actions that call `refreshListPanel()`

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -211,7 +211,11 @@ export default function* (definition, selection, parent, params, config) {
   })
   entityExplorer.init()
 
-  const ctx = new window.nice2.modules.entityexplorer.EntityExplorerActionContext(entityExplorer, null)
+  const panel = new window.nice2.modules.NewClientLegacyActionsPanel({
+    entityName: selection.entityName
+  })
+
+  const ctx = new window.nice2.modules.entityexplorer.EntityExplorerActionContext(entityExplorer, panel)
   if (selection.type === 'ID' && selection.ids.length === 1) {
     ctx.getRecord = () => ({id: selection.ids[0]})
   }


### PR DESCRIPTION
Until now, the action context didn't have a panel (2nd constructor
parameter of the action context). This led to a null pointer when
the legacy action tried to call
`this.getActionContext().getPanel().getStore().reload()` in
`refreshListPanel()`.
Now we're providing a fake panel with a fake store to avoid the null
pointer exception and to reload the list.

Refs: TOCDEV-3100