### PR TITLE
refactor(tocco-ui): fix range display

### DIFF
--- a/packages/tocco-ui/src/Range/StyledRange.js
+++ b/packages/tocco-ui/src/Range/StyledRange.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import {scale} from '../utilStyles'
 
 export const StyledInputWrapper = styled.div`
-  width: 100%;
+  width: calc(100% - 20px); // subtract extender width
 `
 export const StyledInputItemWrapper = styled.div`
   display: inline-block;
@@ -35,5 +35,7 @@ export const StyledInput = styled.div`
 export const StyledExtender = styled.div`
   display: flex;
   align-items: center;
-  margin-left: -20px;
+  position: relative;
+  left: 2px;
+  z-index: 1;
 `

--- a/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
+++ b/packages/tocco-ui/src/StatedValue/StyledStatedValue.js
@@ -10,7 +10,7 @@ import {
 } from '../utilStyles'
 import {StyledHtmlFormatter} from '../FormattedValue/typeFormatters/HtmlFormatter'
 
-const borderWidth = '1px'
+const borderWidth = '1.1px' // deliberately uneven to force correct rendering in chrome
 const animationDuration = '200ms'
 
 const getTextColor = ({isDisplay, secondaryPosition, immutable, signal}) => {


### PR DESCRIPTION
Refs: TOCDEV-3123
Changelog: Fix hidden extender and force border rendering of ranges in chrome
(cherry picked from commit acba4079bef8891ac974e9e4691d37b95e89c5f1)