### PR TITLE
feat(admin): Add more information to docs detail form

### DIFF
--- a/packages/admin/src/routes/docs/components/DocumentView/DocumentView.js
+++ b/packages/admin/src/routes/docs/components/DocumentView/DocumentView.js
@@ -16,7 +16,7 @@ const DocumentView = ({match, history, breadcrumbs, emitAction}) => {
     <EntityDetailApp
       entityName="Resource"
       entityId={match.params.key}
-      formName="Resource"
+      formName="DmsResource"
       mode="update"
       actionAppComponent={Action}
       emitAction={emitAction}


### PR DESCRIPTION
The new form `DmsResource_detail` contains display expressions instead
of legacy custom data providers, so they will be rendered in the
new client, too.

See https://git.tocco.ch/c/nice2/+/39800

Refs: TOCDEV-3120