### PR TITLE
feat(admin): Increase docs list limit from 10 (default) to 25

### DIFF
--- a/packages/admin/src/routes/docs/components/DocsView/DocsView.js
+++ b/packages/admin/src/routes/docs/components/DocsView/DocsView.js
@@ -61,6 +61,7 @@ const DocsView = props => {
         id="documents"
         entityName="Docs_list_item"
         formName="Docs_list_item"
+        limit={25}
         onRowClick={handleRowClick}
         searchFormPosition="left"
         searchFormType="admin"


### PR DESCRIPTION
The entities lists also have 25 entries. This is why we choose 25
for the docs list as well.