### PR TITLE
refactor(merge): use navigation strategy for old client

### DIFF
--- a/packages/merge/README.md
+++ b/packages/merge/README.md
@@ -11,11 +11,4 @@ React-registry name: `merge`
 |-------------------------------- | :---------: | -----------------------| -------- | ---------------------------|
 | `selection`                     | *           | Selection of entities
 | `onSuccess`                     |             | Callback if merge was successful
-| `isOldClient`                   |             | Can be set to true to work with `openEntityList`. Temporary workaround.
-
-
-### Events
-
-| Name                   | Description
-|------------------------|------------
-| `openEntityList`       | Should be set if `isOldClient` is true. Passes an object with entity name and keys {model: 'User, keys:["1"]}
+| `navigationStrategy`            |             | Object consisting of various link factories. For more information see tocco-util/navigationStrategy documentation.

--- a/packages/merge/src/components/MergeSummary/MergeSummary.js
+++ b/packages/merge/src/components/MergeSummary/MergeSummary.js
@@ -14,7 +14,7 @@ import {
 } from './StyledComponents'
 import {StyledButtonWrapper, StyledButton} from '../GlobalStyledComponents'
 
-const MergeSummary = ({mergeResponse, navigationStrategy, isOldClient, close, openEntityList}) => {
+const MergeSummary = ({mergeResponse, navigationStrategy, close}) => {
   const mapToEntityList = entities => Object.entries(_groupBy(entities, e => e.entityLabel))
     .map(([entityLabel, list]) => {
       const model = entities.find(e => e.entityLabel === entityLabel).entity
@@ -23,9 +23,7 @@ const MergeSummary = ({mergeResponse, navigationStrategy, isOldClient, close, op
         model={model}
         keys={keys}
         totalKeys={keys.length}
-        openEntityList={openEntityList}
         navigationStrategy={navigationStrategy}
-        isOldClient={isOldClient}
       /></span>
     }).reduce((prev, curr) => prev === null ? [curr] : [...prev, ', ', curr], null)
 
@@ -96,9 +94,7 @@ MergeSummary.propTypes = {
     showPermissionMessage: PropTypes.bool.isRequired
   }),
   navigationStrategy: navigationStrategy.propTypes,
-  isOldClient: PropTypes.bool.isRequired,
-  close: PropTypes.func.isRequired,
-  openEntityList: PropTypes.func.isRequired
+  close: PropTypes.func.isRequired
 }
 
 export default MergeSummary

--- a/packages/merge/src/components/MergeSummary/MergeSummaryContainer.js
+++ b/packages/merge/src/components/MergeSummary/MergeSummaryContainer.js
@@ -2,17 +2,15 @@ import {connect} from 'react-redux'
 import {injectIntl} from 'react-intl'
 
 import MergeSummary from './MergeSummary'
-import {close, openEntityList} from '../../modules/merge/actions'
+import {close} from '../../modules/merge/actions'
 
 const mapActionCreators = {
-  close,
-  openEntityList
+  close
 }
 
 const mapStateToProps = state => ({
   mergeResponse: state.merge.mergeResponse,
-  navigationStrategy: state.input.navigationStrategy,
-  isOldClient: !!state.input.isOldClient
+  navigationStrategy: state.input.navigationStrategy
 })
 
 export default connect(mapStateToProps, mapActionCreators)(injectIntl(MergeSummary))

--- a/packages/merge/src/components/MergeTable/CellRender.js
+++ b/packages/merge/src/components/MergeTable/CellRender.js
@@ -6,7 +6,6 @@ import {navigationStrategy} from 'tocco-util'
 import _get from 'lodash/get'
 
 import {
-  openEntityList,
   setSelectedMultiple,
   setSelectedMultipleAll,
   setSelectedSingle
@@ -22,9 +21,7 @@ const CellRenderer = ({
   selectedMultiple,
   setSelectedMultipleAll,
   selectedMultipleAll,
-  openEntityList,
-  navigationStrategy,
-  isOldClient
+  navigationStrategy
 }) => {
   const {entityKey} = column
   const entityData = rowData[entityKey]
@@ -39,9 +36,7 @@ const CellRenderer = ({
       name={name}
       setSelectedMultipleAll={setSelectedMultipleAll}
       isSelected={_get(selectedMultipleAll, [name], []).includes(entityKey)}
-      openEntityList={openEntityList}
       navigationStrategy={navigationStrategy}
-      isOldClient={isOldClient}
     />
   }
 
@@ -78,22 +73,18 @@ CellRenderer.propTypes = {
   selectedMultiple: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
   setSelectedMultipleAll: PropTypes.func.isRequired,
   selectedMultipleAll: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)),
-  openEntityList: PropTypes.func.isRequired,
-  navigationStrategy: navigationStrategy.propTypes,
-  isOldClient: PropTypes.bool.isRequired
+  navigationStrategy: navigationStrategy.propTypes
 }
 
 const mapActionCreatorsCell = {
   setSelectedSingle,
   setSelectedMultiple,
-  setSelectedMultipleAll,
-  openEntityList
+  setSelectedMultipleAll
 }
 const mapStateToPropsCell = state => ({
   selectedSingle: state.merge.selected.single,
   selectedMultiple: state.merge.selected.multiple,
   selectedMultipleAll: state.merge.selected.multipleAll,
-  navigationStrategy: state.input.navigationStrategy,
-  isOldClient: !!state.input.isOldClient
+  navigationStrategy: state.input.navigationStrategy
 })
 export const CellRendererContainer = connect(mapStateToPropsCell, mapActionCreatorsCell)(injectIntl(CellRenderer))

--- a/packages/merge/src/components/MergeTable/Selection.js
+++ b/packages/merge/src/components/MergeTable/Selection.js
@@ -20,9 +20,7 @@ export const ManyRelationsCheckBox = React.memo(({
   name,
   setSelectedMultipleAll,
   isSelected,
-  openEntityList,
-  navigationStrategy,
-  isOldClient
+  navigationStrategy
 }) => {
   if (entityData.value.totalKeys === 0) {
     return null
@@ -38,9 +36,7 @@ export const ManyRelationsCheckBox = React.memo(({
           model={entityData.value.relationEntity}
           keys={entityData.value.keys}
           totalKeys={entityData.value.totalKeys}
-          openEntityList={openEntityList}
           navigationStrategy={navigationStrategy}
-          isOldClient={isOldClient}
         />
       </Typography.Label>
     </StyledLabelWrapper>
@@ -59,9 +55,7 @@ ManyRelationsCheckBox.propTypes = {
   name: PropTypes.string.isRequired,
   setSelectedMultipleAll: PropTypes.func.isRequired,
   isSelected: PropTypes.bool.isRequired,
-  openEntityList: PropTypes.func.isRequired,
-  navigationStrategy: navigationStrategy.propTypes,
-  isOldClient: PropTypes.bool.isRequired
+  navigationStrategy: navigationStrategy.propTypes
 }
 
 export const RelationsCheckBoxes = React.memo(({

--- a/packages/merge/src/dev/input.json
+++ b/packages/merge/src/dev/input.json
@@ -4,5 +4,7 @@
     "type": "ID",
     "ids": [1, 2]
   },
-  "isOldClient": true
+  "navigationStrategy": {
+
+  }
 }

--- a/packages/merge/src/main.js
+++ b/packages/merge/src/main.js
@@ -12,8 +12,7 @@ const packageName = 'merge'
 
 const EXTERNAL_EVENTS = [
   'emitAction',
-  'onSuccess',
-  'openEntityList'
+  'onSuccess'
 ]
 
 const initApp = (id, input, events, publicPath) => {

--- a/packages/merge/src/modules/merge/actions.js
+++ b/packages/merge/src/modules/merge/actions.js
@@ -9,7 +9,6 @@ export const EXECUTE_MERGE = 'merge/EXECUTE_MERGE'
 export const SET_MERGE_RESPONSE = 'merge/SET_MERGE_RESPONSE'
 export const SET_MERGE_ERROR = 'merge/SET_MERGE_ERROR'
 export const CLOSE = 'merge/CLOSE'
-export const OPEN_ENTITY_LIST = 'merge/OPEN_ENTITY_LIST'
 
 export const initialize = () => ({
   type: INITIALIZE
@@ -84,12 +83,4 @@ export const setMergeError = (errorMsg, validationErrors) => ({
 
 export const close = () => ({
   type: CLOSE
-})
-
-export const openEntityList = (model, keys) => ({
-  type: OPEN_ENTITY_LIST,
-  payload: {
-    model,
-    keys
-  }
 })

--- a/packages/merge/src/modules/merge/sagas.js
+++ b/packages/merge/src/modules/merge/sagas.js
@@ -10,8 +10,7 @@ export default function* mainSagas() {
   yield all([
     takeLatest(actions.INITIALIZE, initialize),
     takeLatest(actions.EXECUTE_MERGE, executeMerge),
-    takeLatest(actions.CLOSE, close),
-    takeLatest(actions.OPEN_ENTITY_LIST, openEntityList)
+    takeLatest(actions.CLOSE, close)
   ])
 }
 
@@ -115,8 +114,4 @@ export function* close() {
   }]
 
   yield put(externalEvents.fireExternalEvent('onSuccess', {remoteEvents}))
-}
-
-export function* openEntityList({payload}) {
-  yield put(externalEvents.fireExternalEvent('openEntityList', payload))
 }

--- a/packages/merge/src/modules/merge/sagas.spec.js
+++ b/packages/merge/src/modules/merge/sagas.spec.js
@@ -28,8 +28,7 @@ describe('merge', () => {
           expect(generator.next().value).to.deep.equal(all([
             takeLatest(actions.INITIALIZE, sagas.initialize),
             takeLatest(actions.EXECUTE_MERGE, sagas.executeMerge),
-            takeLatest(actions.CLOSE, sagas.close),
-            takeLatest(actions.OPEN_ENTITY_LIST, sagas.openEntityList)
+            takeLatest(actions.CLOSE, sagas.close)
           ]))
           expect(generator.next().done).to.be.true
         })
@@ -240,19 +239,6 @@ describe('merge', () => {
                 [select(sagas.mergeSelector), {selection: selection}]
               ])
               .put(externalEvents.fireExternalEvent('onSuccess', {remoteEvents}))
-              .run()
-          })
-        })
-
-        describe('openEntityList', () => {
-          test('should call openEntityList', () => {
-            const payload = {
-              model: 'User',
-              keys: ['1', '2']
-            }
-
-            return expectSaga(sagas.openEntityList, {payload})
-              .put(externalEvents.fireExternalEvent('openEntityList', payload))
               .run()
           })
         })

--- a/packages/merge/src/util/StyledComponents.js
+++ b/packages/merge/src/util/StyledComponents.js
@@ -1,6 +1,0 @@
-import styled from 'styled-components'
-import {StyledLink} from 'tocco-ui'
-
-export const ManyRelationsStyledLink = styled(StyledLink)`
-  vertical-align: bottom;
-`

--- a/packages/merge/src/util/manyRelationEntityCount.js
+++ b/packages/merge/src/util/manyRelationEntityCount.js
@@ -3,21 +3,11 @@ import PropTypes from 'prop-types'
 import {Typography} from 'tocco-ui'
 import {navigationStrategy} from 'tocco-util'
 
-import {ManyRelationsStyledLink} from './StyledComponents'
-
 const maxCountLink = 100
 
-export const ManyRelationEntityCount = ({model, keys, totalKeys, openEntityList, navigationStrategy, isOldClient}) => {
+export const ManyRelationEntityCount = ({model, keys, totalKeys, navigationStrategy}) => {
   if (totalKeys === 0) {
     return <Typography.Span>{totalKeys}</Typography.Span>
-  } else if (isOldClient) {
-    const showEntities = e => {
-      e.stopPropagation()
-      e.preventDefault()
-      openEntityList(model, keys)
-    }
-
-    return <ManyRelationsStyledLink onClick={showEntities}>({totalKeys})</ManyRelationsStyledLink>
   } else {
     return <navigationStrategy.ListLink entityName={model} entityKeys={keys.slice(0, maxCountLink)}>
       ({totalKeys})
@@ -29,7 +19,5 @@ ManyRelationEntityCount.propTypes = {
   model: PropTypes.string.isRequired,
   keys: PropTypes.arrayOf(PropTypes.string),
   totalKeys: PropTypes.number.isRequired,
-  openEntityList: PropTypes.func.isRequired,
-  navigationStrategy: navigationStrategy.propTypes,
-  isOldClient: PropTypes.bool.isRequired
+  navigationStrategy: navigationStrategy.propTypes
 }


### PR DESCRIPTION
Refs: TOCDEV-3081
Changelog: remove workaround for opening an entity list in the old client