### PR TITLE
refactor: register app only if package name matches

### DIFF
--- a/build/jest-setup.js
+++ b/build/jest-setup.js
@@ -12,6 +12,8 @@ import setupIntlPolyfill from './intl_polyfill'
 
 Enzyme.configure({adapter: new EnzymeAdapter()})
 
+global.__PACKAGE_NAME__ = 'jest'
+
 global.chai = chai
 global.sinon = sinon
 global.expect = chai.expect


### PR DESCRIPTION
- otherwise sub apps (e.g. two-factor-connector in login app) will register itself with a wrong public path

Refs: TOCDEV-3330
Changelog: Fix empty pop-up in old client