### PR TITLE
feat(two-factor-connector): Add external event `onResize`

### DIFF
--- a/packages/two-factor-connector/README.md
+++ b/packages/two-factor-connector/README.md
@@ -13,9 +13,15 @@ React-registry name: `two-factor-connector`
 
 | Name                   | Mandatory | Description
 |------------------------|:---------:|-------------
-| `onSuccess`            |           | Callback if 2fa setup was successful.
 | `username`             |           | Username to use, will be loaded from current principal if not available.
 | `password`             |           | Password to use, only necessary if no active session is available, for example in login app when two-factor activation is forced.
 | `secret`               |           | Secret to use for activation. If not set, a new secret is loaded from the server.
 | `forced`               |           | Whether two factor authentication was forced on user, meaning they couldn't login. Will be used to display alternate info message and run activation without session.
 
+### Events
+
+| Name                   | Description
+|------------------------|------------
+| `onSuccess`            | Is fired if 2fa setup was successful
+| `onCancel`             | Is fired if 2fa setup was cancelled
+| `onResize`             | Is fired whenever the app size has changed

--- a/packages/two-factor-connector/src/main.js
+++ b/packages/two-factor-connector/src/main.js
@@ -60,15 +60,16 @@ const initApp = (id, input, events, publicPath) => {
   }
 })()
 
-const EXTERNAL_EVENTS_PASSWORD_UPDATE = [
+const EXTERNAL_EVENTS = [
   'onSuccess',
-  'onCancel'
+  'onCancel',
+  'onResize'
 ]
 
 const TwoFactorConnectorApp = props => {
   const [app, setApp] = useState(null)
   useEffect(() => {
-    const events = EXTERNAL_EVENTS_PASSWORD_UPDATE.reduce((events, event) => (
+    const events = EXTERNAL_EVENTS.reduce((events, event) => (
       {...events, ...(props[event] && {[event]: props[event]})}
     ), {})
 
@@ -79,7 +80,7 @@ const TwoFactorConnectorApp = props => {
 }
 
 TwoFactorConnectorApp.propTypes = {
-  ...EXTERNAL_EVENTS_PASSWORD_UPDATE.reduce((propTypes, event) => ({...propTypes, [event]: PropTypes.func}), {}),
+  ...EXTERNAL_EVENTS.reduce((propTypes, event) => ({...propTypes, [event]: PropTypes.func}), {}),
   username: PropTypes.string,
   password: PropTypes.string,
   secret: PropTypes.shape({

--- a/packages/two-factor-connector/src/modules/sagas.js
+++ b/packages/two-factor-connector/src/modules/sagas.js
@@ -113,11 +113,19 @@ function* getUsername() {
   }
 }
 
+export function* fireResize() {
+  yield put(externalEvents.fireExternalEvent('onResize'))
+}
+
 export default function* mainSagas() {
   yield all([
     takeLatest(actions.REQUEST_SECRET, requestSecret),
     takeLatest(actions.VERIFY_CODE, verifyCode),
     takeLatest(actions.INITIALIZE, initialize),
-    takeLatest(actions.SUCCESS, success)
+    takeLatest(actions.SUCCESS, success),
+    takeLatest(actions.GO_TO_START, fireResize),
+    takeLatest(actions.GO_TO_SECRET, fireResize),
+    takeLatest(actions.GO_TO_SECRET_VERIFICATION, fireResize),
+    takeLatest(actions.GO_TO_RESULT, fireResize)
   ])
 }

--- a/packages/two-factor-connector/src/modules/sagas.spec.js
+++ b/packages/two-factor-connector/src/modules/sagas.spec.js
@@ -15,7 +15,11 @@ describe('two-factor-connector', () => {
           takeLatest(actions.REQUEST_SECRET, sagas.requestSecret),
           takeLatest(actions.VERIFY_CODE, sagas.verifyCode),
           takeLatest(actions.INITIALIZE, sagas.initialize),
-          takeLatest(actions.SUCCESS, sagas.success)
+          takeLatest(actions.SUCCESS, sagas.success),
+          takeLatest(actions.GO_TO_START, sagas.fireResize),
+          takeLatest(actions.GO_TO_SECRET, sagas.fireResize),
+          takeLatest(actions.GO_TO_SECRET_VERIFICATION, sagas.fireResize),
+          takeLatest(actions.GO_TO_RESULT, sagas.fireResize)
         ]))
         expect(generator.next().done).to.be.true
       })
@@ -189,6 +193,14 @@ describe('two-factor-connector', () => {
             .put(actions.goToResult())
             .run()
         )
+      })
+
+      describe('fireResize', () => {
+        test('should call external onResize event', () => {
+          return expectSaga(sagas.fireResize)
+            .put(externalEvents.fireExternalEvent('onResize'))
+            .run()
+        })
       })
     })
   })


### PR DESCRIPTION
This event is fired whenever the size of the screen (resp. its height)
changes substantially (similar to the `resize` event of the login
and password update app).

This event, for instance, is useful if the app is rendered in a popup
window which should be centered whenever the height of the app changes.

Refs: TOCDEV-3048