### PR TITLE
fix: fix long term caching

### DIFF
--- a/packages/admin/src/modules/navigation/sagas.js
+++ b/packages/admin/src/modules/navigation/sagas.js
@@ -5,14 +5,14 @@ import {cache} from 'tocco-util'
 import * as actions from './actions'
 
 export function* loadMenu(id) {
-  const cachedMenu = cache.getLongTerm('menu', id)
+  const cachedMenu = cache.getMediumTerm('menu', id)
   if (cachedMenu) {
     return cachedMenu
   }
 
   const resp = yield call(rest.requestSaga, 'client/menus/' + id)
   const menu = resp.body.menuItems
-  cache.addLongTerm('menu', id, menu)
+  cache.addMediumTerm('menu', id, menu)
   return menu
 }
 

--- a/packages/admin/src/modules/session/sagas.js
+++ b/packages/admin/src/modules/session/sagas.js
@@ -60,21 +60,9 @@ export function* sessionCheck() {
 }
 
 export function* loadPrincipal() {
-  const cachedPrincipal = cache.getShortTerm('session', 'principal')
-  if (cachedPrincipal !== undefined) {
-    yield put(actions.setUsername(cachedPrincipal.username))
-    yield put(actions.setCurrentBusinessUnit(cachedPrincipal.currentBusinessUnit))
-    return
-  }
-  const principal = yield call(rest.requestSaga, 'principals')
-  const {username, businessUnit: currentBusinessUnit} = principal.body
+  const {username, currentBusinessUnit} = yield call(rest.fetchPrincipal)
   yield put(actions.setUsername(username))
   yield put(actions.setCurrentBusinessUnit(currentBusinessUnit))
-
-  yield cache.addShortTerm('session', 'principal', {
-    username,
-    currentBusinessUnit
-  })
 }
 
 export function* loadBusinessUnits() {

--- a/packages/app-extensions/src/rest/helpers.spec.js
+++ b/packages/app-extensions/src/rest/helpers.spec.js
@@ -606,6 +606,64 @@ describe('app-extensions', () => {
               .returns(expectedReturn)
               .run()
           })
+
+          test('should clear cache because other user & business unit', async() => {
+            cache.addLongTerm('session', 'principal', {
+              username: 'tocco2',
+              businessUnit: 'test2'
+            })
+            cache.addLongTerm('model', 'user', 'key')
+            cache.addMediumTerm('form', 'user', 'key')
+
+            const response = {
+              username: 'tocco',
+              businessUnit: 'test1'
+            }
+
+            const expectedReturn = {
+              username: 'tocco',
+              currentBusinessUnit: 'test1'
+            }
+
+            await expectSaga(helpers.fetchPrincipal)
+              .provide([
+                [matchers.call.fn(requestSaga), {body: response}]
+              ])
+              .returns(expectedReturn)
+              .run()
+
+            expect(cache.getMediumTerm('form', 'user')).to.be.undefined
+            expect(cache.getLongTerm('model', 'user')).to.be.equal('key')
+          })
+
+          test('should cache principal info object after fetch', async() => {
+            const response = {
+              username: 'tocco',
+              businessUnit: 'test1'
+            }
+
+            const expectedReturn = {
+              username: 'tocco',
+              currentBusinessUnit: 'test1'
+            }
+
+            await expectSaga(helpers.fetchPrincipal)
+              .provide([
+                [matchers.call.fn(requestSaga), {body: response}]
+              ])
+              .returns(expectedReturn)
+              .run()
+              .then(({effects}) => {
+                expect(effects.call.length).to.be.equal(1)
+              })
+
+            return expectSaga(helpers.fetchPrincipal)
+              .returns(expectedReturn)
+              .run()
+              .then(({effects}) => {
+                expect(effects.call).to.be.undefined
+              })
+          })
         })
       })
     })

--- a/packages/login/src/modules/sagas.js
+++ b/packages/login/src/modules/sagas.js
@@ -78,9 +78,6 @@ export function* handleFailedResponse() {
 }
 
 export function* handleSuccessfulLogin(response) {
-  const timeout = response.timeout || DEFAULT_TIMEOUT
-  yield put(externalEvents.fireExternalEvent('loginSuccess', {timeout}))
-
   const [revisionChanged, localChanged] = yield all([call(rest.hasRevisionIdChanged), call(intl.hasUserLocaleChanged)])
   if (revisionChanged || localChanged) {
     yield call(cache.clearAll)
@@ -88,6 +85,8 @@ export function* handleSuccessfulLogin(response) {
     yield call(cache.clearShortTerm)
   }
   yield put(setPassword(''))
+  const timeout = response.timeout || DEFAULT_TIMEOUT
+  yield put(externalEvents.fireExternalEvent('loginSuccess', {timeout}))
 }
 
 export function* loginSaga({payload}) {

--- a/packages/tocco-util/src/cache/cache.js
+++ b/packages/tocco-util/src/cache/cache.js
@@ -1,11 +1,19 @@
 import nice from '../nice'
 
+/*
+ * Short term caching is per browser tab. The short term cache is clear after login or business unit change
+ * Medium term cache is cleared if long term cache is cleared or principal or business unit has changed
+ * Long term cache is cleared if language or revision has changed
+ */
+
+const MEDIUM_TERM_TYPES = ['menu', 'form']
 const getKey = (type, id) => `cache.${type}.${id}`
 
 export const addShortTerm = (type, id, value) => add(type, id, value, sessionStorage)
+export const addMediumTerm = (type, id, value) => add(type, id, value, localStorage)
 export const addLongTerm = (type, id, value) => add(type, id, value, localStorage)
 
-export const add = (type, id, value, storage) => {
+const add = (type, id, value, storage) => {
   if (__DEV__ || nice.getRunEnv() !== 'PRODUCTION') {
     return null
   }
@@ -14,6 +22,7 @@ export const add = (type, id, value, storage) => {
 }
 
 export const getShortTerm = (type, id) => get(type, id, sessionStorage)
+export const getMediumTerm = (type, id) => get(type, id, localStorage)
 export const getLongTerm = (type, id) => get(type, id, localStorage)
 
 const get = (type, id, storage) => {
@@ -27,11 +36,22 @@ const get = (type, id, storage) => {
 }
 
 export const removeShortTerm = (type, id) => remove(type, id, sessionStorage)
+export const removeMediumTerm = (type, id) => remove(type, id, localStorage)
 export const removeLongTerm = (type, id) => remove(type, id, localStorage)
 const remove = (type, id, storage) => storage.removeItem(getKey(type, id))
 
 export const clearShortTerm = () => clear(sessionStorage)
 const clear = storage => storage.clear()
+
+export const clearMediumTerm = () => {
+  Object.keys(localStorage).forEach(key => {
+    MEDIUM_TERM_TYPES.forEach(type => {
+      if (key.startsWith(`cache.${type}.`)) {
+        localStorage.removeItem(key)
+      }
+    })
+  })
+}
 
 export const clearAll = () => {
   localStorage.clear()

--- a/packages/tocco-util/src/cache/cache.spec.js
+++ b/packages/tocco-util/src/cache/cache.spec.js
@@ -1,4 +1,15 @@
-import {addShortTerm, addLongTerm, getShortTerm, getLongTerm, clearAll, clearShortTerm, removeLongTerm} from './cache'
+import {
+  addShortTerm,
+  addMediumTerm,
+  addLongTerm,
+  getShortTerm,
+  getMediumTerm,
+  getLongTerm,
+  clearAll,
+  clearShortTerm,
+  removeLongTerm,
+  clearMediumTerm
+} from './cache'
 
 describe('tocco-util', () => {
   describe('cache', () => {
@@ -125,6 +136,16 @@ describe('tocco-util', () => {
         const cachedValueLongTerm = getLongTerm(type, id)
         expect(cachedValueShortTerm).to.be.undefined
         expect(cachedValueLongTerm).to.eql(value)
+      })
+
+      test('should clear medium term cache', () => {
+        addMediumTerm('form', 'id', 'form')
+        addMediumTerm('menu', 'id', 'menu')
+        addLongTerm('model', 'id', 'model')
+        clearMediumTerm()
+        expect(getMediumTerm('form', 'id')).to.be.undefined
+        expect(getMediumTerm('menu', 'id')).to.be.undefined
+        expect(getLongTerm('model', 'id')).to.eql('model')
       })
     })
 

--- a/packages/tocco-util/src/cache/index.js
+++ b/packages/tocco-util/src/cache/index.js
@@ -1,20 +1,28 @@
 import {
   addShortTerm,
+  addMediumTerm,
   addLongTerm,
   getShortTerm,
+  getMediumTerm,
   getLongTerm,
   removeShortTerm,
+  removeMediumTerm,
   removeLongTerm,
   clearShortTerm,
+  clearMediumTerm,
   clearAll
 } from './cache'
 export default {
   addShortTerm,
+  addMediumTerm,
   addLongTerm,
   getShortTerm,
+  getMediumTerm,
   getLongTerm,
   removeShortTerm,
+  removeMediumTerm,
   removeLongTerm,
   clearShortTerm,
+  clearMediumTerm,
   clearAll
 }


### PR DESCRIPTION
check if the user and business unit is the same if in the long term cache all items of the type form and menu are removed after the following events:
- page is refreshed (checking after the login is not enough because the tocco support login and cookies won't trigger the check)
- login (avoid problems with login after logout without reloading the page)

Additional fix:
- the loginSuccess event should be fired after the cache is cleared

Refs: TOCDEV-3273
Changelog: fix long term caching