### PR TITLE
feat(docs-browser): Add input param `domainTypes` to filter domains

### DIFF
--- a/packages/docs-browser/README.md
+++ b/packages/docs-browser/README.md
@@ -12,6 +12,7 @@ React-registry name: `docs-browser`
 |------------------------|:---------:|-------------
 | `history`              |           | The history to use (if not provided, a hash history is created)
 | `navigationStrategy`   |           | Object consisting of various link factories. For more information see tocco-util/navigationStrategy documentation.
+| `domainTypes`          |           | Array of domain types to show
 
 ### Events
 

--- a/packages/docs-browser/src/components/DocsView/DocsView.js
+++ b/packages/docs-browser/src/components/DocsView/DocsView.js
@@ -13,7 +13,7 @@ const ICONS = {
   Resource: 'file'
 }
 
-const getParent = match => {
+export const getParent = match => {
   if (match.params && match.params.model) {
     const model = match.params.model.charAt(0).toUpperCase() + match.params.model.slice(1)
     const key = match.params.key
@@ -26,8 +26,15 @@ const getParent = match => {
   return null
 }
 
+export const getTql = (parent, domainTypes) =>
+  !parent
+  && Array.isArray(domainTypes)
+  && domainTypes.length > 0
+    ? `exists(relDomain_type where IN(unique_id, ${domainTypes.map(type => `"${type}"`).join(',')}))`
+    : null
+
 const DocsView = props => {
-  const {storeKey, history, match, navigationStrategy, onSearchChange, emitAction, openFileDialog} = props
+  const {storeKey, history, match, domainTypes, navigationStrategy, onSearchChange, emitAction, openFileDialog} = props
 
   const handleRowClick = ({id}) => {
     const [model, key] = id.split('/')
@@ -49,6 +56,7 @@ const DocsView = props => {
   }
 
   const parent = getParent(match)
+  const tql = getTql(parent, domainTypes)
 
   const handleUploadDocument = function* (definition, selection, parent, params, config, onSuccess, onError) {
     const directory = false
@@ -94,6 +102,7 @@ const DocsView = props => {
           'upload-directory': handleUploadDirectory
         }}
         navigationStrategy={navigationStrategy}
+        tql={tql}
       />
       <FileInput/>
     </>
@@ -105,6 +114,7 @@ DocsView.propTypes = {
   match: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   navigationStrategy: PropTypes.object,
+  domainTypes: PropTypes.objectOf(PropTypes.string),
   onSearchChange: PropTypes.func.isRequired,
   emitAction: PropTypes.func.isRequired,
   openFileDialog: PropTypes.func.isRequired

--- a/packages/docs-browser/src/components/DocsView/DocsView.spec.js
+++ b/packages/docs-browser/src/components/DocsView/DocsView.spec.js
@@ -1,0 +1,57 @@
+import {getParent, getTql} from './DocsView'
+
+describe('docs-browser', () => {
+  describe('components', () => {
+    describe('DocsView', () => {
+      describe('getParent', () => {
+        test('should return null if no path match', () => {
+          const match = {
+            params: {}
+          }
+          expect(getParent(match)).to.equal(null)
+        })
+
+        test('should return parent if has path match', () => {
+          const match = {
+            params: {
+              model: 'folder',
+              key: '9345'
+            }
+          }
+          expect(getParent(match)).to.eql({
+            model: 'Docs_list_item',
+            key: 'Folder/9345'
+          })
+        })
+      })
+
+      describe('getTql', () => {
+        test('should return tql if is root level and domain types are set', () => {
+          const parent = null
+          const domainTypes = ['public_file_repository', 'internal_file_repository']
+          expect(getTql(parent, domainTypes)).to.equal(
+            'exists(relDomain_type where IN(unique_id, "public_file_repository","internal_file_repository"))'
+          )
+        })
+
+        test('should return no tql if is not root level and domain types are set', () => {
+          const parent = {
+            model: 'Docs_list_item',
+            key: 'Folder/9345'
+          }
+          const domainTypes = ['public_file_repository', 'internal_file_repository']
+          expect(getTql(parent, domainTypes)).to.equal(null)
+        })
+
+        test('should return no tql if is root level and no domain types are set', () => {
+          const parent = {
+            model: 'Docs_list_item',
+            key: 'Folder/9345'
+          }
+          const domainTypes = null
+          expect(getTql(parent, domainTypes)).to.equal(null)
+        })
+      })
+    })
+  })
+})

--- a/packages/docs-browser/src/components/DocsView/DocsViewContainer.js
+++ b/packages/docs-browser/src/components/DocsView/DocsViewContainer.js
@@ -1,0 +1,13 @@
+import {connect} from 'react-redux'
+import {injectIntl} from 'react-intl'
+
+import DocsView from './DocsView'
+
+const mapStateToProps = state => ({
+  domainTypes: state.input.domainTypes
+})
+
+const mapActionCreators = {
+}
+
+export default connect(mapStateToProps, mapActionCreators)(injectIntl(DocsView))

--- a/packages/docs-browser/src/components/DocsView/index.js
+++ b/packages/docs-browser/src/components/DocsView/index.js
@@ -1,1 +1,1 @@
-export {default} from './DocsView'
+export {default} from './DocsViewContainer'

--- a/packages/docs-browser/src/dev/input.json
+++ b/packages/docs-browser/src/dev/input.json
@@ -1,3 +1,3 @@
 {
-
+  "domainTypes": ["public_file_repository"]
 }

--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -113,7 +113,8 @@ class DocsBrowserApp extends React.Component {
 
 DocsBrowserApp.propTypes = {
   history: PropTypes.object,
-  navigationStrategy: PropTypes.object
+  navigationStrategy: PropTypes.object,
+  domainTypes: PropTypes.arrayOf(PropTypes.string)
 }
 
 export default DocsBrowserApp


### PR DESCRIPTION
Can, for instance, be used for the default mode of the public docs
browser ("domainTypes": ["public_file_repository"]).

Refs: TOCDEV-3368
Changelog: New input param `domainTypes` to filter domains