### PR TITLE
fix(entity-list): set simple form fields …

### DIFF
--- a/packages/entity-list/src/modules/searchForm/sagas.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.js
@@ -120,12 +120,20 @@ export function* loadSearchFilter(entityName) {
   ))
 }
 
+export function* setSimpleForm() {
+  const formDefinition = {txtFulltext: 'fulltext-search'}
+  yield put(actions.setFormFieldsFlat(formDefinition))
+}
+
 export function* loadSearchForm() {
   const {searchFormType, formName} = yield select(entityListSelector)
   if (searchFormType === searchFormTypes.SIMPLE) {
+    yield call(setSimpleForm)
     return null
   }
+
   let formDefinition = yield call(rest.fetchForm, formName, 'search', true)
+
   if (formDefinition) {
     const {parent} = yield select(inputSelector)
     if (parent && parent.reverseRelationName) {
@@ -134,10 +142,12 @@ export function* loadSearchForm() {
 
     yield put(actions.setFormDefinition(formDefinition))
     yield put(actions.setFormFieldsFlat(getFormFieldFlat(formDefinition)))
+    return formDefinition
   } else {
     yield put(setSearchFormType(searchFormTypes.SIMPLE))
+    yield call(setSimpleForm)
+    return null
   }
-  return formDefinition
 }
 
 export function* getEntityModel() {

--- a/packages/entity-list/src/modules/searchForm/sagas.spec.js
+++ b/packages/entity-list/src/modules/searchForm/sagas.spec.js
@@ -203,7 +203,17 @@ describe('entity-list', () => {
                 [select(sagas.entityListSelector), {searchFormType: 'basic'}]
               ])
               .not.put(actions.setFormDefinition(formDefinition))
+              .call(sagas.setSimpleForm)
               .put(setSearchFormType('simple'))
+              .run()
+          })
+
+          test('should set simple form if type is simple', () => {
+            return expectSaga(sagas.loadSearchForm)
+              .provide([
+                [select(sagas.entityListSelector), {searchFormType: 'simple'}]
+              ])
+              .call(sagas.setSimpleForm)
               .run()
           })
         })
@@ -217,6 +227,14 @@ describe('entity-list', () => {
               ])
               .dispatch(setInitialized())
               .returns(entityModel)
+              .run()
+          })
+        })
+
+        describe('setSimpleForm saga', () => {
+          test('should set simple form fields', () => {
+            return expectSaga(sagas.setSimpleForm)
+              .put.like({action: {type: actions.SET_FORM_FIELDS_FLAT}})
               .run()
           })
         })


### PR DESCRIPTION
- this is necesarry to map a txtFulltext fields to fulltext-search
 in the query builder
Changelog: Fix fulltext search form
Refs: TOCDEV-3425