### PR TITLE
fix(entity-list): fix load data if parent is changed

### DIFF
--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -183,7 +183,7 @@ export function* setParent() {
     call(loadFormDefinition, formDefinition, formName, true)
   ])
   yield put(selectionActions.clearSelection())
-  yield call(reloadData)
+  yield call(loadData, 1)
 }
 
 export function* reloadData() {

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -138,7 +138,7 @@ describe('entity-list', () => {
                 [matchers.call.fn(getEndpoint), endpoint],
                 [matchers.call.fn(getSearchEndpoint), searchEndpoint],
                 [matchers.call.fn(getConstriction), constriction],
-                [matchers.call.fn(sagas.reloadData), {}]
+                [matchers.call.fn(sagas.loadData), {}]
               ])
               .put(actions.setEntityModel(model))
               .put(actions.setFormSelectable(selectable))

--- a/packages/entity-list/src/modules/preferences/reducer.js
+++ b/packages/entity-list/src/modules/preferences/reducer.js
@@ -29,9 +29,9 @@ const ACTION_HANDLERS = {
 }
 
 const initialState = {
-  positions: null,
-  sorting: null,
-  columns: null
+  positions: {},
+  sorting: [],
+  columns: {}
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/entity-list/src/modules/preferences/reducer.spec.js
+++ b/packages/entity-list/src/modules/preferences/reducer.spec.js
@@ -2,9 +2,9 @@ import reducer from './'
 import * as actions from './actions'
 
 const EXPECTED_INITIAL_STATE = {
-  positions: null,
-  sorting: null,
-  columns: null
+  positions: {},
+  sorting: [],
+  columns: {}
 }
 
 describe('entity-list', () => {
@@ -17,7 +17,7 @@ describe('entity-list', () => {
 
         test('should handle SET_SELECTION', () => {
           const stateBefore = {
-            positions: null
+            positions: {}
           }
           const positions = {
             firstname: 0,


### PR DESCRIPTION
if the setParent method was called while the entities are already loaded but the entity count request was not finished, the list was not reloaded because initialized is not true