### PR TITLE
fix(docs-browser): Only show breadcrumbs up to specified root node

### DIFF
--- a/packages/docs-browser/src/modules/path/sagas.js
+++ b/packages/docs-browser/src/modules/path/sagas.js
@@ -6,6 +6,7 @@ import * as actions from './actions'
 
 export const textResourceSelector = (state, key) => state.intl.messages[key] || key
 export const docsPathSelector = state => state.docs.path
+export const rootNodesSelector = state => state.input.rootNodes
 
 export function* getSearchBreadcrumbs() {
   return [{
@@ -29,11 +30,23 @@ export function* loadBreadcrumbs({payload: {location}}) {
     breadcrumbs = yield call(getSearchBreadcrumbs)
   } else {
     const url = node ? `documents/${node.model}/${node.key}/breadcrumbs` : 'documents/breadcrumbs'
-    const result = yield call(rest.requestSaga, url)
+    const options = {
+      queryParams: {
+        rootnodes: yield call(getRootNodesParam)
+      }
+    }
+    const result = yield call(rest.requestSaga, url, options)
     breadcrumbs = result.body.breadcrumbs
   }
 
   yield put(actions.setBreadcrumbs(breadcrumbs))
+}
+
+function* getRootNodesParam() {
+  const rootNodes = yield select(rootNodesSelector)
+  return Array.isArray(rootNodes) && rootNodes.length > 0
+    ? rootNodes.map(node => `${node.entityName}/${node.key}`).join(',')
+    : null
 }
 
 export default function* mainSagas() {

--- a/packages/docs-browser/src/modules/path/sagas.spec.js
+++ b/packages/docs-browser/src/modules/path/sagas.spec.js
@@ -24,11 +24,13 @@ describe('admin', () => {
               test('should load root breadcrumbs', () => {
                 const pathname = '/docs'
                 const breadcrumbs = [{display: 'root'}]
+                const options = {queryParams: {rootnodes: null}}
 
                 return expectSaga(sagas.loadBreadcrumbs, actions.loadBreadcrumbs(pathname))
                   .provide([
                     [select(sagas.docsPathSelector), {}],
-                    [call(rest.requestSaga, 'documents/breadcrumbs'), {
+                    [select(sagas.rootNodesSelector), null],
+                    [call(rest.requestSaga, 'documents/breadcrumbs', options), {
                       body: {breadcrumbs}
                     }]
                   ])
@@ -39,11 +41,36 @@ describe('admin', () => {
               test('should load breadcrumbs of node', () => {
                 const pathname = '/docs/folder/45/list'
                 const breadcrumbs = [{display: 'root'}, {display: 'item 1'}, {display: 'item 2'}]
+                const options = {queryParams: {rootnodes: null}}
 
                 return expectSaga(sagas.loadBreadcrumbs, actions.loadBreadcrumbs(pathname))
                   .provide([
                     [select(sagas.docsPathSelector), {}],
-                    [call(rest.requestSaga, 'documents/Folder/45/breadcrumbs'), {
+                    [select(sagas.rootNodesSelector), null],
+                    [call(rest.requestSaga, 'documents/Folder/45/breadcrumbs', options), {
+                      body: {breadcrumbs}
+                    }]
+                  ])
+                  .put(actions.setBreadcrumbs(breadcrumbs))
+                  .run()
+              })
+
+              test('should load breadcrumbs with root nodes', () => {
+                const pathname = '/docs/folder/45/list'
+                const breadcrumbs = [{display: 'root'}, {display: 'item 2'}]
+                const options = {queryParams: {rootnodes: 'Folder/25,Folder/38'}}
+
+                return expectSaga(sagas.loadBreadcrumbs, actions.loadBreadcrumbs(pathname))
+                  .provide([
+                    [select(sagas.docsPathSelector), {}],
+                    [select(sagas.rootNodesSelector), [{
+                      entityName: 'Folder',
+                      key: '25'
+                    }, {
+                      entityName: 'Folder',
+                      key: '38'
+                    }]],
+                    [call(rest.requestSaga, 'documents/Folder/45/breadcrumbs', options), {
                       body: {breadcrumbs}
                     }]
                   ])


### PR DESCRIPTION
If root nodes are defined, the breadcrumbs navigation should "stop"
at the specified root node instead of showing the entire path up to
the actual domain node.

Also see: https://git.tocco.ch/c/nice2/+/40240

Refs: TOCDEV-3368