### PR TITLE
feat(docs-browser): Add input prop `documentDetailFormName`

### DIFF
--- a/packages/docs-browser/README.md
+++ b/packages/docs-browser/README.md
@@ -14,6 +14,7 @@ React-registry name: `docs-browser`
 | `navigationStrategy`   |           | Object consisting of various link factories. For more information see tocco-util/navigationStrategy documentation.
 | `domainTypes`          |           | Array of domain types to show
 | `rootNodes`            |           | Array of root nodes to use instead of the domains (array of objects with `entityName` and `key`)
+| `documentDetailFormName`|          | Name of the document detail form to use (default: "DmsResource") 
 
 ### Events
 

--- a/packages/docs-browser/src/components/DocumentView/DocumentView.js
+++ b/packages/docs-browser/src/components/DocumentView/DocumentView.js
@@ -4,7 +4,7 @@ import EntityDetailApp from 'tocco-entity-detail/src/main'
 
 import Action from '../Action/'
 
-const DocumentView = ({match, history, breadcrumbs, navigationStrategy, emitAction}) => {
+const DocumentView = ({match, history, breadcrumbs, formName, navigationStrategy, emitAction}) => {
   const handleEntityDeleted = () => {
     const lastList = breadcrumbs.slice().reverse()
       .find(breadcrumb => breadcrumb.type === 'list')
@@ -16,7 +16,7 @@ const DocumentView = ({match, history, breadcrumbs, navigationStrategy, emitActi
     <EntityDetailApp
       entityName="Resource"
       entityId={match.params.key}
-      formName="DmsResource"
+      formName={formName || 'DmsResource'}
       mode="update"
       actionAppComponent={Action}
       navigationStrategy={navigationStrategy}
@@ -39,6 +39,7 @@ DocumentView.propTypes = {
     path: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired
   })).isRequired,
+  formName: PropTypes.string,
   navigationStrategy: PropTypes.object,
   emitAction: PropTypes.func.isRequired
 }

--- a/packages/docs-browser/src/components/DocumentView/DocumentViewContainer.js
+++ b/packages/docs-browser/src/components/DocumentView/DocumentViewContainer.js
@@ -5,7 +5,8 @@ import {actionEmitter} from 'tocco-app-extensions'
 import DocumentView from './DocumentView'
 
 const mapStateToProps = state => ({
-  breadcrumbs: state.docs.path.breadcrumbs
+  breadcrumbs: state.docs.path.breadcrumbs,
+  formName: state.input.documentDetailFormName
 })
 
 const mapActionCreators = {

--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -128,7 +128,8 @@ DocsBrowserApp.propTypes = {
   rootNodes: PropTypes.arrayOf(PropTypes.shape({
     entityName: PropTypes.string,
     key: PropTypes.string
-  }))
+  })),
+  documentDetailFormName: PropTypes.string
 }
 
 export default DocsBrowserApp


### PR DESCRIPTION
Can be defined to override the default document detail form name
(which is "DmsResource")

Refs: TOCDEV-3458