### PR TITLE
fix(tocco-ui): fix empty integer and number edit

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/IntegerEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/IntegerEdit.js
@@ -15,7 +15,11 @@ const IntegerEdit = ({value, onChange, options, immutable, name, id}) => {
   } = options || {}
 
   const handleChange = ({value, floatValue}) => {
-    onChange(allowLeadingZeros ? value : floatValue)
+    let newValue = allowLeadingZeros ? value : floatValue
+    if (!newValue) {
+      newValue = null
+    }
+    onChange(newValue)
   }
 
   const isAllowed = ({floatValue}) =>

--- a/packages/tocco-ui/src/EditableValue/typeEditors/IntegerEdit.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/IntegerEdit.spec.js
@@ -44,6 +44,23 @@ describe('tocco-ui', () => {
           wrapper.find('input').simulate('change', {target: {value: '100', focus: () => {}}})
         })
 
+        test('should call onChange handler with value null', done => {
+          const changeHandler = value => {
+            expect(value).to.be.null
+            done()
+          }
+
+          const wrapper = mount(
+            <IntegerEdit
+              value={1}
+              onChange={changeHandler}
+              options={{maxValue: 100}}
+            />
+          )
+
+          wrapper.find('input').simulate('change', {target: {value: '', focus: () => {}}})
+        })
+
         test('should not call onChange it number is too high', done => {
           const spy = sinon.spy()
           const wrapper = mount(

--- a/packages/tocco-ui/src/EditableValue/typeEditors/NumberEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/NumberEdit.js
@@ -68,7 +68,7 @@ const NumberEdit = props => {
 
   const handleChange = values => {
     if (props.onChange && checkValueRange(minValue, calculatedMaxValue, values.floatValue)) {
-      props.onChange(values.floatValue)
+      props.onChange(values.floatValue ? values.floatValue : null)
     }
   }
 

--- a/packages/tocco-ui/src/EditableValue/typeEditors/NumberEdit.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/NumberEdit.spec.js
@@ -16,6 +16,19 @@ describe('tocco-ui', () => {
           expect(wrapper.find('input')).to.have.length(1)
         })
 
+        test('should call onChange handler with value null', done => {
+          const changeHandler = value => {
+            expect(value).to.be.null
+            done()
+          }
+
+          const wrapper = mountWithIntl(
+            <NumberEdit value={1234567.89} options={{}} onChange={changeHandler} />
+          )
+
+          wrapper.find('input').simulate('change', {target: {value: '', focus: () => {}}})
+        })
+
         test('should return number string in en', () => {
           const result = '1,234,567.89'
           const wrapper = mountWithIntl(


### PR DESCRIPTION
if an integer or number edit the value should be null and not undefined

Refs: TOCDEV-3375