### PR TITLE
fix(tocco-ui): no initial onChange

### DIFF
--- a/packages/tocco-ui/src/EditableValue/EditableValue.stories.js
+++ b/packages/tocco-ui/src/EditableValue/EditableValue.stories.js
@@ -118,7 +118,7 @@ storiesOf('Tocco-UI | EditableValue', module)
       <EditableValueStory
         type="html"
         knobType={text}
-        defaultValue={'<h1>Test</h1>'}
+        defaultValue={'<h1>Test</h1> TEst <span>TEST</span>'}
       />,
     {knobs: {escapeHTML: false}}
   )

--- a/packages/tocco-ui/src/EditableValue/typeEditors/HtmlEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/HtmlEdit.js
@@ -34,8 +34,8 @@ class HtmlEdit extends React.Component {
     this.lazyQuill = lazy(() => import(/* webpackChunkName: "quill" */ 'react-quill'))
   }
 
-  handleChange = value => {
-    if (this.props.onChange) {
+  handleChange = (value, delta, source) => {
+    if (this.props.onChange && source === 'user') {
       this.props.onChange(value)
     }
   }
@@ -55,7 +55,12 @@ class HtmlEdit extends React.Component {
             onChange={this.handleChange}
             id={this.props.id}
             theme="snow"
-            value={this.props.value}
+            defaultValue={this.props.value}
+            modules={{
+              clipboard: {
+                matchVisual: false
+              }
+            }}
           />
         </Suspense>
       </StyledHtmlEdit>


### PR DESCRIPTION
- in HTML Edit a onChange should only be triggered after user Input and never of api changes. Such api changes can be triggered if the value has content that is not wrapped in an element.

Changelog: Fix html edit initial change
Refs: TOCDEV-336