### PR TITLE
fix: do not show notifier for aborted fetch

### DIFF
--- a/packages/app-extensions/src/rest/request.js
+++ b/packages/app-extensions/src/rest/request.js
@@ -1,3 +1,5 @@
+import {saga} from 'tocco-util'
+
 import InformationError from './InformationError'
 
 const PRECONDITION_FAILED_STATUS_CODE = 412
@@ -53,7 +55,7 @@ export function sendRequest(url, options, acceptedErrorCodes = [], acceptedStatu
     acceptedStatusCodes.push(PRECONDITION_FAILED_STATUS_CODE)
   }
 
-  return fetch(url, options)
+  return fetch(url, {...options, signal: saga.abortController.signal})
     .then(response => (extractBody(response)))
     .then(response => (handleError(response, acceptedErrorCodes, acceptedStatusCodes)))
 }

--- a/packages/tocco-util/src/saga/abortController.js
+++ b/packages/tocco-util/src/saga/abortController.js
@@ -1,0 +1,2 @@
+export const abortController = new AbortController()
+window.addEventListener('beforeunload', () => abortController.abort())

--- a/packages/tocco-util/src/saga/index.js
+++ b/packages/tocco-util/src/saga/index.js
@@ -1,3 +1,4 @@
 import {checkStatusLoop, autoRestartSaga, createGenerator, injectSaga} from './saga'
+import {abortController} from './abortController'
 
-export default {checkStatusLoop, autoRestartSaga, createGenerator, injectSaga}
+export default {checkStatusLoop, autoRestartSaga, createGenerator, injectSaga, abortController}

--- a/packages/tocco-util/src/saga/saga.js
+++ b/packages/tocco-util/src/saga/saga.js
@@ -1,6 +1,7 @@
 import {all, call, put, delay} from 'redux-saga/effects'
 
 import consoleLogger from '../consoleLogger'
+import {abortController} from './abortController'
 
 /**
  * Sends a request to a location in a repetitive manner until the response has another status
@@ -37,10 +38,12 @@ export const autoRestartSaga = (generator, config, logErrorAction) => {
       try {
         yield call(generator, config, ...args)
       } catch (error) {
-        if (logErrorAction) {
-          yield put(logErrorAction('client.common.unexpectedError', 'client.common.unexpectedError', error))
-        } else {
-          consoleLogger.logError('error', error)
+        if (abortController.signal.aborted === false) {
+          if (logErrorAction) {
+            yield put(logErrorAction('client.common.unexpectedError', 'client.common.unexpectedError', error))
+          } else {
+            consoleLogger.logError('error', error)
+          }
         }
       }
     }


### PR DESCRIPTION
if page is refreshed and a request is pending in firefox this results in an unexpected error notifier. if requests are aborted because the page is reloaded no notifier should be shown.

Refs: TOCDEV-3557
Changelog: do not show notifier for aborted fetch