### PR TITLE
refactor(docs-browser): set embedded property

### DIFF
--- a/packages/docs-browser/src/components/Action/actions/Move.js
+++ b/packages/docs-browser/src/components/Action/actions/Move.js
@@ -60,6 +60,7 @@ export const MoveAction = ({selection, onSuccess, onError, context, initialize, 
       onListParentChange={parent => setParent(parent)}
       getCustomLocation={getCustomLocation}
       navigationStrategy={{}}
+      embedded={true}
     />
     <StyledButtonsWrapper>
       <Button


### PR DESCRIPTION
Refs: TOCDEV-3571
Changelog: Set background color of breadcrumbs inside doc browser to white