### PR TITLE
fix(copy): ignore field if path is null

### DIFF
--- a/packages/copy/src/modules/copy/sagas.js
+++ b/packages/copy/src/modules/copy/sagas.js
@@ -48,5 +48,5 @@ export function* getValues(entityName, entityKey, formName) {
 export function* getPaths(formName) {
   const formDefinition = yield call(rest.fetchForm, formName, 'create')
   const fields = yield call(form.getFieldDefinitions, formDefinition)
-  return fields.filter(f => f.ignoreCopy !== true).map(e => e.path)
+  return fields.filter(f => f.ignoreCopy !== true && f.path).map(e => e.path)
 }


### PR DESCRIPTION
location-field element in form has no path and produces a 400 "empty path" error during fetching the entity

Refs: TOCDEV-3293
Changelog: ignore field if path is null in copy action