### PR TITLE
fix(docs-browser): Fix usage of special list form if root nodes set

### DIFF
--- a/packages/docs-browser/src/components/DocsView/DocsView.js
+++ b/packages/docs-browser/src/components/DocsView/DocsView.js
@@ -78,6 +78,8 @@ const DocsView = props => {
 
   const [selection, setSelection] = useState([])
   const parent = useMemo(() => getParent(match), [match.params])
+
+  const keys = !parent && rootNodes ? rootNodes.map(node => `${node.entityName}/${node.key}`) : null
   const listFormName = useMemo(() => formName === null ? getFormName(parent, keys) : formName, [match.params])
 
   useEffect(() => {
@@ -93,7 +95,6 @@ const DocsView = props => {
     }
   }
 
-  const keys = !parent && rootNodes ? rootNodes.map(node => `${node.entityName}/${node.key}`) : null
   const tql = !parent && !keys ? getTql(domainTypes) : null
 
   const handleUploadDocument = function* (definition, selection, parent, params, config, onSuccess, onError) {


### PR DESCRIPTION
In commit 9250b83, the `listFormName` variable was introduced on
line 82. However, the variable depends on `keys` which was set later
on line 97. Therefore, `keys` was always undefined, so the form
for specific root nodes `Root_docs_list_item_specific` was never used.