### PR TITLE
fix(docs-browser): Fix usage of special list form if root nodes set

### DIFF
--- a/packages/docs-browser/src/components/DocsView/DocsView.js
+++ b/packages/docs-browser/src/components/DocsView/DocsView.js
@@ -79,6 +79,8 @@ const DocsView = props => {
 
   const [selection, setSelection] = useState([])
   const parent = useMemo(() => getParent(match), [match.params])
+
+  const keys = !parent && rootNodes ? rootNodes.map(node => `${node.entityName}/${node.key}`) : null
   const listFormName = useMemo(() => formName === null ? getFormName(parent, keys) : formName, [match.params])
 
   useEffect(() => {
@@ -94,7 +96,6 @@ const DocsView = props => {
     }
   }
 
-  const keys = !parent && rootNodes ? rootNodes.map(node => `${node.entityName}/${node.key}`) : null
   const tql = !parent && !keys ? getTql(domainTypes) : null
 
   const handleUploadDocument = function* (definition, selection, parent, params, config, onSuccess, onError) {

--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -72,7 +72,11 @@ const initApp = (id, input, events = {}, publicPath) => {
     history.push(input.initialLocation)
   }
 
-  const singleRootNode = Array.isArray(input.rootNodes) && input.rootNodes.length === 1 ? input.rootNodes[0] : null
+  const singleRootNode = Array.isArray(input.rootNodes) && input.rootNodes.length === 1
+    && input.rootNodes[0].entityName !== 'Resource'
+    ? input.rootNodes[0]
+    : null
+  
   const startUrl = singleRootNode
     ? `/docs/${singleRootNode.entityName.toLowerCase()}/${singleRootNode.key}/list`
     : '/docs'


### PR DESCRIPTION
In commit 9250b83, the `listFormName` variable was introduced on
line 82. However, the variable depends on `keys` which was set later
on line 97. Therefore, `keys` was always undefined, so the form
for specific root nodes `Root_docs_list_item_specific` was never used.