### PR TITLE
fix(entity-list): fix reusing of entity list store

### DIFF
--- a/packages/entity-list/src/main.js
+++ b/packages/entity-list/src/main.js
@@ -76,7 +76,7 @@ const initApp = (id, input, events = {}, publicPath) => {
     {
       input,
       events,
-      actions: getDispatchActions(input),
+      actions: [reloadAll(true), ...getDispatchActions(input)],
       publicPath,
       textResourceModules: ['component', 'common']
     }

--- a/packages/entity-list/src/modules/entityList/actions.js
+++ b/packages/entity-list/src/modules/entityList/actions.js
@@ -58,6 +58,9 @@ export const reloadData = () => ({
   type: RELOAD_DATA
 })
 
-export const reloadAll = () => ({
-  type: RELOAD_ALL
+export const reloadAll = waitForInputDispatch => ({
+  type: RELOAD_ALL,
+  payload: {
+    waitForInputDispatch
+  }
 })

--- a/packages/entity-list/src/modules/entityList/sagas.js
+++ b/packages/entity-list/src/modules/entityList/sagas.js
@@ -1,4 +1,4 @@
-import {put, call, all, take, takeLatest} from 'redux-saga/effects'
+import {put, all, take, takeLatest} from 'redux-saga/effects'
 import {appFactory} from 'tocco-app-extensions'
 
 import * as actions from './../entityList/actions'
@@ -10,16 +10,16 @@ export const entityListSelector = state => state.entityList
 
 export default function* sagas() {
   yield all([
-    call(initialize),
     takeLatest(actions.RELOAD_DATA, reloadData),
-    takeLatest(actions.RELOAD_ALL, initialize, false)
+    takeLatest(actions.RELOAD_ALL, initialize)
   ])
 }
 
-export function* initialize(waitForInputDispatch = true) {
+export function* initialize({payload: {waitForInputDispatch}}) {
   if (waitForInputDispatch) {
     yield take(appFactory.inputDispatchActionType)
   }
+  yield put(listActions.setInProgress(true))
   yield put(listActions.initialize())
   yield put(preferenceActions.loadPreferences())
   yield put(searchFormActions.initialize())

--- a/packages/entity-list/src/modules/entityList/sagas.spec.js
+++ b/packages/entity-list/src/modules/entityList/sagas.spec.js
@@ -1,4 +1,4 @@
-import {call, takeLatest, all} from 'redux-saga/effects'
+import {takeLatest, all} from 'redux-saga/effects'
 import {appFactory} from 'tocco-app-extensions'
 import {expectSaga} from 'redux-saga-test-plan'
 
@@ -16,9 +16,8 @@ describe('entity-list', () => {
           test('should fork child sagas', () => {
             const generator = rootSaga()
             expect(generator.next().value).to.deep.equal(all([
-              call(sagas.initialize),
               takeLatest(actions.RELOAD_DATA, sagas.reloadData),
-              takeLatest(actions.RELOAD_ALL, sagas.initialize, false)
+              takeLatest(actions.RELOAD_ALL, sagas.initialize)
             ]))
             expect(generator.next().done).to.be.true
           })
@@ -26,8 +25,9 @@ describe('entity-list', () => {
 
         describe('initialize', () => {
           test('should coordinate loading of modules and dependencies', () => {
-            return expectSaga(sagas.initialize)
+            return expectSaga(sagas.initialize, {payload: {waitForInputDispatch: true}})
               .dispatch({type: appFactory.inputDispatchActionType})
+              .put(listActions.setInProgress(true))
               .put(listActions.initialize())
               .put(preferenceActions.loadPreferences())
               .put(searchFormActions.initialize())


### PR DESCRIPTION
fix two problems if a store was reused (e.g. navigate docs list -> docs detail -> docs list (other parent)):
- in the initial state inProgress is true. However if the store was reused inProgress is false and set to true in the reloadData saga which is too late
- the call(initialize) in the root saga was not triggered if the store was reused. Move call to main.js

Refs: TOCDEV-3615, TOCDEV-3449
Changelog: fix reusing of entity list store