### PR TITLE
feat(docs-browser): Add input props to define detail form names

### DIFF
--- a/packages/docs-browser/README.md
+++ b/packages/docs-browser/README.md
@@ -18,6 +18,8 @@ React-registry name: `docs-browser`
 | `listLimit`            |           | Amount of records per page in list
 | `listFormName`         |           | Set a form name for the list
 | `documentDetailFormName`|          | Name of the document detail form to use (default: "DmsResource")
+| `domainDetailFormName` |           | Name of the domain detail form to use (default: "DmsDomain")
+| `folderDetailFormName` |           | Name of the folder detail form to use (default: "DmsFolder")
 | `searchFormType`       |           | Possible values: none (no search form shown), simple (only one fulltext search field), basic (usual search form with advanced expansion), admin (full search with search filter)
 | `selectionStyle`       |           | none", "multi" or "single". If not defined and form model selectable is true, "multi" is used. Otherwise no selection is possible.
 | `memoryHistory`        |           | If set to true in-memory history. This is useful in testing and non-DOM environments.

--- a/packages/docs-browser/src/components/Action/actions/CreateDomain.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateDomain.js
@@ -4,6 +4,7 @@ import EntityDetailApp from 'tocco-entity-detail/src/main'
 import {injectIntl, intlShape} from 'react-intl'
 
 import getNode from '../../../utils/getNode'
+import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
   const handleEntityCreated = ({id}) => {
@@ -30,9 +31,11 @@ const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
       ]
     : []
 
+  const formName = getDetailFormName(context, 'Domain')
+
   return <EntityDetailApp
     entityName="Domain"
-    formName="Domain"
+    formName={formName}
     mode="create"
     defaultValues={defaultValues}
     onEntityCreated={handleEntityCreated}

--- a/packages/docs-browser/src/components/Action/actions/CreateFolder.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateFolder.js
@@ -4,6 +4,7 @@ import EntityDetailApp from 'tocco-entity-detail/src/main'
 import {injectIntl, intlShape} from 'react-intl'
 
 import getNode from '../../../utils/getNode'
+import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
   const handleEntityCreated = ({id}) => {
@@ -30,9 +31,11 @@ const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
       ]
     : []
 
+  const formName = getDetailFormName(context, 'Folder')
+
   return <EntityDetailApp
     entityName="Folder"
-    formName="Folder"
+    formName={formName}
     mode="create"
     defaultValues={defaultValues}
     onEntityCreated={handleEntityCreated}

--- a/packages/docs-browser/src/components/Action/actions/Edit.js
+++ b/packages/docs-browser/src/components/Action/actions/Edit.js
@@ -4,6 +4,8 @@ import {injectIntl, intlShape} from 'react-intl'
 import EntityDetailApp from 'tocco-entity-detail/src/main'
 import {selection} from 'tocco-util'
 
+import getDetailFormName from '../../../utils/getDetailFormName'
+
 const EditAction = ({selection, onSuccess, onCancel, intl, context, emitAction}) => {
   const [entityName, entityKey] = selection.ids[0].split('/')
 
@@ -29,9 +31,11 @@ const EditAction = ({selection, onSuccess, onCancel, intl, context, emitAction})
     })
   }
 
+  const formName = getDetailFormName(context, entityName)
+
   return <EntityDetailApp
       entityName={entityName}
-      formName={`Dms${entityName}`}
+      formName={formName}
       entityId={entityKey}
       mode="update"
       onEntityUpdated={handleEntityUpdated}

--- a/packages/docs-browser/src/components/DocsView/DocsView.js
+++ b/packages/docs-browser/src/components/DocsView/DocsView.js
@@ -73,6 +73,8 @@ const DocsView = props => {
     getCustomLocation,
     disableViewPersistor,
     formName,
+    domainDetailFormName,
+    folderDetailFormName,
     showActions
   } = props
 
@@ -139,7 +141,11 @@ const DocsView = props => {
           emitAction={emitAction}
           actionAppComponent={Action}
           contextParams={{
-            history
+            history,
+            detailFormNames: {
+              Domain: domainDetailFormName,
+              Folder: folderDetailFormName
+            }
           }}
           customActions={{
             'upload-document': handleUploadDocument,
@@ -179,6 +185,8 @@ DocsView.propTypes = {
   getCustomLocation: PropTypes.func,
   disableViewPersistor: PropTypes.bool,
   formName: PropTypes.string,
+  domainDetailFormName: PropTypes.string,
+  folderDetailFormName: PropTypes.string,
   showActions: PropTypes.bool
 }
 

--- a/packages/docs-browser/src/components/DocsView/DocsViewContainer.js
+++ b/packages/docs-browser/src/components/DocsView/DocsViewContainer.js
@@ -13,6 +13,8 @@ const mapStateToProps = state => ({
   getCustomLocation: state.input.getCustomLocation,
   disableViewPersistor: state.input.disableViewPersistor,
   formName: state.docs.list.formName,
+  domainDetailFormName: state.input.domainDetailFormName,
+  folderDetailFormName: state.input.folderDetailFormName,
   showActions: state.input.showActions
 })
 

--- a/packages/docs-browser/src/utils/getDetailFormName.js
+++ b/packages/docs-browser/src/utils/getDetailFormName.js
@@ -1,0 +1,6 @@
+const getDetailFormName = (context, entityName) =>
+  context.detailFormNames && context.detailFormNames[entityName]
+    ? context.detailFormNames[entityName]
+    : `Dms${entityName}`
+
+export default getDetailFormName


### PR DESCRIPTION
New props `domainDetailFormName` and `folderDetailFormName` which
work the same way as the already existing `documentDetailFormName`.
-> Can be defined to override the default detail form names
   (which are "DmsDomain" and "DmsFolder")

Refs: TOCDEV-3458