### PR TITLE
refactor(docs-browser): adjust breadcrumbs padding

### DIFF
--- a/packages/admin/src/routes/entities/components/DocsView/DocsView.js
+++ b/packages/admin/src/routes/entities/components/DocsView/DocsView.js
@@ -3,7 +3,7 @@ import DocsBrowserApp from 'tocco-docs-browser/src/main'
 import {rest} from 'tocco-app-extensions'
 import PropTypes from 'prop-types'
 
-const DocsView = ({entityName, entityKey, showActions}) => {
+const DocsView = ({entityName, entityKey, showActions, hasLeftPadding}) => {
   const [folderKey, setFolderKey] = useState(null)
 
   const fetchFolder = async() => {
@@ -19,10 +19,14 @@ const DocsView = ({entityName, entityKey, showActions}) => {
 
   return folderKey
     && <DocsBrowserApp
+      hasLeftPadding={hasLeftPadding}
       sortable={false}
       searchFormType="none"
       rootNodes={[
-        {key: folderKey, entityName: 'Folder'}
+        {
+          key: folderKey,
+          entityName: 'Folder'
+        }
       ]}
       embedded={true}
       showActions={showActions}
@@ -34,7 +38,8 @@ const DocsView = ({entityName, entityKey, showActions}) => {
 DocsView.propTypes = {
   entityName: PropTypes.string.isRequired,
   entityKey: PropTypes.string.isRequired,
-  showActions: PropTypes.bool.isRequired
+  showActions: PropTypes.bool.isRequired,
+  hasLeftPadding: PropTypes.bool
 }
 
 export default DocsView

--- a/packages/admin/src/routes/entities/components/ListView/DocsViewAdapter.js
+++ b/packages/admin/src/routes/entities/components/ListView/DocsViewAdapter.js
@@ -5,11 +5,12 @@ import {currentViewPropType} from '../../utils/propTypes'
 
 const DocsViewAdapter = ({currentViewInfo}) =>
     <DocsView
+        hasLeftPadding={true}
         entityName={currentViewInfo.parentModel.name}
         entityKey={currentViewInfo.parentKey}
         showActions={true}
     />
-  
+
 DocsViewAdapter.propTypes = {
   currentViewInfo: currentViewPropType
 }

--- a/packages/docs-browser/README.md
+++ b/packages/docs-browser/README.md
@@ -27,6 +27,8 @@ React-registry name: `docs-browser`
 | `embedded`             |           | If true, the styling is more subtle (E.g. no background color for in the breadcrumbs). Default is false.
 | `showActions`          |           | Attribute will be passed along to entity-list.
 | `sortable`             |           | Attribute will be passed along to entity-list.
+| `hasLeftPadding`       |           | If true, a LeftPadding will be applied to the Breadcrumbs.
+
 ### Events
 
 | Name                | Payload                       | Description

--- a/packages/docs-browser/src/components/DocsBrowser/DocsBrowser.js
+++ b/packages/docs-browser/src/components/DocsBrowser/DocsBrowser.js
@@ -18,7 +18,8 @@ const DocsBrowser = ({
   emitAction,
   openFileDialog,
   theme,
-  embedded
+  embedded,
+  hasLeftPadding
 }) => {
   // eslint-disable-next-line no-unused-vars
   const [docsViewNumber, forceDocsViewUpdate] = useReducer(x => x + 1, 0)
@@ -50,7 +51,7 @@ const DocsBrowser = ({
 
   return (
     <StyledWrapper>
-      <StyledBreadcrumbs embedded={embedded}>
+      <StyledBreadcrumbs hasLeftPadding={hasLeftPadding}>
         <Breadcrumbs {...embedded ? {backgroundColor: themeUtil.color('paper')({theme})} : {}}/>
       </StyledBreadcrumbs>
       <StyledContent>
@@ -96,7 +97,8 @@ DocsBrowser.propTypes = {
   searchMode: PropTypes.bool.isRequired,
   navigationStrategy: PropTypes.object,
   embedded: PropTypes.bool,
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  hasLeftPadding: PropTypes.bool
 }
 
 export default withTheme(DocsBrowser)

--- a/packages/docs-browser/src/components/DocsBrowser/DocsBrowserContainer.js
+++ b/packages/docs-browser/src/components/DocsBrowser/DocsBrowserContainer.js
@@ -9,7 +9,8 @@ import {openDialog} from '../../modules/create/actions'
 const mapStateToProps = state => ({
   searchMode: state.docs.path.searchMode,
   navigationStrategy: state.input.navigationStrategy,
-  embedded: state.input.embedded
+  embedded: state.input.embedded,
+  hasLeftPadding: state.input.hasLeftPadding
 })
 
 const mapActionCreators = {

--- a/packages/docs-browser/src/components/DocsBrowser/StyledComponents.js
+++ b/packages/docs-browser/src/components/DocsBrowser/StyledComponents.js
@@ -19,7 +19,7 @@ export const StyledContent = styled.div`
 
 export const StyledBreadcrumbs = styled.div`
   grid-area: breadcrumbs;
-  ${({embedded}) => embedded && `
+  ${({hasLeftPadding}) => !hasLeftPadding && `
     > div {
       padding-left: 0;
     }


### PR DESCRIPTION
Refs: TOCDEV-3571
Changelog: Adjust left padding of Breadcrumbs in list view