### PR TITLE
fix(docs-browser): forward input props to move action

### DIFF
--- a/packages/docs-browser/src/components/Action/actions/Move.js
+++ b/packages/docs-browser/src/components/Action/actions/Move.js
@@ -26,6 +26,9 @@ export const MoveAction = ({
   initialize,
   moveElements,
   isWaiting,
+  domainTypes,
+  rootNodes,
+  businessUnit,
   emitAction
 }) => {
   const initialNode = getNode(context.history.location.pathname)
@@ -72,6 +75,9 @@ export const MoveAction = ({
       embedded={true}
       emitAction={emitAction}
       noLeftPadding={true}
+      domainTypes={domainTypes}
+      rootNodes={rootNodes}
+      businessUnit={businessUnit}
     />
     <StyledButtonsWrapper>
       <Button
@@ -100,5 +106,11 @@ MoveAction.propTypes = {
   initialize: PropTypes.func.isRequired,
   moveElements: PropTypes.func.isRequired,
   isWaiting: PropTypes.bool.isRequired,
+  domainTypes: PropTypes.arrayOf(PropTypes.string),
+  rootNodes: PropTypes.arrayOf(PropTypes.shape({
+    entityName: PropTypes.string,
+    key: PropTypes.string
+  })),
+  businessUnit: PropTypes.string,
   emitAction: PropTypes.func.isRequired
 }

--- a/packages/docs-browser/src/components/Action/actions/MoveContainer.js
+++ b/packages/docs-browser/src/components/Action/actions/MoveContainer.js
@@ -11,7 +11,10 @@ const mapActionCreators = {
 }
 
 const mapStateToProps = state => ({
-  isWaiting: state.docs.move.isWaiting
+  isWaiting: state.docs.move.isWaiting,
+  domainTypes: state.input.domainTypes,
+  rootNodes: state.input.rootNodes,
+  businessUnit: state.input.businessUnit
 })
 
 const MoveContainer = connect(mapStateToProps, mapActionCreators)(MoveAction)

--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -171,6 +171,7 @@ DocsBrowserApp.propTypes = {
   memoryHistory: PropTypes.bool,
   disableViewPersistor: PropTypes.bool,
   getCustomLocation: PropTypes.func,
+  businessUnit: PropTypes.string,
   ...EXTERNAL_EVENTS.reduce((propTypes, event) => {
     propTypes[event] = PropTypes.func
     return propTypes


### PR DESCRIPTION
forward domainTypes, rootNodes and businessUnit to docs-browser of move action as this docs-browser should be restricted similarly as the main docs-browser

Refs: TOCDEV-3620