### PR TITLE
fix(app-extensions): fix report action form

### DIFF
--- a/packages/app-extensions/src/actions/components/ReportSettings.js
+++ b/packages/app-extensions/src/actions/components/ReportSettings.js
@@ -5,7 +5,6 @@ import {FormattedMessage, injectIntl, intlShape} from 'react-intl'
 
 import simpleFormConnector from '../containers/simpleFormConnector'
 import {
-  getFormDataDefaults,
   getFormDefinition,
   getGroupedValues,
   reportSettingsDefinitionPropType,
@@ -54,7 +53,6 @@ export class ReportSettings extends React.Component {
           onChange={({values, valid}) => {
             this.handleSettingsChange(values, valid)
           }}
-          defaultValues={getFormDataDefaults(settingsDefinition)}
           mode="create"
         />
         {this.customSettingsDefined

--- a/packages/app-extensions/src/actions/components/ReportSettings.spec.js
+++ b/packages/app-extensions/src/actions/components/ReportSettings.spec.js
@@ -135,7 +135,7 @@ const formDefinitionFull = {
       disabled: false,
       label: 'Dateiid',
       id: 'fileid',
-      options: null,
+      targetEntity: null,
       type: 'string'
     },
     {
@@ -144,20 +144,7 @@ const formDefinitionFull = {
       disabled: false,
       label: 'Archivierung',
       id: 'archiveType',
-      options: [
-        {
-          display: 'Nicht archiviert',
-          key: 'not_archived'
-        },
-        {
-          display: 'Archiviert',
-          key: 'archived'
-        },
-        {
-          display: 'Archiviert mit Publikation',
-          key: 'archived_and_published'
-        }
-      ],
+      targetEntity: 'Output_job_archive_type',
       type: 'single-select-box'
     }
   ],

--- a/packages/app-extensions/src/actions/utils/report.js
+++ b/packages/app-extensions/src/actions/utils/report.js
@@ -37,23 +37,6 @@ export const transformValues = values => {
   ), {})
 }
 
-export const getFormDataDefaults = settingsDefinition => {
-  const extractDefaultValues = name =>
-    (settingsDefinition[name] || []).reduce((result, field) => (
-      {
-        ...result,
-        ...(field.options ? {[field.id]: field.options} : {})
-      }
-    ), {})
-
-  return {
-    relationEntities: {
-      ...extractDefaultValues(GROUP_GENERAL),
-      ...extractDefaultValues(GROUP_RECIPIENT)
-    }
-  }
-}
-
 export const getFormDefinition = (settingsDefinition, intl) => {
   const msg = id => intl.formatMessage({id})
 

--- a/packages/app-extensions/src/actions/utils/report.spec.js
+++ b/packages/app-extensions/src/actions/utils/report.spec.js
@@ -1,7 +1,7 @@
 import _get from 'lodash/get'
 import {IntlStub} from 'tocco-test-util'
 
-import {getGroupedValues, getFormDataDefaults, getFormDefinition, transformValues} from './report'
+import {getGroupedValues, getFormDefinition, transformValues} from './report'
 describe('app-extensions', () => {
   describe('actions', () => {
     describe('utils', () => {
@@ -21,26 +21,6 @@ describe('app-extensions', () => {
 
             const result = getGroupedValues(settingsDefinition, values)
             expect(result).to.eql({generalSettings: {}, recipientSettings: {}})
-          })
-        })
-
-        describe('getFormDataDefaults', () => {
-          test('should return an object with relatinEntites', () => {
-            const options1 = [{key: 1, display: 'a'}, {key: 2, display: 'b'}]
-            const options2 = [{key: 3, display: 'c'}, {key: 4, display: 'd'}]
-
-            const settingsDefinition = {
-              generalSettings: null,
-              recipientSettings: [{id: 'a', options: options1}, {id: 'b', options: options2}]
-            }
-
-            const result = getFormDataDefaults(settingsDefinition)
-            expect(result).to.eql({
-              relationEntities: {
-                a: options1,
-                b: options2
-              }
-            })
           })
         })
 


### PR DESCRIPTION
- options are ignored by the client
- targetEntity is required for single-selects

Refs: TOCDEV-3637