### PR TITLE
fix(app-extensions): Lower modal z-index to make ExtJS modal visible

### DIFF
--- a/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
+++ b/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
@@ -46,7 +46,7 @@ export const StyledModalWrapper = styled.div`
   width: 100%;
   height: 100%;
   position: absolute;
-  z-index: 99999;
+  z-index: 99; // lower than ExtJS modals and mask (must be able to open legacy ExtJS modals on top of our modals)
 `
 
 export const StyledPageOverlay = styled.div`


### PR DESCRIPTION
- We need to be able to show legacy ExtJS modals on top of our modals
  (e.g. legacy action "Edit rights" on Folder/Domain edit form which
  is shown in a modal)
- The mask of ExtJS modals has z-index 100, we have to remain below it

Refs: TOCDEV-3647