### PR TITLE
fix(docs-browser): Disable sorting in `move` action

### DIFF
--- a/packages/docs-browser/src/components/Action/actions/Move.js
+++ b/packages/docs-browser/src/components/Action/actions/Move.js
@@ -78,6 +78,7 @@ export const MoveAction = ({
       domainTypes={domainTypes}
       rootNodes={rootNodes}
       businessUnit={businessUnit}
+      sortable={false}
     />
     <StyledButtonsWrapper>
       <Button


### PR DESCRIPTION
The `move` action is used for entity documents/folders as well which
cannot be sorted (because their label is generated dynamically in
ContentTreeNode#getLabel()). As sorting might not be the most important
feature in the `move` action, we simply disable it everywhere
(regardless of whether we're moving an entity doc/folder or not)

Refs: TOCDEV-3125