### PR TITLE
chore: Fix setting correct nice version when releasing

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -50,7 +50,7 @@ function checkPackage() {
 }
 
 function setNiceVersion() {
-  nice_version=$(head -n 1 nice-current-version.txt | sed -r 's/(\.0$|\.)//g')
+  nice_version=$(head -n 1 nice-current-version.txt | sed 's/\.0$//' | sed 's/\.//')
 }
 
 function setCurrentReleaseTag() {


### PR DESCRIPTION
The bash command which sets the nice version to use for the tag
("2.29.0" -> "229", "3.0.0" -> "30") which was changed in rev
1bc2e29ab5b033640390fc6daa02b19075fed200 apparently doesn't work
on all machines (at least on my machine I get 'invalid option --r').

Using the `sed` command without the `-r` parameter might be a more
stable solution.