### PR TITLE
refactor(entity-browser): adjust store ids

### DIFF
--- a/packages/entity-browser/src/routes/detail/components/EntityDetail/EntityDetail.js
+++ b/packages/entity-browser/src/routes/detail/components/EntityDetail/EntityDetail.js
@@ -60,9 +60,9 @@ class EntityDetail extends React.Component {
     this.props.router.history.push(this.props.detailParams.parentUrl)
   }
 
-  getApp = ({entityName, entityId, formName, mode}) =>
+  getApp = ({entityName, entityId, formName, mode}) => (
     <EntityDetailApp
-      id={`${this.props.appId}_detail_${formName}_${entityId}` }
+      id={`${this.props.appId}_detail_${formName}_${entityId}`}
       entityName={entityName}
       entityId={entityId}
       formName={formName}
@@ -78,6 +78,7 @@ class EntityDetail extends React.Component {
       }}
       theme={{}}
     />
+  )
 
   msg = id => (this.props.intl.formatMessage({id}))
 

--- a/packages/entity-browser/src/routes/list/containers/ListViewContainer.js
+++ b/packages/entity-browser/src/routes/list/containers/ListViewContainer.js
@@ -29,28 +29,32 @@ const handleNavigateToAction = props => ({definition, selection}) => {
   })
 }
 
-const mapStateToProps = (state, props) => ({
-  id: `${state.entityBrowser.appId}_entity-browser-list`,
-  locale: state.input.locale,
-  entityName: state.entityBrowser.entityName,
-  formName: state.entityBrowser.formBase,
-  searchFormType: state.input.showSearchForm ? 'basic' : 'none',
-  limit: state.input.limit,
-  searchFilters: state.input.searchFilters,
-  preselectedSearchFields: state.input.preselectedSearchFields,
-  disableSimpleSearch: state.input.disableSimpleSearch,
-  simpleSearchFields: state.input.simpleSearchFields,
-  onRowClick: e => {
-    props.router.history.push(`/detail/${e.id}`)
-  },
-  onNavigateToCreate: handleNavigateToCreate(props),
-  onNavigateToAction: handleNavigateToAction(props),
-  searchFormPosition: 'top',
-  actionAppComponent: Action,
-  store: viewPersistor.viewInfoSelector(props.router.history.location.pathname).store,
-  onStoreCreate: store => {
-    viewPersistor.persistViewInfo(props.router.history.location.pathname, {store}, 0)
+const mapStateToProps = (state, props) => {
+  const id = `${state.entityBrowser.appId}_entity-browser-list`
+  const storeId = `${id}_${props.router.history.location.pathname}`
+  return {
+    id,
+    locale: state.input.locale,
+    entityName: state.entityBrowser.entityName,
+    formName: state.entityBrowser.formBase,
+    searchFormType: state.input.showSearchForm ? 'basic' : 'none',
+    limit: state.input.limit,
+    searchFilters: state.input.searchFilters,
+    preselectedSearchFields: state.input.preselectedSearchFields,
+    disableSimpleSearch: state.input.disableSimpleSearch,
+    simpleSearchFields: state.input.simpleSearchFields,
+    onRowClick: e => {
+      props.router.history.push(`/detail/${e.id}`)
+    },
+    onNavigateToCreate: handleNavigateToCreate(props),
+    onNavigateToAction: handleNavigateToAction(props),
+    searchFormPosition: 'top',
+    actionAppComponent: Action,
+    store: viewPersistor.viewInfoSelector(storeId).store,
+    onStoreCreate: store => {
+      viewPersistor.persistViewInfo(storeId, {store}, 0)
+    }
   }
-})
+}
 
 export default connect(mapStateToProps, mapDispatchToProps)(EntityListApp)

--- a/packages/entity-detail/src/components/SubGrid/SubGrid.js
+++ b/packages/entity-detail/src/components/SubGrid/SubGrid.js
@@ -10,11 +10,12 @@ const StyledListApp = styled.div`
 
 const SubGrid = props => {
   const formBase = `${props.detailFormName}_${props.formField.path}`
-  const subgridPersistorId = `subgrid-${props.entityName}-${props.entityKey}-${props.formField.reverseRelation}`
+  const id = `${props.appId}-subgrid-${props.entityName}-${props.entityKey}-${props.formField.reverseRelation}`
+
   return (
     <StyledListApp>
       <EntityListApp
-        id={`${props.appId}-subgrid-${formBase}`}
+        id={id}
         entityName={props.formField.targetEntity}
         formName={formBase}
         limit={props.limit}
@@ -37,9 +38,9 @@ const SubGrid = props => {
           model: props.entityName
         }}
         emitAction={props.emitAction}
-        store={viewPersistor.viewInfoSelector(subgridPersistorId).store}
+        store={viewPersistor.viewInfoSelector(id).store}
         onStoreCreate={store => {
-          viewPersistor.persistViewInfo(subgridPersistorId, {store})
+          viewPersistor.persistViewInfo(id, {store})
         }}
       />
     </StyledListApp>

--- a/packages/entity-detail/src/main.js
+++ b/packages/entity-detail/src/main.js
@@ -111,7 +111,7 @@ class EntityDetailApp extends React.Component {
       return events
     }, {})
 
-    this.app = initApp('id', props, events)
+    this.app = initApp(props.id, props, events)
   }
 
   render() {


### PR DESCRIPTION
due to naming conflicts the same store was loaded for different nice tabs.
With this change i made sure, that every tab gets its own id.

Refs: TOCDEV-3683
Changelog: Fix multi-tab problem
Cherry-pick:Up