### PR TITLE
chore: scripts do not push temporary release tags

### DIFF
--- a/scripts/cherrypick.sh
+++ b/scripts/cherrypick.sh
@@ -98,7 +98,6 @@ git checkout -b releasing/auto-$(date +%s%N)
 # push cherry picked commits
 current_branch=$(git branch --show-current)
 git push origin $current_branch
-git push --tags
 
 # create github PR
 pr=$(curl -s -H "Authorization: token ${GITHUB_BOT_TOKEN}" -X POST \

--- a/scripts/release-package.sh
+++ b/scripts/release-package.sh
@@ -72,6 +72,7 @@ fi
 git commit -m "docs(${package}): changelog ${new_version}" ${changelog_file}
 echo "releasing and publishing ${package} with version ${new_version}"
 yarn publish --new-version ${new_version}
+git tag --delete _tocco-$(transformPackageName $package)@${new_version}
 
 if [[ $auto = true ]]; then
   PUSH="n"
@@ -81,8 +82,6 @@ else
 fi
 
 if [ "$PUSH" = "y" ] || [ "$PUSH" = "Y" ]; then
-  git fetch --tags -f
-  git push --tags
   git push --set-upstream https://github.com/tocco/tocco-client.git ${targetBranch}
   echo "${color_green}Commits and tags pushed to ${targetBranch}!${color_reset}"
 else

--- a/scripts/tagging.sh
+++ b/scripts/tagging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script will look for release commits since the last release tag on the current branch and 
+# This script will look for release commits since the last release tag on the current branch and
 # then create the missing tags. Thus all releases have tags that dont have to be merged within the according commit.
 
 echo "---Release Tagging Script---"
@@ -26,12 +26,10 @@ do
         echo "Commit '$msg' ($commit) is a release commit"
         tag_name="$(echo "$full_msg" | grep -e '- ' | sed 's/- //g')"
 
-        echo "Delete existing tag _$tag_name"
-        git push --delete origin _$tag_name
+        echo "Create tag '$tag_name'"
+        git tag -f $tag_name $commit
 
-        echo "Create tag  '$tag_name'"
-        git tag -f $tag_name $commit 
+        echo "Push tag '$tag_name'"
+        git push --set-upstream https://github.com/tocco/tocco-client.git $tag_name
     fi
 done
-echo "pushing tags..."
-git push --tags


### PR DESCRIPTION
if multiple auto cherrypicking ci jobs (on different release branches) are executed "git push --tags" fails because an auto-merge tag (of another nice-release) was moved. As the pushed tags with the prefix "_" are deleted by the tagging ci job now the tags are instant locally deleted after the creation.

Cherry-pick: Up