### PR TITLE
fix(admin): use history to create url for new tab

### DIFF
--- a/packages/admin/src/routes/entities/utils/navigationStrategy.js
+++ b/packages/admin/src/routes/entities/utils/navigationStrategy.js
@@ -72,7 +72,8 @@ export default (history, match) => {
   }
 
   const openDetail = (entityName, key) => {
-    window.open(`/e/${entityName}/${key}`, '_blank')
+    const url = history.createHref({pathname: `/e/${entityName}/${key}`})
+    window.open(url, '_blank')
   }
 
   return {


### PR DESCRIPTION
- otherwise additional parts like '/beta' may be lost

Refs: TOCDEV-3360
Changelog: New tabs opened through navigationStrategy now work with all base urls.