### PR TITLE
refactor(entity-list): add collapsed bool to store

### DIFF
--- a/packages/entity-list/src/components/EntityList/EntityList.js
+++ b/packages/entity-list/src/components/EntityList/EntityList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, {useState} from 'react'
+import React from 'react'
 
 import SearchViewContainer from '../../containers/SearchViewContainer'
 import ListViewContainer from '../../containers/ListViewContainer'
@@ -8,14 +8,12 @@ import searchFormTypes, {searchFormTypePropTypes} from '../../util/searchFormTyp
 
 const EntityList = ({
   searchFormType,
+  searchFormCollapsed,
   searchFormPosition,
-  searchFormCollapsedDefault,
-  searchFormCollapsedChange
+  setSearchFormCollapsed
 }) => {
-  const [isCollapsed, setIsCollapsed] = useState(searchFormCollapsedDefault)
   const toggleCollapse = () => {
-    searchFormCollapsedChange(!isCollapsed)
-    setIsCollapsed(!isCollapsed)
+    setSearchFormCollapsed(!searchFormCollapsed)
   }
 
   if (searchFormType === searchFormTypes.NONE) {
@@ -25,9 +23,9 @@ const EntityList = ({
   const PositioningContainer = searchFormPosition === 'left' ? LeftPositioning : TopPositioning
 
   return (
-    <PositioningContainer searchFormType={searchFormType} isCollapsed={isCollapsed}>
+    <PositioningContainer searchFormType={searchFormType} isCollapsed={searchFormCollapsed}>
       <SearchGrid>
-        <SearchViewContainer isCollapsed={isCollapsed} toggleCollapse={toggleCollapse}/>
+        <SearchViewContainer isCollapsed={searchFormCollapsed} toggleCollapse={toggleCollapse}/>
       </SearchGrid>
       <ListGrid searchFormType={searchFormType}>
         <ListViewContainer/>
@@ -39,8 +37,8 @@ const EntityList = ({
 EntityList.propTypes = {
   searchFormType: searchFormTypePropTypes,
   searchFormPosition: PropTypes.oneOf(['top', 'left']),
-  searchFormCollapsedDefault: PropTypes.bool,
-  searchFormCollapsedChange: PropTypes.func
+  searchFormCollapsed: PropTypes.bool,
+  setSearchFormCollapsed: PropTypes.func
 }
 
 export default EntityList

--- a/packages/entity-list/src/components/EntityList/EntityListContainer.js
+++ b/packages/entity-list/src/components/EntityList/EntityListContainer.js
@@ -2,7 +2,7 @@ import {connect} from 'react-redux'
 import {injectIntl} from 'react-intl'
 
 import EntityList from './EntityList'
-import {initialize, searchFormCollapsedChange} from '../../modules/entityList/actions'
+import {initialize, setSearchFormCollapsed} from '../../modules/entityList/actions'
 import {initialize as initializeSearchForm} from '../../modules/searchForm/actions'
 import {loadPreferences} from '../../modules/preferences/actions'
 
@@ -10,13 +10,13 @@ const mapActionCreators = {
   initialize,
   initializeSearchForm,
   loadPreferences,
-  searchFormCollapsedChange
+  setSearchFormCollapsed
 }
 
 const mapStateToProps = state => ({
   searchFormType: state.input.searchFormType,
   searchFormPosition: state.input.searchFormPosition,
-  searchFormCollapsedDefault: state.input.searchFormCollapsed
+  searchFormCollapsed: state.entityList.searchFormCollapsed
 })
 
 export default connect(mapStateToProps, mapActionCreators)(injectIntl(EntityList))

--- a/packages/entity-list/src/input.js
+++ b/packages/entity-list/src/input.js
@@ -3,7 +3,8 @@ import {
   setFormName,
   setEntityName,
   setParent,
-  setSearchFormPosition
+  setSearchFormPosition,
+  setSearchFormCollapsedInitialValue
 } from './modules/entityList/actions'
 import {
   setDisableSimpleSearch,
@@ -144,5 +145,11 @@ const actionSettings = [
     action: setInputSearchFilters,
     argsFactory: input => [input.searchFilters],
     reload: reloadOptions.DATA
+  },
+  {
+    name: 'searchFormCollapsed',
+    action: setSearchFormCollapsedInitialValue,
+    argsFactory: input => [input.searchFormCollapsed],
+    reload: reloadOptions.NOTHING
   }
 ]

--- a/packages/entity-list/src/modules/entityList/actions.js
+++ b/packages/entity-list/src/modules/entityList/actions.js
@@ -7,7 +7,8 @@ export const SET_SEARCH_FORM_POSITION = 'entityList/SET_SEARCH_FORM_POSITION'
 export const SET_FORM_NAME = 'entityList/SET_FORM_NAME'
 export const RELOAD_ALL = 'entityList/RELOAD_ALL'
 export const RELOAD_DATA = 'entityList/RELOAD_DATA'
-export const SEARCH_FORM_COLLAPSED_CHANGE = 'entityList/SEARCH_FORM_COLLAPSED_CHANGE'
+export const SET_SEARCH_FORM_COLLAPSED = 'entityList/SET_SEARCH_FORM_COLLAPSED'
+export const SET_SEARCH_FORM_COLLAPSED_INITIAL_VALUE = 'entityList/SET_SEARCH_FORM_COLLAPSED_INITIAL_VALUE'
 
 export const setInitialized = (initialized = true) => ({
   type: SET_INITIALIZED,
@@ -63,9 +64,16 @@ export const reloadAll = () => ({
   type: RELOAD_ALL
 })
 
-export const searchFormCollapsedChange = collapsed => ({
-  type: SEARCH_FORM_COLLAPSED_CHANGE,
+export const setSearchFormCollapsed = searchFormCollapsed => ({
+  type: SET_SEARCH_FORM_COLLAPSED,
   payload: {
-    collapsed
+    searchFormCollapsed
+  }
+})
+
+export const setSearchFormCollapsedInitialValue = searchFormCollapsed => ({
+  type: SET_SEARCH_FORM_COLLAPSED_INITIAL_VALUE,
+  payload: {
+    searchFormCollapsed
   }
 })

--- a/packages/entity-list/src/modules/entityList/reducer.js
+++ b/packages/entity-list/src/modules/entityList/reducer.js
@@ -18,7 +18,9 @@ const ACTION_HANDLERS = {
   [actions.SET_FORM_NAME]: reducerUtil.singleTransferReducer('formName'),
   [actions.SET_SEARCH_FORM_TYPE]: setSearchFormType,
   [actions.SET_SEARCH_FORM_POSITION]: reducerUtil.singleTransferReducer('searchFormPosition'),
-  [actions.SET_PARENT]: reducerUtil.singleTransferReducer('parent')
+  [actions.SET_PARENT]: reducerUtil.singleTransferReducer('parent'),
+  [actions.SET_SEARCH_FORM_COLLAPSED]: reducerUtil.singleTransferReducer('searchFormCollapsed'),
+  [actions.SET_SEARCH_FORM_COLLAPSED_INITIAL_VALUE]: reducerUtil.singleTransferReducer('searchFormCollapsed')
 }
 
 const initialState = {
@@ -27,7 +29,8 @@ const initialState = {
   formName: '',
   searchFormType: searchFormTypes.BASIC,
   searchFormPosition: 'top',
-  parent: null
+  parent: null,
+  searchFormCollapsed: false
 }
 
 export default function reducer(state = initialState, action) {

--- a/packages/entity-list/src/modules/entityList/reducer.spec.js
+++ b/packages/entity-list/src/modules/entityList/reducer.spec.js
@@ -8,7 +8,8 @@ const INITIAL_STATE = {
   initialized: false,
   searchFormType: searchFormTypes.BASIC,
   searchFormPosition: 'top',
-  parent: null
+  parent: null,
+  searchFormCollapsed: false
 }
 
 describe('entity-list', () => {

--- a/packages/entity-list/src/modules/entityList/sagas.js
+++ b/packages/entity-list/src/modules/entityList/sagas.js
@@ -13,7 +13,7 @@ export default function* sagas() {
     call(initialize),
     takeLatest(actions.RELOAD_DATA, reloadData),
     takeLatest(actions.RELOAD_ALL, initialize, false),
-    takeLatest(actions.SEARCH_FORM_COLLAPSED_CHANGE, searchFormCollapsed)
+    takeLatest(actions.SET_SEARCH_FORM_COLLAPSED, searchFormCollapsed)
   ])
 }
 
@@ -42,6 +42,6 @@ export function* reloadData() {
   yield put(searchFormActions.executeSearch())
 }
 
-export function* searchFormCollapsed({payload: {collapsed}}) {
-  yield put(externalEvents.fireExternalEvent('onSearchFormCollapsedChange', {collapsed}))
+export function* searchFormCollapsed({payload: {searchFormCollapsed}}) {
+  yield put(externalEvents.fireExternalEvent('onSearchFormCollapsedChange', {collapsed: searchFormCollapsed}))
 }

--- a/packages/entity-list/src/modules/entityList/sagas.spec.js
+++ b/packages/entity-list/src/modules/entityList/sagas.spec.js
@@ -19,7 +19,7 @@ describe('entity-list', () => {
               call(sagas.initialize),
               takeLatest(actions.RELOAD_DATA, sagas.reloadData),
               takeLatest(actions.RELOAD_ALL, sagas.initialize, false),
-              takeLatest(actions.SEARCH_FORM_COLLAPSED_CHANGE, sagas.searchFormCollapsed)
+              takeLatest(actions.SET_SEARCH_FORM_COLLAPSED, sagas.searchFormCollapsed)
             ]))
             expect(generator.next().done).to.be.true
           })


### PR DESCRIPTION
- store search form collapsed property in store. Otherwise it would be ignored when a store is loaded since the state is only represented in a locale state of a component.

Refs: TOCDEV-3985