### PR TITLE
refactor(tocco-ui): wrap preview image in link

### DIFF
--- a/packages/tocco-ui/src/Preview/Preview.js
+++ b/packages/tocco-ui/src/Preview/Preview.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React, {useState} from 'react'
 
 import Icon from '../Icon'
-import Link from '../Link'
 import Typography from '../Typography'
 import StyledPreview from './StyledPreview'
 import {validateCssDimension} from '../utilStyles'
@@ -11,64 +10,42 @@ import {validateCssDimension} from '../utilStyles'
  * Use <Preview> to display a preview of any kind of file. Provide URLs to thumbnail and file.
  */
 const Preview = ({
-  onClick,
   thumbnailUrl,
   alt,
   srcUrl,
   fileName,
-  downloadOnClick,
   caption,
   maxDimensionX,
   maxDimensionY
 }) => {
   const [isLoaded, setIsLoaded] = useState(false)
 
-  const handleOnClick = () => {
-    if (typeof onClick === 'function') {
-      onClick(srcUrl, thumbnailUrl)
-    }
-  }
-
   const handleOnLoad = () => setIsLoaded(Math.random())
 
   const image = thumbnailUrl
-    ? (
-    <img
+    ? <img
       alt={alt}
       title={alt}
       src={thumbnailUrl}
-      onClick={handleOnClick}
       onLoad={handleOnLoad}
       data-image-in-cache={isLoaded}
     />
-      )
-    : (
-    <Icon
-      icon="file-alt"
-    />
-      )
-
-  const imageWrapper = downloadOnClick && srcUrl && !onClick
-    ? (
-    <Link
-      alt={fileName || alt}
-      download={fileName || caption}
-      href={srcUrl}
-      label={image}
-    />
-      )
-    : (
-        image
-      )
-
-  const interactive = ((downloadOnClick && srcUrl) || onClick)
+    : <div
+      alt={alt}
+      title={alt}
+    >
+      <Icon
+        icon="file-alt"
+      />
+    </div>
 
   return <StyledPreview
-    interactive={interactive}
     maxDimensionX={maxDimensionX}
     maxDimensionY={maxDimensionY}
   >
-    {imageWrapper}
+    <a target="_blank" rel="noopener noreferrer" alt={alt} href={srcUrl}>
+      {image}
+    </a>
     {caption && <Typography.Figcaption>{caption}</Typography.Figcaption>}
   </StyledPreview>
 }
@@ -84,18 +61,9 @@ Preview.propTypes = {
    */
   caption: PropTypes.string,
   /**
-   * If true the image will be linked (srcUrl).
-   */
-  downloadOnClick: PropTypes.bool,
-  /**
    * Suggest a filename for download.
    */
   fileName: PropTypes.string,
-  /**
-   * Trigger function by click on image. Receives the srcLink and
-   * thumbnailLink as arguments. onClick overrules downloadOnClick.
-   */
-  onClick: PropTypes.func,
   /**
    * Declare maximal width of displayed image as css property.
    */

--- a/packages/tocco-ui/src/Preview/Preview.spec.js
+++ b/packages/tocco-ui/src/Preview/Preview.spec.js
@@ -11,7 +11,6 @@ describe('tocco-ui', () => {
         <Preview
           alt="alternative text"
           caption="caption text"
-          downloadOnClick={true}
           srcUrl="/link-to-source"
           thumbnailUrl="/link-to-thumbnail"
         />
@@ -25,7 +24,6 @@ describe('tocco-ui', () => {
       expect(a).to.have.length(1)
       expect(a).to.have.attr('href', '/link-to-source')
       expect(a).to.have.attr('alt', 'alternative text')
-      expect(a).to.have.attr('download', 'caption text')
       expect(img).to.have.length(1)
       expect(img).to.have.attr('alt', 'alternative text')
       expect(img).to.have.attr('src', '/link-to-thumbnail')
@@ -52,61 +50,6 @@ describe('tocco-ui', () => {
       expect(wrapper.find('img')).to.have.length(0)
       expect(wrapper.find(Icon)).to.have.length(1)
       expect(wrapper.find(Icon).prop('icon')).to.deep.equal('file-alt')
-    })
-
-    test('link image if demanded and allowed', () => {
-      let wrapper = mount(
-        <Preview
-          alt="alt text"
-          downloadOnClick={false}
-          srcUrl="/link-to-source"
-        />
-      )
-
-      expect(wrapper.find('a')).to.have.length(0)
-
-      wrapper = mount(
-        <Preview
-          alt="alt text"
-          downloadOnClick={true}
-          srcUrl="/link-to-source"
-        />
-      )
-
-      const a = wrapper.find('a')
-
-      expect(a).to.have.length(1)
-      expect(a).to.have.attr('href', '/link-to-source')
-
-      wrapper = shallow(
-        <Preview
-          alt="alt text"
-          downloadOnClick={true}
-          onClick={(srcUrl, thumbnailUrl) => alert(srcUrl + '\n' + thumbnailUrl)}
-          srcUrl="/link-to-source"
-        />
-      ).dive()
-
-      expect(wrapper.find('a')).to.have.length(0)
-    })
-
-    test('trigger callback on click', () => {
-      const srcUrl = '/link-to-source'
-      const thumbnailUrl = '/link-to-thumbnail'
-      const onClickFunction = sinon.spy()
-
-      const wrapper = shallow(
-        <Preview
-          alt="alt text"
-          downloadOnClick={true}
-          onClick={onClickFunction}
-          srcUrl={srcUrl}
-          thumbnailUrl={thumbnailUrl}
-        />
-      )
-
-      wrapper.find('img').simulate('click')
-      expect(onClickFunction).to.be.calledWith(srcUrl, thumbnailUrl)
     })
   })
 })

--- a/packages/tocco-ui/src/Preview/StyledPreview.js
+++ b/packages/tocco-ui/src/Preview/StyledPreview.js
@@ -3,17 +3,6 @@ import _get from 'lodash/get'
 
 import {shadeColor, scale} from '../utilStyles'
 
-const declareInteraction = ({interactive}) => {
-  if (interactive) {
-    return `
-      &:hover,
-      &:focus {
-        opacity: .7;
-      }
-    `
-  }
-}
-
 const StyledPreview = styled.figure`
   && {
     vertical-align: top;
@@ -27,7 +16,6 @@ const StyledPreview = styled.figure`
       border: 1px solid ${({theme}) => shadeColor(_get(theme, 'colors.paper'), 2)};
       max-width: ${({maxDimensionX}) => maxDimensionX || '100%'};
       max-height: ${({maxDimensionY}) => maxDimensionY || '100%'};
-      ${props => declareInteraction(props)}
     }
 
     figcaption {


### PR DESCRIPTION
- simplify preview component and remove unused props

Refs: TOCDEV-2728
Changelog: Add preview for documents