### PR TITLE
refactor(app-extensions): fix modal holder z-index

### DIFF
--- a/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
+++ b/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
@@ -48,7 +48,8 @@ export const StyledModalHolder = styled.div`
   top: 0;
   left: 0;
   position: absolute;
-  z-index: 4; // higher than StyledHeader
+  // higher than StyledHeader and very high value to prevent other elements blocking it when implemented as a widget
+  z-index: 999999;
 `
 
 export const StyledModalWrapper = styled.div`
@@ -79,10 +80,11 @@ export const StyledModalButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
 `
+
 export const GlobalTetherStyle = createGlobalStyle`
   ${StyledTether} {
     && {
-      z-index: 99999; // higher than StyledModalWrapper
+      z-index: 9999999; // higher than StyledModalHolder
     }
   }
 `


### PR DESCRIPTION
Refs: TOCDEV-3987
Changelog: Increase z-index of modal holder to properly display as widget

(cherry picked from commit e487fadc53e2c08a6b935001d2a1e14c7815f51b)