### PR TITLE
chore: properly pass artifacts between jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,16 +3,6 @@ image: node:14.15.4-alpine
 variables:
   CYPRESS_INSTALL_BINARY: "0"
 
-cache: &global_cache
-  key:
-    files:
-      - yarn.lock
-      - packages/*/yarn.lock
-  policy: pull
-  paths:
-    - node_modules/
-    - packages/*/node_modules/
-
 stages:
   - setup
   - quality
@@ -23,18 +13,30 @@ stages:
 
 yarn_setup:
   stage: setup
+  needs: []
   only:
     - external_pull_requests
     - master
   cache:
-    <<: *global_cache
-    policy: pull-push
+    key:
+      files:
+        - yarn.lock
+        - packages/*/yarn.lock
+    paths:
+      - node_modules/
+      - packages/*/node_modules/
+  artifacts:
+    paths:
+    - node_modules/
+    - packages/*/node_modules/
   script:
     - yarn setup:ci
   interruptible: true
 
 linting:
   stage: quality
+  dependencies:
+    - yarn_setup
   only:
     - external_pull_requests
     - master
@@ -43,6 +45,8 @@ linting:
 
 test:
   stage: quality
+  dependencies:
+    - yarn_setup
   only:
     - external_pull_requests
     - master
@@ -54,6 +58,8 @@ test:
 
 storybook:
   stage: quality
+  dependencies:
+    - yarn_setup
   only:
     - external_pull_requests
     - master
@@ -65,6 +71,9 @@ storybook:
 
 storybook-link:
   stage: pullrequest
+  dependencies: []
+  needs:
+    - storybook
   cache: {}
   before_script:
     - apk update && apk add bash && apk add curl && apk add jq
@@ -75,6 +84,7 @@ storybook-link:
 
 cherrypick:
   stage: release
+  dependencies: []
   only:
     - /^nice-releases\/[0-9]+$/
   before_script:
@@ -86,6 +96,8 @@ cherrypick:
 
 cypress:
   stage: onschedule
+  dependencies:
+    - yarn_setup
   image: cypress/base:10
   variables:
     CYPRESS_INSTALL_BINARY: "6.4.0"


### PR DESCRIPTION
Stop misusing the cache for passing build artifacts. For our
runners we use per-host caches. So, one can't assume a cache
from a previous job to be available.