### PR TITLE
refactor(tocco-ui): fix preview img dimensions

### DIFF
--- a/packages/tocco-ui/src/Preview/StyledPreview.js
+++ b/packages/tocco-ui/src/Preview/StyledPreview.js
@@ -16,6 +16,7 @@ const StyledPreview = styled.figure`
       border: 1px solid ${({theme}) => shadeColor(_get(theme, 'colors.paper'), 2)};
       max-width: ${({maxDimensionX}) => maxDimensionX || '100%'};
       max-height: ${({maxDimensionY}) => maxDimensionY || '100%'};
+      min-width: 90px; // prevent collapse to 1px if there is no preview generated
     }
 
     figcaption {


### PR DESCRIPTION
Refs: TOCDEV-3995
Changelog: Prevent preview image collapsing to 1px if preview cannot be generated
(cherry picked from commit d904292c15c22e480004e9a7cbc6d1a0b07b7e92)