### PR TITLE
chore: fix build

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -60,6 +60,7 @@ webpackConfig.output = {
   chunkFilename: 'chunk-[name].[contenthash].js',
   path: outputDir,
   libraryTarget: 'umd',
+  library: `tocco-${__PACKAGE__}`,
   publicPath: '/'
 }
 


### PR DESCRIPTION
- with the update of webpack to version 5.x a hidden problem was introduced.
  There is a problem with  multiple webpack-compiled files loaded on the same page. Like in nice2.
  They would overwrite themself in an internal webpack caching util.
  Therefore the library name is needed.

Refs: TOCDEV-3998