### PR TITLE
refactor(tocco-ui): add display-expression icon

### DIFF
--- a/packages/app-extensions/src/appFactory/ThemeWrapper.js
+++ b/packages/app-extensions/src/appFactory/ThemeWrapper.js
@@ -1,13 +1,28 @@
-import {ThemeProvider, withTheme} from 'styled-components'
+import {ThemeProvider, withTheme, createGlobalStyle} from 'styled-components'
 import _merge from 'lodash/merge'
 import {ToccoTheme} from 'tocco-theme'
+import {theme} from 'tocco-ui'
 import React, {useMemo} from 'react'
 import PropTypes from 'prop-types'
+import {darken} from 'polished'
+
+const GlobalStyle = createGlobalStyle`
+
+  // Legacy (display expression) icons styling
+  .text-success {
+    color: ${theme.color('signal.success.text')};
+  }
+
+  .text-muted {
+    color: ${({theme}) => darken(0.4, theme.colors.paper)};
+  }
+`
 
 const ThemeWrapper = ({theme, appTheme, children}) => {
   const mergedTheme = useMemo(() => _merge({}, theme, appTheme), [theme, appTheme])
 
   return <ThemeProvider theme={mergedTheme}>
+    <GlobalStyle/>
     {children}
   </ThemeProvider>
 }

--- a/packages/tocco-ui/src/Icon/FontAwesomeAdapter.js
+++ b/packages/tocco-ui/src/Icon/FontAwesomeAdapter.js
@@ -4,7 +4,7 @@ import _get from 'lodash/get'
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
 import {library} from '@fortawesome/fontawesome-svg-core'
 import {
-  faSquareFull, faStar as faStarSolid
+  faSquareFull, faStar as faStarSolid, faSquare as faSquareSolid
 } from '@fortawesome/pro-solid-svg-icons'
 import {
   faTimes, faCircle, faHorizontalRule, faSync, faMinus, faTimesCircle, faInfoCircle,
@@ -26,8 +26,12 @@ import {faGoogle, faFacebook, faFacebookF, faDropbox, faMicrosoft, faJira, faApp
     faCheckCircle, faGoogle, faFacebook, faFacebookF, faDropbox, faMicrosoft, faJira, faApple, faBars, faExternalLink,
     faPhone, faMapMarked, faSearch, faCog, faDownload, faUpload, faInfo, faHorizontalRule, faSync, faSquareFull,
     faCompress, faBook, faSortUp, faSortDown, faQuestionCircle, faEllipsisV, faMinus, faTimesCircle, faInfoCircle,
-    faExclamationCircle, faTrash, faList, faSquare, faBell, faArrowToBottom)
+    faExclamationCircle, faTrash, faList, faSquare, faBell, faArrowToBottom, faSquareSolid)
 })()
+
+/**
+ * The following icons are solely used to support custom display expressions and should not be removed: faSquareSolid
+ */
 
 const FontAwesomeAdapter = ({icon, style}) =>
   <FontAwesomeIcon

--- a/packages/tocco-ui/src/Icon/mapping.json
+++ b/packages/tocco-ui/src/Icon/mapping.json
@@ -1,20 +1,4 @@
 {
-  "angle-down": {
-    "id": "fal, angle-down",
-    "lib": "fa"
-  },
-  "angle-left": {
-    "id": "fal, angle-left",
-    "lib": "fa"
-  },
-  "angle-right": {
-    "id": "fal, angle-right",
-    "lib": "fa"
-  },
-  "angle-up": {
-    "id": "fal, angle-up",
-    "lib": "fa"
-  },
   "apple": {
     "id": "fab, apple",
     "lib": "fa",


### PR DESCRIPTION
- Solid suqare icon is used fo a display expression in task list.
  This icon should not be removed otherwise the icon is rendered as missing icon (question mark).
- add global legacy styling
- remove removed angle icons from mapping

Changelog: Fix suqare icon display expressions
Refs: TOCDEV-4101