### PR TITLE
refactor(docs-browser): shallow detail message

### DIFF
--- a/packages/docs-browser/src/components/Action/actions/CreateDomain.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateDomain.js
@@ -7,6 +7,12 @@ import getNode from '../../../utils/getNode'
 import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
+  const emitActionBarrier = action => {
+    if (action.payload && action.payload.title !== 'client.entity-detail.createSuccessfulTitle') {
+      emitAction(action)
+    }
+  }
+
   const handleEntityCreated = ({id}) => {
     const remoteEvents = [{
       type: 'entity-create-event',
@@ -39,7 +45,7 @@ const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
     mode="create"
     defaultValues={defaultValues}
     onEntityCreated={handleEntityCreated}
-    emitAction={emitAction}
+    emitAction={emitActionBarrier}
   />
 }
 

--- a/packages/docs-browser/src/components/Action/actions/CreateFolder.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateFolder.js
@@ -7,6 +7,12 @@ import getNode from '../../../utils/getNode'
 import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
+  const emitActionBarrier = action => {
+    if (action.payload && action.payload.title !== 'client.entity-detail.createSuccessfulTitle') {
+      emitAction(action)
+    }
+  }
+
   const handleEntityCreated = ({id}) => {
     const remoteEvents = [{
       type: 'entity-create-event',
@@ -39,7 +45,7 @@ const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
     mode="create"
     defaultValues={defaultValues}
     onEntityCreated={handleEntityCreated}
-    emitAction={emitAction}
+    emitAction={emitActionBarrier}
   />
 }
 

--- a/packages/docs-browser/src/components/Action/actions/Edit.js
+++ b/packages/docs-browser/src/components/Action/actions/Edit.js
@@ -7,6 +7,12 @@ import {selection} from 'tocco-util'
 import getDetailFormName from '../../../utils/getDetailFormName'
 
 const EditAction = ({selection, onSuccess, onCancel, intl, context, emitAction}) => {
+  const emitActionBarrier = action => {
+    if (action.payload && action.payload.title !== 'client.entity-detail.saveSuccessfulTitle') {
+      emitAction(action)
+    }
+  }
+  
   const [entityName, entityKey] = selection.ids[0].split('/')
 
   if (entityName === 'Resource') {
@@ -34,13 +40,13 @@ const EditAction = ({selection, onSuccess, onCancel, intl, context, emitAction})
   const formName = getDetailFormName(context, entityName)
 
   return <EntityDetailApp
-      entityName={entityName}
-      formName={formName}
-      entityId={entityKey}
-      mode="update"
-      onEntityUpdated={handleEntityUpdated}
-      emitAction={emitAction}
-    />
+    entityName={entityName}
+    formName={formName}
+    entityId={entityKey}
+    mode="update"
+    onEntityUpdated={handleEntityUpdated}
+    emitAction={emitActionBarrier}
+  />
 }
 
 EditAction.propTypes = {


### PR DESCRIPTION
- to avoid two messages, the entity-detail success messages are shallowed by the action.

Changelog: Dms edit and create messages clean up
Refs: TOCDEV-4021
Cherry-pick: up