### PR TITLE
feat(devcon): Add new input param `baseRoute`

### DIFF
--- a/packages/devcon/README.md
+++ b/packages/devcon/README.md
@@ -4,7 +4,9 @@ Developer console (for internal use only)
 
 ### Input parameters
 
-None
+| Name                   | Mandatory | Description
+|------------------------|:---------:|-------------
+| `baseRoute `           |           | Route where the developer console is loaded (part after top level domain)
 
 ### Events
 

--- a/packages/devcon/src/main.js
+++ b/packages/devcon/src/main.js
@@ -15,7 +15,9 @@ const initApp = (id, input, events, publicPath) => {
   errorLogging.addToStore(store, true, ['console', 'remote', 'notification'])
   notification.addToStore(store, true)
 
-  const history = createBrowserHistory()
+  const history = createBrowserHistory({
+    ...input.baseRoute && {basename: input.baseRoute}
+  })
   const routes = require('./routes/index').default(store, input)
 
   const content = <Router history={history} routes={routes}/>


### PR DESCRIPTION
Necessary to serve the devcon app under a specific URL (not root path),
e.g. "/devcon". Otherwise the internal routing inside the app does not work.

Refs: TOCDEV-3951