### PR TITLE
feat(app-extensions): enable entity creation from remote fields

### DIFF
--- a/packages/app-extensions/src/field/editableTypeConfigs/remote.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/remote.js
@@ -46,6 +46,10 @@ export default {
         >
           {children}
         </formData.navigationStrategy.DetailLink>
-      : null
+      : null,
+    createPermission: formData.entityModel
+      && formField.relationName
+      && formData.entityModel.paths[formField.relationName].createPermission,
+    openRemoteCreate: () => formData.openRemoteCreate(formField, formName, formData)
   })
 }

--- a/packages/app-extensions/src/formData/FormDataContainer.js
+++ b/packages/app-extensions/src/formData/FormDataContainer.js
@@ -4,6 +4,7 @@ import {injectIntl} from 'react-intl'
 import {connect} from 'react-redux'
 import _isEqual from 'lodash/isEqual'
 import _reduce from 'lodash/reduce'
+import _get from 'lodash/get'
 import _pick from 'lodash/pick'
 import _merge from 'lodash/merge'
 import {
@@ -20,6 +21,7 @@ import {changeFieldValue, touchField} from './values/actions'
 import {uploadDocument} from './upload/actions'
 import {loadSearchFilters} from './searchFilters/actions'
 import {loadLocationsSuggestions} from './locations/actions'
+import {openRemoteCreate} from './remoteCreate/actions'
 
 const FormData = props =>
   <React.Fragment>{React.cloneElement(props.children, {formData: props})}</React.Fragment>
@@ -56,7 +58,8 @@ const mapStateToProps = (
   ...(navigationStrategy && state.formData.navigationStrategy
     ? {navigationStrategy: state.formData.navigationStrategy.navigationStrategy}
     : {}
-  )
+  ),
+  entityModel: _get(state, 'entityDetail.entityModel')
 })
 
 const mapActionCreators = {
@@ -67,7 +70,8 @@ const mapActionCreators = {
   changeFieldValue: changeFieldValue,
   touchField: touchField,
   loadSearchFilters: loadSearchFilters,
-  loadLocationsSuggestions: loadLocationsSuggestions
+  loadLocationsSuggestions: loadLocationsSuggestions,
+  openRemoteCreate: openRemoteCreate
 }
 
 const FormDataContainer = connect(

--- a/packages/app-extensions/src/formData/formData.js
+++ b/packages/app-extensions/src/formData/formData.js
@@ -17,6 +17,7 @@ import locationSagas from './locations/sagas'
 import locations from './locations/reducer'
 import navigationStrategy from './navigationStrategy/reducer'
 import {setNavigationStrategy} from './navigationStrategy/actions'
+import remoteCreateSagas from './remoteCreate/sagas'
 
 export const relationEntitiesSelector = store => store.formData.relationEntities.data
 export const tooltipSelector = store => store.formData.tooltips.data
@@ -40,6 +41,7 @@ export const addToStore = (store, config) => {
   store.sagaMiddleware.run(uploadSagas)
   store.sagaMiddleware.run(searchFilterSagas)
   store.sagaMiddleware.run(locationSagas)
+  store.sagaMiddleware.run(remoteCreateSagas, config)
 
   if (config.navigationStrategy) {
     store.dispatch(setNavigationStrategy(config.navigationStrategy))

--- a/packages/app-extensions/src/formData/remoteCreate/RemoteCreate.js
+++ b/packages/app-extensions/src/formData/remoteCreate/RemoteCreate.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const handleEntityCreated = (close, answerChannel) => result => {
+  close()
+  answerChannel.put(result)
+}
+
+const RemoteCreate = ({
+  DetailApp,
+  targetEntity,
+  answerChannel,
+  close,
+  emitAction
+}) => {
+  return <DetailApp
+    entityName={targetEntity}
+    formName={targetEntity}
+    mode={'create'}
+    onEntityCreated={handleEntityCreated(close, answerChannel)}
+    emitAction={emitAction}
+  />
+}
+
+RemoteCreate.propTypes = {
+  DetailApp: PropTypes.func.isRequired,
+  targetEntity: PropTypes.string.isRequired,
+  answerChannel: PropTypes.object.isRequired,
+  emitAction: PropTypes.func.isRequired,
+  close: PropTypes.func.isRequired
+}
+
+export default RemoteCreate

--- a/packages/app-extensions/src/formData/remoteCreate/RemoteCreateContainer.js
+++ b/packages/app-extensions/src/formData/remoteCreate/RemoteCreateContainer.js
@@ -1,0 +1,10 @@
+import {connect} from 'react-redux'
+
+import actionEmitter from '../../actionEmitter'
+import RemoteCreate from './RemoteCreate'
+
+const mapActionCreators = {
+  emitAction: actionEmitter.dispatchEmittedAction
+}
+
+export default connect(null, mapActionCreators)(RemoteCreate)

--- a/packages/app-extensions/src/formData/remoteCreate/actions.js
+++ b/packages/app-extensions/src/formData/remoteCreate/actions.js
@@ -1,0 +1,10 @@
+export const OPEN_REMOTE_CREATE = 'formData/OPEN_REMOTE_CREATE'
+export const FINISH_CREATION = 'formData/FINISH_CREATION'
+
+export const openRemoteCreate = (formField, formName) => ({
+  type: OPEN_REMOTE_CREATE,
+  payload: {
+    formField,
+    formName
+  }
+})

--- a/packages/app-extensions/src/formData/remoteCreate/sagas.js
+++ b/packages/app-extensions/src/formData/remoteCreate/sagas.js
@@ -1,0 +1,31 @@
+import {all, call, put, take, takeEvery} from 'redux-saga/effects'
+import {channel} from 'redux-saga'
+import {v4 as uuid} from 'uuid'
+import React from 'react'
+
+import * as actions from './actions'
+import * as valueActions from '../values/actions'
+import rest from '../../rest'
+import notification from '../../notification'
+import RemoteCreate from './RemoteCreateContainer'
+
+export default function* sagas(config) {
+  yield all([
+    takeEvery(actions.OPEN_REMOTE_CREATE, openRemoteCreate, config)
+  ])
+}
+
+export function* openRemoteCreate({detailApp}, {payload: {formName, formField}}) {
+  const answerChannel = yield call(channel)
+  const modalId = yield call(uuid)
+  const buildCreateForm = ({close}) => <RemoteCreate
+    targetEntity={formField.targetEntity}
+    answerChannel={answerChannel}
+    close={close}
+    DetailApp={detailApp}/>
+  yield put(notification.modal(modalId, formField.label, null, buildCreateForm, true))
+
+  const {id} = yield take(answerChannel)
+  const display = yield call(rest.fetchDisplay, formField.targetEntity, id)
+  yield put(valueActions.changeFieldValue(formName, formField.path, {key: id, display}))
+}

--- a/packages/app-extensions/src/formData/remoteCreate/sagas.spec.js
+++ b/packages/app-extensions/src/formData/remoteCreate/sagas.spec.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import {expectSaga} from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import {rest, notification} from 'tocco-app-extensions'
+import {takeEvery, all} from 'redux-saga/effects'
+import {channel} from 'redux-saga'
+
+import * as remoteCreateActions from './actions'
+import rootSaga, * as sagas from './sagas'
+import * as valueActions from '../values/actions'
+
+describe('app-extensions', () => {
+  describe('formData', () => {
+    describe('remoteCreate', () => {
+      describe('sagas', () => {
+        describe('root saga', () => {
+          test('should handle remoteCreate', () => {
+            const config = {}
+            const generator = rootSaga(config)
+
+            expect(generator.next().value).to.deep.equal(
+              all([
+                takeEvery(remoteCreateActions.OPEN_REMOTE_CREATE, sagas.openRemoteCreate, config)
+              ])
+            )
+
+            expect(generator.next().done).to.be.true
+          })
+        })
+
+        describe('openRemoteCreate', () => {
+          test('should prompt a modal and spawn close saga', () => {
+            const DetailApp = () => <div>ListApp</div>
+            const formField = {label: 'Person', path: 'relUser', targetEntity: 'User'}
+            const formName = 'detailForm'
+            const expectedId = 'some-id'
+            const expectedDisplay = 'display'
+
+            const action = remoteCreateActions.openRemoteCreate(formField, formName)
+            const config = {DetailApp}
+            return expectSaga(sagas.openRemoteCreate, config, action)
+              .provide([
+                [matchers.call.fn(rest.fetchDisplay), expectedDisplay],
+                [channel, {}],
+                {
+                  take() {
+                    return {id: expectedId}
+                  }
+                }
+              ])
+              .call(rest.fetchDisplay, formField.targetEntity, expectedId)
+              .put.actionType(notification.modal().type)
+              .put(valueActions.changeFieldValue(formName, formField.path, {key: expectedId, display: expectedDisplay}))
+              .run()
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/entity-detail/src/main.js
+++ b/packages/entity-detail/src/main.js
@@ -52,7 +52,11 @@ const initApp = (id, input, events = {}, publicPath) => {
       }
     }
   )
-  formData.addToStore(store, {listApp: EntityListApp, navigationStrategy: input.navigationStrategy})
+  formData.addToStore(store, {
+    listApp: EntityListApp,
+    detailApp: EntityDetailApp,
+    navigationStrategy: input.navigationStrategy
+  })
   keyDown.addToStore(store, shortcuts)
 
   const dispatchActions = getDispatchActions(input)

--- a/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/RemoteSelect.js
@@ -36,7 +36,8 @@ RemoteSelect.propTypes = {
     openAdvancedSearch: PropTypes.func,
     tooltips: PropTypes.objectOf(PropTypes.string),
     loadTooltip: PropTypes.func,
-    DetailLink: PropTypes.func
+    DetailLink: PropTypes.func,
+    createPermission: PropTypes.bool
   }),
   immutable: PropTypes.bool,
   id: PropTypes.string

--- a/packages/tocco-ui/src/Select/IndicatorsContainer.js
+++ b/packages/tocco-ui/src/Select/IndicatorsContainer.js
@@ -5,13 +5,18 @@ import PropTypes from 'prop-types'
 import Ball from '../Ball'
 import {StyledIndicatorsContainerWrapper} from './StyledComponents'
 
-const handleMouseUp = (openAdvancedSearch, value) => event => {
+const handleAdvancedSearch = (openAdvancedSearch, value) => event => {
   openAdvancedSearch(value)
   event.stopPropagation()
 }
 
+const handleCreate = openCreate => event => {
+  openCreate()
+  event.stopPropagation()
+}
+
 const IndicatorsContainer = props => {
-  const {openAdvancedSearch, isDisabled} = props.selectProps
+  const {openAdvancedSearch, openRemoteCreate, isDisabled, createPermission} = props.selectProps
 
   return (
     <StyledIndicatorsContainerWrapper>
@@ -22,9 +27,19 @@ const IndicatorsContainer = props => {
       && <span
         onTouchEnd={e => e.stopPropagation()}
         onMouseDown={e => e.stopPropagation()}
-        onMouseUp={handleMouseUp(openAdvancedSearch, props.value)}>
+        onMouseUp={handleAdvancedSearch(openAdvancedSearch, props.value)}>
         <Ball
           icon="search"
+          tabIndex={-1}
+        />
+      </span>}
+        {createPermission
+        && <span
+          onTouchEnd={e => e.stopPropagation()}
+          onMouseDown={e => e.stopPropagation()}
+          onMouseUp={handleCreate(openRemoteCreate)}>
+        <Ball
+          icon="plus"
           tabIndex={-1}
         />
       </span>}
@@ -45,7 +60,9 @@ IndicatorsContainer.propTypes = {
   children: PropTypes.node,
   selectProps: PropTypes.shape({
     openAdvancedSearch: PropTypes.func,
-    isDisabled: PropTypes.bool
+    openRemoteCreate: PropTypes.func,
+    isDisabled: PropTypes.bool,
+    createPermission: PropTypes.bool
   }),
   value: PropTypes.oneOfType([
     ItemPropType,

--- a/packages/tocco-ui/src/Select/Select.js
+++ b/packages/tocco-ui/src/Select/Select.js
@@ -36,7 +36,9 @@ const Select = ({
   theme,
   tooltips,
   value,
-  DetailLink
+  DetailLink,
+  createPermission,
+  openRemoteCreate
 }) => {
   const selectComponent = useRef(null)
   const selectWrapper = useRef(null)
@@ -119,6 +121,8 @@ const Select = ({
           moreOptionsAvailable={moreOptionsAvailable}
           moreOptionsAvailableText={moreOptionsAvailableText}
           blurInputOnSelect={false}
+          createPermission={createPermission}
+          openRemoteCreate={openRemoteCreate}
         />
       </div>
     </div>
@@ -212,7 +216,15 @@ Select.propTypes = {
   /**
    * Open menu with click on input field
    */
-  openMenuOnClick: PropTypes.bool
+  openMenuOnClick: PropTypes.bool,
+  /**
+   * Whether a new option may be created
+   */
+  createPermission: PropTypes.bool,
+  /**
+   * Opens a modal with a create form
+   */
+  openRemoteCreate: PropTypes.func
 }
 
 export default withTheme(Select)

--- a/packages/tocco-ui/src/Select/Select.spec.js
+++ b/packages/tocco-ui/src/Select/Select.spec.js
@@ -3,6 +3,7 @@ import ReactSelect from 'react-select'
 import {mount} from 'enzyme'
 import {TestThemeProvider} from 'tocco-test-util'
 
+import Ball from '../Ball'
 import Select from './Select'
 
 describe('tocco-ui', () => {
@@ -15,6 +16,48 @@ describe('tocco-ui', () => {
           </TestThemeProvider>
         )
         expect(wrapper.find(ReactSelect)).to.have.length(1)
+      })
+
+      test('should render advanced search button', () => {
+        const wrapper = mount(
+          <TestThemeProvider>
+            <Select openAdvancedSearch={() => {}} immutable={false}/>
+          </TestThemeProvider>
+        )
+        expect(wrapper.find(Ball).filterWhere(b => b.props().icon === 'search')).to.have.length(1)
+      })
+      test('should not render advanced search button when disabled', () => {
+        const wrapper = mount(
+          <TestThemeProvider>
+            <Select openAdvancedSearch={() => {}} immutable={true}/>
+          </TestThemeProvider>
+        )
+        expect(wrapper.find(Ball).filterWhere(b => b.props().icon === 'search')).to.have.length(0)
+      })
+      test('should not render advanced search button without function', () => {
+        const wrapper = mount(
+          <TestThemeProvider>
+            <Select immutable={false}/>
+          </TestThemeProvider>
+        )
+        expect(wrapper.find(Ball).filterWhere(b => b.props().icon === 'search')).to.have.length(0)
+      })
+
+      test('should render remote create button', () => {
+        const wrapper = mount(
+          <TestThemeProvider>
+            <Select createPermission={true}/>
+          </TestThemeProvider>
+        )
+        expect(wrapper.find(Ball).filterWhere(b => b.props().icon === 'plus')).to.have.length(1)
+      })
+      test('should not render remote create button when not allowed', () => {
+        const wrapper = mount(
+          <TestThemeProvider>
+            <Select createPermission={false}/>
+          </TestThemeProvider>
+        )
+        expect(wrapper.find(Ball).filterWhere(b => b.props().icon === 'plus')).to.have.length(0)
       })
     })
   })


### PR DESCRIPTION
Refs: TOCDEV-3016
Changelog: Add button to remote fields that opens a popup containing a create form