### PR TITLE
feat(devcon): Add simple SQL log view

### DIFF
--- a/packages/devcon/src/routes/devcon/components/DevCon/DevCon.js
+++ b/packages/devcon/src/routes/devcon/components/DevCon/DevCon.js
@@ -13,6 +13,7 @@ const DevCon = ({routes}) =>
     <StyledNavigation>
       <Link href="/log"><StyledLink>Log</StyledLink></Link>
       <Link href="/dbrefactoring"><StyledLink>DB Refactoring</StyledLink></Link>
+      <Link href="/sqllog"><StyledLink>SQL Log</StyledLink></Link>
     </StyledNavigation>
     {routes.map((route, i) => (
       <RouteWithSubRoutes key={i} {...route}/>

--- a/packages/devcon/src/routes/index.js
+++ b/packages/devcon/src/routes/index.js
@@ -4,6 +4,7 @@ import {Redirect} from 'react-router-dom'
 import devCon from './devcon'
 import log from './log'
 import dbRefactoring from './dbrefactoring'
+import sqlLog from './sqllog'
 
 export const createRoutes = (store, input) => [{
   path: '/',
@@ -23,6 +24,11 @@ export const createRoutes = (store, input) => [{
       path: '/dbrefactoring',
       exact: true,
       render: dbRefactoring(store, input)
+    },
+    {
+      path: '/sqllog',
+      exact: true,
+      render: sqlLog(store, input)
     }
   ]
 }]

--- a/packages/devcon/src/routes/sqllog/components/LogForm/LogForm.js
+++ b/packages/devcon/src/routes/sqllog/components/LogForm/LogForm.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {StatedValue} from 'tocco-ui'
+import Range from 'tocco-ui/src/Range'
+
+const LogForm = ({active, elapsed, setActive, setElapsed}) => {
+  const handleActiveChange = e => {
+    setActive(e.target.checked)
+  }
+
+  const handleElapsedChange = value => {
+    setElapsed(value)
+  }
+
+  return (
+    <div>
+      <StatedValue label="Active" fixLabel>
+        <input type="checkbox" checked={active} onChange={handleActiveChange}/>
+      </StatedValue>
+      <StatedValue label="Elapsed" hasValue={!!elapsed}>
+        <Range
+        fromText="from"
+        toText="to"
+        type="number"
+        value={elapsed}
+        options={{
+          postPointDigits: 0,
+          fixedDecimalScale: true
+        }}
+        events={{
+          onChange: handleElapsedChange
+        }}
+      />
+      </StatedValue>
+    </div>
+  )
+}
+
+LogForm.propTypes = {
+  active: PropTypes.bool.isRequired,
+  elapsed: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({
+      from: PropTypes.number,
+      to: PropTypes.number
+    })
+  ]),
+  setActive: PropTypes.func.isRequired,
+  setElapsed: PropTypes.func.isRequired
+}
+
+export default LogForm

--- a/packages/devcon/src/routes/sqllog/components/LogForm/LogFormContainer.js
+++ b/packages/devcon/src/routes/sqllog/components/LogForm/LogFormContainer.js
@@ -1,0 +1,16 @@
+import {connect} from 'react-redux'
+
+import {setActive, setElapsed} from '../../modules/actions'
+import LogForm from './LogForm'
+
+const mapStateToProps = state => ({
+  active: state.sqlLog.active,
+  elapsed: state.sqlLog.elapsed
+})
+
+const mapActionCreators = {
+  setActive,
+  setElapsed
+}
+
+export default connect(mapStateToProps, mapActionCreators)(LogForm)

--- a/packages/devcon/src/routes/sqllog/components/LogForm/index.js
+++ b/packages/devcon/src/routes/sqllog/components/LogForm/index.js
@@ -1,0 +1,1 @@
+export {default} from './LogFormContainer'

--- a/packages/devcon/src/routes/sqllog/components/LogTable/LogEntry.js
+++ b/packages/devcon/src/routes/sqllog/components/LogTable/LogEntry.js
@@ -1,0 +1,48 @@
+import React, {useState} from 'react'
+import PropTypes from 'prop-types'
+
+import {
+  StyledLogEntry,
+  StyledStatementHeader,
+  StyledStatement,
+  StyledTime,
+  StyledElapsedContainer,
+  StyledElapsed
+} from './StyledLogEntry'
+
+const LogEntry = ({entry}) => {
+  const [expanded, setExpanded] = useState(false)
+
+  const truncate = entry.sql.length > 100
+
+  const handleClick = () => {
+    if (truncate) {
+      setExpanded(!expanded)
+    }
+  }
+
+  const header = truncate ? entry.sql.substr(0, 100) + '...' : entry.sql
+
+  return (
+    <StyledLogEntry>
+      <StyledStatementHeader expandable={truncate} onClick={handleClick}>{header}</StyledStatementHeader>
+      {expanded && <StyledStatement>{entry.sql}</StyledStatement>}
+      <StyledTime>{new Date(entry.timestamp.iMillis).toLocaleString()}</StyledTime>
+      <StyledElapsedContainer>
+        <StyledElapsed elapsed={entry.elapsed}>{entry.elapsed} ms</StyledElapsed>
+      </StyledElapsedContainer>
+    </StyledLogEntry>
+  )
+}
+
+LogEntry.propTypes = {
+  entry: PropTypes.shape({
+    sql: PropTypes.string.isRequired,
+    timestamp: PropTypes.shape({
+      iMillis: PropTypes.number.isRequired
+    }).isRequired,
+    elapsed: PropTypes.number.isRequired
+  }).isRequired
+}
+
+export default LogEntry

--- a/packages/devcon/src/routes/sqllog/components/LogTable/LogTable.js
+++ b/packages/devcon/src/routes/sqllog/components/LogTable/LogTable.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Typography} from 'tocco-ui'
+
+import LogEntry from './LogEntry'
+import {StyledLogTable} from './StyledLogEntry'
+
+const filterEntries = (entries, elapsed) => {
+  if (!elapsed) {
+    return entries
+  }
+  return entries.filter(entry => {
+    if (elapsed.isRangeValue === true) {
+      return entry.elapsed >= elapsed.from && entry.elapsed <= elapsed.to
+    }
+    return entry.elapsed >= elapsed
+  })
+}
+
+const LogTable = ({entries, elapsed}) => {
+  const filteredEntries = filterEntries(entries, elapsed)
+  return (
+    <StyledLogTable>
+      {filteredEntries.length > 0
+        ? filteredEntries.map(entry => <LogEntry key={entry.key} entry={entry}/>)
+        : <Typography.Span>No entries so far.</Typography.Span>
+      }
+    </StyledLogTable>
+  )
+}
+
+LogTable.propTypes = {
+  entries: PropTypes.arrayOf(PropTypes.shape({
+    sql: PropTypes.string.isRequired,
+    elapsed: PropTypes.number.isRequired,
+    timestamp: PropTypes.shape({
+      iMillis: PropTypes.number.isRequired
+    }).isRequired
+  })).isRequired,
+  elapsed: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({
+      from: PropTypes.number,
+      to: PropTypes.number
+    })
+  ])
+}
+
+export default LogTable

--- a/packages/devcon/src/routes/sqllog/components/LogTable/LogTableContainer.js
+++ b/packages/devcon/src/routes/sqllog/components/LogTable/LogTableContainer.js
@@ -1,0 +1,13 @@
+import {connect} from 'react-redux'
+
+import LogTable from './LogTable'
+
+const mapStateToProps = state => ({
+  entries: state.sqlLog.entries,
+  elapsed: state.sqlLog.elapsed
+})
+
+const mapActionCreators = {
+}
+
+export default connect(mapStateToProps, mapActionCreators)(LogTable)

--- a/packages/devcon/src/routes/sqllog/components/LogTable/StyledLogEntry.js
+++ b/packages/devcon/src/routes/sqllog/components/LogTable/StyledLogEntry.js
@@ -1,0 +1,76 @@
+import styled from 'styled-components'
+import {declareFont} from 'tocco-ui'
+
+const BORDER_COLOR = {
+  ERROR: '#a00'
+}
+
+export const StyledLogTable = styled.div`
+  display: grid;
+  gap: 1px;
+`
+
+export const StyledLogEntry = styled.div`
+  display: grid;
+  height: fit-content;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 1em;
+  ${props => `border: 1px solid ${BORDER_COLOR[props.level] || '#ddd'};`}
+`
+
+export const StyledStatementHeader = styled.span`
+  grid-column: 1 / 3;
+  ${props => props.expandable && 'cursor: pointer;'}
+
+  && {
+    ${declareFont()}
+  }
+`
+
+export const StyledStatement = styled.span`
+  grid-column: 1 / 3;
+  margin-top: 1em;
+
+  && {
+    ${declareFont()}
+  }
+`
+
+export const StyledTime = styled.span`
+  grid-row-start: 1;
+  grid-column-start: 3;
+  text-align: right;
+
+  && {
+    ${declareFont()}
+  }
+`
+
+export const StyledElapsedContainer = styled.span`
+  grid-column-start: 3;
+  text-align: right;
+  margin-top: 1em;
+
+  && {
+    ${declareFont()}
+  }
+`
+
+const getBackgroundColor = elapsed => {
+  if (elapsed >= 1000) {
+    return '#f00'
+  }
+  if (elapsed >= 500) {
+    return '#ff8c00'
+  }
+  if (elapsed >= 100) {
+    return '#ff0'
+  }
+  return '#dedede'
+}
+
+export const StyledElapsed = styled.span`
+  background-color: ${props => getBackgroundColor(props.elapsed)};
+  border-radius: 5px;
+  padding: .5em;
+`

--- a/packages/devcon/src/routes/sqllog/components/LogTable/index.js
+++ b/packages/devcon/src/routes/sqllog/components/LogTable/index.js
@@ -1,0 +1,1 @@
+export {default} from './LogTableContainer'

--- a/packages/devcon/src/routes/sqllog/components/LogView/LogView.js
+++ b/packages/devcon/src/routes/sqllog/components/LogView/LogView.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import {Typography} from 'tocco-ui'
+
+import LogForm from '../LogForm'
+import LogTable from '../LogTable'
+
+const LogView = () => (
+  <>
+    <Typography.H1>SQL Log</Typography.H1>
+    <LogForm/>
+    <LogTable/>
+  </>
+)
+
+export default LogView

--- a/packages/devcon/src/routes/sqllog/components/LogView/index.js
+++ b/packages/devcon/src/routes/sqllog/components/LogView/index.js
@@ -1,0 +1,1 @@
+export {default} from './LogView'

--- a/packages/devcon/src/routes/sqllog/index.js
+++ b/packages/devcon/src/routes/sqllog/index.js
@@ -1,0 +1,12 @@
+import {route, reducer as reducerUtil} from 'tocco-util'
+
+export default (store, input) => {
+  if (module.hot) {
+    module.hot.accept('./route', () => {
+      const reducers = require('./route').default.reducers
+      reducerUtil.hotReloadReducers(store, reducers)
+    })
+  }
+
+  return route.loadRoute(store, input, () => (import('./route')))
+}

--- a/packages/devcon/src/routes/sqllog/modules/actions.js
+++ b/packages/devcon/src/routes/sqllog/modules/actions.js
@@ -1,0 +1,24 @@
+export const RECEIVE_ENTRY = 'sqllog/RECEIVE_ENTRY'
+export const SET_ACTIVE = 'sqllog/SET_ACTIVE'
+export const SET_ELAPSED = 'sqllog/SET_ELAPSED'
+
+export const receiveEntry = data => ({
+  type: RECEIVE_ENTRY,
+  payload: {
+    data
+  }
+})
+
+export const setActive = active => ({
+  type: SET_ACTIVE,
+  payload: {
+    active
+  }
+})
+
+export const setElapsed = elapsed => ({
+  type: SET_ELAPSED,
+  payload: {
+    elapsed
+  }
+})

--- a/packages/devcon/src/routes/sqllog/modules/index.js
+++ b/packages/devcon/src/routes/sqllog/modules/index.js
@@ -1,0 +1,1 @@
+export {default} from './reducer'

--- a/packages/devcon/src/routes/sqllog/modules/reducer.js
+++ b/packages/devcon/src/routes/sqllog/modules/reducer.js
@@ -1,0 +1,33 @@
+import {v4 as uuid} from 'uuid'
+import {reducer as reducerUtil} from 'tocco-util'
+
+import * as actions from './actions'
+
+const handleReceiveEntry = (state, {payload}) =>
+  state.active
+    ? {
+        ...state,
+        entries: [{
+          ...payload.data,
+          key: uuid()
+        },
+        ...state.entries]
+      }
+    : state
+
+const ACTION_HANDLERS = {
+  [actions.RECEIVE_ENTRY]: handleReceiveEntry,
+  [actions.SET_ACTIVE]: reducerUtil.singleTransferReducer('active'),
+  [actions.SET_ELAPSED]: reducerUtil.singleTransferReducer('elapsed')
+}
+
+const initialState = {
+  entries: [],
+  active: false,
+  elapsed: null
+}
+
+export default function reducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+  return handler ? handler(state, action) : state
+}

--- a/packages/devcon/src/routes/sqllog/modules/sagas.js
+++ b/packages/devcon/src/routes/sqllog/modules/sagas.js
@@ -1,0 +1,18 @@
+import {socket} from 'tocco-app-extensions'
+import {all, call} from 'redux-saga/effects'
+
+import * as actions from './actions'
+
+export default function* mainSagas() {
+  yield all([
+    call(initSocket)
+  ])
+}
+
+export function* initSocket() {
+  const params = {
+    name: 'sqllogging',
+    messageReceivedAction: actions.receiveEntry
+  }
+  yield call(socket.connectSocket, params)
+}

--- a/packages/devcon/src/routes/sqllog/route.js
+++ b/packages/devcon/src/routes/sqllog/route.js
@@ -1,0 +1,11 @@
+import LogView from './components/LogView'
+import sqlLog from './modules'
+import sagas from './modules/sagas'
+
+export default {
+  container: LogView,
+  reducers: {
+    sqlLog
+  },
+  sagas: [sagas]
+}


### PR DESCRIPTION
New simple SQL log view for the developer console:
- New entries are added at the top of the list (received via web socket)
- Note that the view only shows the entries which get logged while
  the log view is active (and the old entries disappear when the user
  navigates away from the log view and then returns)
- Possible to filter by elapsed time ("greater than" mode or range)
  to find slow queries

Refs: TOCDEV-3951