### PR TITLE
fix(devcon): Prevent complete reload of DevCon when changing page

### DIFF
--- a/packages/devcon/src/routes/devcon/components/DevCon/DevCon.js
+++ b/packages/devcon/src/routes/devcon/components/DevCon/DevCon.js
@@ -1,19 +1,19 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {Typography, Link} from 'tocco-ui'
+import {Typography} from 'tocco-ui'
 import {notification} from 'tocco-app-extensions'
 
 import RouteWithSubRoutes from '../../../../components/RouteWithSubRoutes'
-import {StyledDevCon, StyledNavigation, StyledLink} from './StyledDevCon'
+import {StyledDevCon, StyledNavigation, StyledRouterLink} from './StyledDevCon'
 
 const DevCon = ({routes}) =>
   <StyledDevCon>
     <notification.Notifications/>
     <Typography.Span>Tocco Developer Console</Typography.Span>
     <StyledNavigation>
-      <Link href="/log"><StyledLink>Log</StyledLink></Link>
-      <Link href="/dbrefactoring"><StyledLink>DB Refactoring</StyledLink></Link>
-      <Link href="/sqllog"><StyledLink>SQL Log</StyledLink></Link>
+      <StyledRouterLink to="/log">Log</StyledRouterLink>
+      <StyledRouterLink to="/dbrefactoring">DB Refactoring</StyledRouterLink>
+      <StyledRouterLink to="/sqllog">SQL Log</StyledRouterLink>
     </StyledNavigation>
     {routes.map((route, i) => (
       <RouteWithSubRoutes key={i} {...route}/>

--- a/packages/devcon/src/routes/devcon/components/DevCon/StyledDevCon.js
+++ b/packages/devcon/src/routes/devcon/components/DevCon/StyledDevCon.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import {theme, scale} from 'tocco-ui'
+import {theme, scale, RouterLink} from 'tocco-ui'
 
 export const StyledDevCon = styled.div`
   && {
@@ -16,7 +16,7 @@ export const StyledNavigation = styled.div`
   display: flex;
 `
 
-export const StyledLink = styled.div`
+export const StyledRouterLink = styled(RouterLink)`
   padding: 1em;
   background-color: #ddd;
   border-radius: 5px;


### PR DESCRIPTION
"Seamless" navigation enabled by using the `RouterLink` component
instead of the `Link` component (the latter renders a simple `<a>`
Link instead of a RouterLink).

This means, that the Redux store is kept and that we can navigate
around in the DevCon without losing application log or SQL log entries
etc.

Refs: TOCDEV-3951