### PR TITLE
fix(devcon): Fix generating SQL and changesets in prod env

### DIFF
--- a/packages/devcon/src/routes/modelvalidation/modules/sagas.js
+++ b/packages/devcon/src/routes/modelvalidation/modules/sagas.js
@@ -70,7 +70,7 @@ export function* generateSql() {
   const options = {
     method: 'POST',
     body: {
-      uuids: selection
+      uuids: Array.from(selection)
     }
   }
   try {
@@ -113,7 +113,7 @@ export function* generateChangelog() {
   const options = {
     method: 'POST',
     body: {
-      uuids: selection
+      uuids: Array.from(selection)
     }
   }
   try {


### PR DESCRIPTION
Requesting the SQL and changesets with the `selection` (which
is a Set) for some reason works in local dev environment (package
`devcon` started locally in tocco-client repository), but gets
serialized to `{}` when the app is included in the Nice repository,
which leads to an error because a List<String> is expected on the
server side.

We have to convert it to an array to fix the serialization.

Refs: TOCDEV-3951
Changelog: Fix generating SQL and changesets in prod env