### PR TITLE
refactor(docs-browser): shallow detail message

### DIFF
--- a/packages/docs-browser/src/components/Action/actions/CreateDomain.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateDomain.js
@@ -8,7 +8,8 @@ import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
   const emitActionBarrier = action => {
-    if (action.payload && action.payload.title !== 'client.entity-detail.createSuccessfulTitle') {
+    if (action.payload && action.payload.toaster
+      && action.payload.toaster.title !== 'client.entity-detail.createSuccessfulTitle') {
       emitAction(action)
     }
   }

--- a/packages/docs-browser/src/components/Action/actions/CreateFolder.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateFolder.js
@@ -8,7 +8,8 @@ import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
   const emitActionBarrier = action => {
-    if (action.payload && action.payload.title !== 'client.entity-detail.createSuccessfulTitle') {
+    if (action.payload && action.payload.toaster
+      && action.payload.toaster.title !== 'client.entity-detail.createSuccessfulTitle') {
       emitAction(action)
     }
   }


### PR DESCRIPTION
- to avoid two messages, the entity-detail success messages are shallowed by the action.

Changelog: Dms edit and create messages clean up
Refs: TOCDEV-4021