### PR TITLE
fix(input-edit): ignore empty tql strings in InputEditSearch

### DIFF
--- a/packages/input-edit/src/components/InputEditSearch/InputEditSearch.js
+++ b/packages/input-edit/src/components/InputEditSearch/InputEditSearch.js
@@ -37,6 +37,7 @@ const transformFormValuesToTql = (values, form) =>
     ))
     .filter(({path, fieldType, value}) => value && (!Array.isArray(value) || value.length > 0))
     .map(({path, fieldType, value}) => tqlBuilder.getTql(path, value, fieldType))
+    .filter(tql => tql.length > 0)
 
 const getFieldType = (path, form) => {
   const container = form.children.find(child => child.children.length > 0)


### PR DESCRIPTION
Refs: TOCDEV-4302
Cherry-pick: Up