### PR TITLE
style(tocco-ui): add spans to ButtonMenu labels

### DIFF
--- a/packages/tocco-ui/src/Menu/ButtonMenu.js
+++ b/packages/tocco-ui/src/Menu/ButtonMenu.js
@@ -52,7 +52,7 @@ const ButtonMenu = props => {
       onClick={handleClick}
       icon={icon}
     >
-      {label}
+      <span>{label}</span>
       <StyledIconWrapper>
         <Icon icon={chevronIcon}/>
       </StyledIconWrapper>


### PR DESCRIPTION
- Button usually adds them itself, but doesn't work when passing children