### PR TITLE
fix(tocco-ui): don't resize column after mouse release

### DIFF
--- a/packages/tocco-ui/src/Table/useResize.js
+++ b/packages/tocco-ui/src/Table/useResize.js
@@ -22,22 +22,27 @@ export default (tableElRef, resizeCallback, resizeFinishedCallback) => {
   const onMouseUp = useCallback(() => {
     if (resizingColumn) {
       resizeFinishedCallback(resizingColumn.id)
+      /**
+       * Internally the resizing is finished and `onMouseMove` should not
+       * invoke any resize callback handler anymore.
+       */
+      setIsResizing(false)
+      lastPositionX.current = undefined
 
       /**
-       * So that the last mouse event is still within the context of "resizing".
+       * Workaround:
+       * The follow up click event should still be within the context of "resizing".
        * Otherwise the resizingColumn which is returned is already cleared
-       * and the follow up click event could be interpreted for something else (e.g. sorting)
+       * and the follow up click event could be interpreted for something else (e.g. sorting).
        */
       setTimeout(() => {
-        setIsResizing(false)
         setResizingColumn(null)
-        lastPositionX.current = undefined
       }, 100)
     }
   }, [resizingColumn, resizeFinishedCallback])
 
   const onMouseMove = useCallback(e => {
-    if (resizingColumn) {
+    if (resizingColumn && isResizing) {
       handler.current = requestAnimationFrame(() => {
         if (lastPositionX.current) {
           const diff = e.clientX - lastPositionX.current

--- a/packages/tocco-ui/src/Table/useResize.spec.js
+++ b/packages/tocco-ui/src/Table/useResize.spec.js
@@ -68,6 +68,41 @@ describe('tocco-ui', () => {
         expect(map).to.not.have.property('mousemove')
         expect(map).to.not.have.property('mouseup')
       })
+
+      test('should stop resizing immediately when mouse up event invoked', () => {
+        jest.useFakeTimers()
+
+        const tableElRef = {current: {querySelector: () => ({offsetWidth: 50})}}
+        const resizeCallback = sinon.spy()
+        const resizeFinishedCallback = sinon.spy()
+        window.removeEventListener = sinon.spy()
+
+        const map = {}
+        window.addEventListener = jest.fn((event, cb) => {
+          map[event] = cb
+        })
+
+        const {result} = renderHook(() => useResize(tableElRef, resizeCallback, resizeFinishedCallback))
+
+        const column = {id: 'firstname'}
+        act(() => {
+          result.current.startResize(column)()
+        })
+
+        expect(map).to.have.property('mousemove')
+        expect(map).to.have.property('mouseup')
+
+        map.mousemove({clientX: 100})
+        map.mousemove({clientX: 200})
+        expect(resizeCallback.called).to.equal(true)
+        
+        resizeCallback.resetHistory()
+
+        map.mouseup()
+        map.mousemove({clientX: 300})
+        
+        expect(resizeCallback.called).to.equal(false)
+      })
     })
   })
 })


### PR DESCRIPTION
Columns resized after mouse has been release already.
This has been fixed by not invoking resize callback after mouse-up event
has been invoked.

Changelog: don't resize column after mouse release
Refs: TOCDEV-4017