### PR TITLE
refactor(tocco-ui): fix popper menu

### DIFF
--- a/packages/tocco-ui/src/Menu/Menu.js
+++ b/packages/tocco-ui/src/Menu/Menu.js
@@ -1,13 +1,19 @@
 import React, {useEffect, useRef, useState} from 'react'
 import PropTypes from 'prop-types'
 import {usePopper} from 'react-popper'
+import ReactDOM from 'react-dom'
 
 import {StyledPopper, StyledPopperWrapper} from './StyledComponents'
 
 /**
  * Menu realised with popper.
  */
-const Menu = ({referenceElement, onClose, open, children}) => {
+const Menu = ({
+  referenceElement,
+  onClose,
+  open,
+  children
+}) => {
   const thisEl = useRef(null)
   const [popperElement, setPopperElement] = useState(null)
   const [bottom, setBottom] = useState(0)
@@ -30,7 +36,10 @@ const Menu = ({referenceElement, onClose, open, children}) => {
     }
   }, [referenceElement])
 
-  const {styles, attributes} = usePopper(referenceElement, popperElement, {
+  const {
+    styles,
+    attributes
+  } = usePopper(referenceElement, popperElement, {
     placement: 'bottom-start',
     modifiers: [
       {
@@ -38,10 +47,8 @@ const Menu = ({referenceElement, onClose, open, children}) => {
         options: {
           offset: [0, 5]
         }
-      }
-    ]
-  }
-  )
+      }]
+  })
 
   if (!open) {
     return null
@@ -49,13 +56,15 @@ const Menu = ({referenceElement, onClose, open, children}) => {
 
   return (
     <StyledPopperWrapper ref={thisEl}>
-      {children && <StyledPopper
-        ref={setPopperElement}
-        style={styles.popper}
-        {...attributes.popper}
-        rectBottom={bottom}>
-        {React.Children.map(children, child => child && React.cloneElement(child, {onClose: onClose}))}
-      </StyledPopper>}
+      {children && ReactDOM.createPortal(
+        <StyledPopper
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+          rectBottom={bottom}>
+          {React.Children.map(children, child => child && React.cloneElement(child, {onClose: onClose}))}
+        </StyledPopper>,
+        document.body)}
     </StyledPopperWrapper>
   )
 }

--- a/packages/tocco-ui/src/Menu/StyledComponents.js
+++ b/packages/tocco-ui/src/Menu/StyledComponents.js
@@ -4,13 +4,13 @@ import {Button, declareFont, scale, theme, StyledScrollbar} from '../index'
 import {interactiveStyling} from '../utilStyles'
 
 export const StyledIconWrapper = styled.div`
-  margin-left: 4px;
-  margin-right: -3px;
+  margin-left: ${scale.space(-1.7)};
+  margin-right: -${scale.space(-2.1)};
 `
 
 export const StyledIconButtonWrapper = styled(Button)`
-  padding-left: .9rem;
-  padding-right: .9rem;
+  padding-left: ${scale.space(-0.5)};
+  padding-right: ${scale.space(-0.5)};
 `
 
 export const StyledPopperWrapper = styled.div`
@@ -25,7 +25,7 @@ export const StyledPopper = styled.div`
   background: ${theme.color('paper')};
   box-shadow: 0 0 5px rgba(0, 0, 0, .3);
   border: 1px solid ${theme.color('secondaryLight')};
-  z-index: 99999;
+  z-index: 1101; /* higher than .bm-menu-wrap 1100 */
   ${StyledScrollbar}
 `
 


### PR DESCRIPTION
Refs: TOCDEV-4343
Changelog: Fix popper menu disappearing behind bm-menu elements