### PR TITLE
feat(tocco-ui): add open in new tab to document compact

### DIFF
--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
@@ -8,14 +8,29 @@ const getDownloadUrl = binaryLink =>
   download.addParameterToURL(binaryLink, 'download', true)
 
 const DocumentCompactFormatter = ({value}) => (
-  <Link
-    alt={value.alt || value.fileName}
-    download={value.fileName}
-    icon="arrow-to-bottom"
-    look="raised"
-    href={getDownloadUrl(value.binaryLink)}
-    stopPropagation={true}
-  />
+  <>
+    <Link
+      alt={value.alt || value.fileName}
+      download={value.fileName}
+      icon="external-link"
+      look="raised"
+      target="_blank"
+      href={value.binaryLink}
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    />
+    <Link
+      alt={value.alt || value.fileName}
+      download={value.fileName}
+      icon="arrow-to-bottom"
+      look="raised"
+      href={getDownloadUrl(value.binaryLink)}
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    />
+  </>
 )
 
 DocumentCompactFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.spec.js
@@ -37,7 +37,7 @@ describe('tocco-ui', () => {
             thumbnailLink: 'thumbnail url'
           }}/>)
 
-          expect(wrapper.find('a')).to.have.length(1)
+          expect(wrapper.find('a')).to.have.length(2)
           expect(wrapper.find('img')).to.have.length(0)
         })
       })


### PR DESCRIPTION
Refs: TOCDEV-2727
Changelog: add open in new tab to document compact