### PR TITLE
feat(entity-list): use scope for preferences

### DIFF
--- a/packages/entity-list/src/modules/preferences/sagas.js
+++ b/packages/entity-list/src/modules/preferences/sagas.js
@@ -28,8 +28,9 @@ export default function* sagas() {
 }
 
 export function* loadPreferences() {
-  const listState = yield select(listSagas.entityListSelector)
-  const formName = `${listState.formName}_list`
+  const entityListState = yield select(listSagas.entityListSelector)
+  const listState = yield select(listSagas.listSelector)
+  const formName = `${entityListState.formName}_${listState.scope}`
   const preferences = yield call(rest.fetchUserPreferences, `${formName}*`)
   yield put(setPositions(util.getPositions(preferences)))
   yield put(setSorting(util.getSorting(preferences)))
@@ -47,8 +48,9 @@ export function* changePosition({payload}) {
 
   const newPositions = yield call(util.changePosition, positions, field, afterFieldPosition)
   yield put(setPositions(newPositions))
-  const listState = yield select(listSagas.entityListSelector)
-  const formName = `${listState.formName}_list`
+  const entityListState = yield select(listSagas.entityListSelector)
+  const listState = yield select(listSagas.listSelector)
+  const formName = `${entityListState.formName}_${listState.scope}`
   yield call(rest.deleteUserPreferences, `${formName}.*.positions`)
   const positionPreferences = yield call(util.getPositionsPreferencesToSave, formName, newPositions)
   yield call(rest.savePreferences, positionPreferences)
@@ -57,8 +59,9 @@ export function* changePosition({payload}) {
 export function* saveSorting() {
   const {sorting: sortings} = yield select(listSagas.listSelector)
   if (sortings.length > 0) {
-    const listState = yield select(listSagas.entityListSelector)
-    const formName = `${listState.formName}_list`
+    const entityListState = yield select(listSagas.entityListSelector)
+    const listState = yield select(listSagas.listSelector)
+    const formName = `${entityListState.formName}_${listState.scope}`
     yield all([
       call(rest.deleteUserPreferences, `${formName}.sortingField*`),
       call(rest.deleteUserPreferences, `${formName}.sortingDirection*`)
@@ -74,18 +77,20 @@ export function* saveSorting() {
 }
 
 export function* resetSorting() {
-  const listState = yield select(listSagas.entityListSelector)
+  const entityListState = yield select(listSagas.entityListSelector)
+  const listState = yield select(listSagas.listSelector)
   yield all([
-    call(rest.deleteUserPreferences, `${listState.formName}_list.sortingField*`),
-    call(rest.deleteUserPreferences, `${listState.formName}_list.sortingDirection*`)
+    call(rest.deleteUserPreferences, `${entityListState.formName}_${listState.scope}.sortingField*`),
+    call(rest.deleteUserPreferences, `${entityListState.formName}_${listState.scope}.sortingDirection*`)
   ])
   yield call(listSagas.setSorting)
   yield call(listSagas.reloadData)
 }
 
 export function* resetPreferences() {
-  const listState = yield select(listSagas.entityListSelector)
-  yield call(rest.deleteUserPreferences, `${listState.formName}_list.*`)
+  const entityListState = yield select(listSagas.entityListSelector)
+  const listState = yield select(listSagas.listSelector)
+  yield call(rest.deleteUserPreferences, `${entityListState.formName}_${listState.scope}.*`)
   yield call(listSagas.setSorting)
   yield call(listSagas.reloadData)
 }
@@ -135,10 +140,11 @@ function* saveColumnPreferences(answerChannel, preferencesColumns, formDefinitio
 }
 
 export function* resetColumns() {
-  const listState = yield select(listSagas.entityListSelector)
+  const entityListState = yield select(listSagas.entityListSelector)
+  const listState = yield select(listSagas.listSelector)
   yield all([
-    call(rest.deleteUserPreferences, `${listState.formName}_list.*.position`),
-    call(rest.deleteUserPreferences, `${listState.formName}_list.*.hidden`)
+    call(rest.deleteUserPreferences, `${entityListState.formName}_${listState.scope}.*.position`),
+    call(rest.deleteUserPreferences, `${entityListState.formName}_${listState.scope}.*.hidden`)
   ])
   yield put(listActions.refresh())
 }

--- a/packages/entity-list/src/modules/preferences/sagas.spec.js
+++ b/packages/entity-list/src/modules/preferences/sagas.spec.js
@@ -52,6 +52,7 @@ describe('entity-list', () => {
             return expectSaga(sagas.loadPreferences)
               .provide([
                 [select(entityListSelector), {formName: 'User'}],
+                [select(listSelector), {scope: 'list'}],
                 [matchers.call.fn(rest.fetchUserPreferences), preferences]
               ])
               .put.actionType(actions.SET_POSITIONS)
@@ -65,6 +66,7 @@ describe('entity-list', () => {
             return expectSaga(sagas.changePosition, {payload: {field: 'firstname', afterFieldPosition: 'mail'}})
               .provide([
                 [select(entityListSelector), {formName: 'User'}],
+                [select(listSelector), {scope: 'list'}],
                 [select(sagas.preferencesSelector), {positions: {firstname: 1, mail: 2}}],
                 [matchers.call.fn(rest.deleteUserPreferences)],
                 [matchers.call.fn(rest.savePreferences)]
@@ -97,7 +99,7 @@ describe('entity-list', () => {
             return expectSaga(sagas.saveSorting)
               .provide([
                 [select(entityListSelector), {formName: 'User'}],
-                [select(listSelector), {sorting: providedSorting}],
+                [select(listSelector), {scope: 'list', sorting: providedSorting}],
                 [matchers.call.fn(rest.deleteUserPreferences)],
                 [matchers.call.fn(rest.savePreferences)]
               ])
@@ -110,7 +112,7 @@ describe('entity-list', () => {
             return expectSaga(sagas.saveSorting)
               .provide([
                 [select(entityListSelector), {formName: 'User'}],
-                [select(listSelector), {sorting: []}]
+                [select(listSelector), {scope: 'list', sorting: []}]
               ])
               .not.call.like({fn: rest.savePreferences})
               .not.call.like({fn: rest.deleteUserPreferences})
@@ -122,6 +124,7 @@ describe('entity-list', () => {
           test('should remove sorting preferences', () => {
             return expectSaga(sagas.resetSorting)
               .provide([
+                [select(listSelector), {scope: 'list'}],
                 [select(entityListSelector), {formName: 'User'}],
                 [matchers.call.fn(rest.deleteUserPreferences)],
                 [matchers.call.fn(listSagas.setSorting)],
@@ -139,6 +142,7 @@ describe('entity-list', () => {
           test('should remove all preferences', () => {
             return expectSaga(sagas.resetPreferences)
               .provide([
+                [select(listSelector), {scope: 'list'}],
                 [select(entityListSelector), {formName: 'User'}],
                 [matchers.call.fn(rest.deleteUserPreferences)],
                 [matchers.call.fn(listSagas.setSorting)],
@@ -170,7 +174,8 @@ describe('entity-list', () => {
                         }
                       ]
                     }]
-                  }
+                  },
+                  scope: 'list'
                 }],
                 [select(listSagas.entityListSelector), {}],
                 [select(sagas.preferencesSelector), preferencesSelector],
@@ -219,6 +224,7 @@ describe('entity-list', () => {
           test('should delete preferences', () => {
             return expectSaga(sagas.resetColumns)
               .provide([
+                [select(listSelector), {scope: 'list'}],
                 [select(entityListSelector), {formName: 'User'}],
                 [matchers.call.fn(rest.deleteUserPreferences)]
               ])


### PR DESCRIPTION
Use scope also for preferences,
so that each scope has it's own preferences.

Changelog: use scope for preferences
Refs: TOCDEV-4333