### PR TITLE
refactor(tocco-ui): only load huge global styles once per app

### DIFF
--- a/packages/admin/src/components/Admin/Admin.js
+++ b/packages/admin/src/components/Admin/Admin.js
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import {Redirect, Route, Router, Switch} from 'react-router-dom'
 import {createBrowserHistory} from 'history'
-import {BurgerButton, LoadMask} from 'tocco-ui'
+import {BurgerButton, GlobalStyles, LoadMask} from 'tocco-ui'
 import {FormattedMessage} from 'react-intl'
 import {withTheme} from 'styled-components'
 import {notification} from 'tocco-app-extensions'
@@ -63,6 +63,7 @@ const Admin = ({
 
   return <LoadMask required={[history !== null]}>
     <Router history={history || {}}>
+      <GlobalStyles/>
       <notification.Notifications navigationStrategy={navigationStrategy()}/>
       <StyledWrapper id="outer-container">
         <Header/>

--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -14,6 +14,7 @@ import {selectionStylePropType} from 'tocco-entity-list/src/util/selectionStyles
 import createHashHistory from 'history/createHashHistory'
 import createMemoryHistory from 'history/createMemoryHistory'
 import {Router as ReactRouter, Route, Redirect} from 'react-router'
+import {GlobalStyles} from 'tocco-ui'
 
 import DocsBrowser from './components/DocsBrowser'
 import reducers, {sagas} from './modules/reducers'
@@ -80,6 +81,7 @@ const initApp = (id, input, events = {}, publicPath) => {
   const content = (
     <ReactRouter history={history}>
       {handleNotifications && <notification.Notifications/>}
+      <GlobalStyles/>
       <DocsBrowser history={history}/>
       <Route exact path="/">
         <Redirect to={startUrl}/>

--- a/packages/entity-browser/src/main.js
+++ b/packages/entity-browser/src/main.js
@@ -12,6 +12,7 @@ import createHashHistory from 'history/createHashHistory'
 import createMemoryHistory from 'history/createMemoryHistory'
 import PropTypes from 'prop-types'
 import {route} from 'tocco-util'
+import {GlobalStyles} from 'tocco-ui'
 
 import {sagas} from './modules/reducers'
 
@@ -75,7 +76,10 @@ const initApp = (id, input, events, publicPath) => {
 
   const routes = require('./routes/index').default(store, input)
 
-  const content = <route.Router history={history} routes={routes}/>
+  const content = <>
+    <GlobalStyles/>
+    <route.Router history={history} routes={routes}/>
+  </>
 
   const app = appFactory.createApp(
     packageName,

--- a/packages/input-edit/src/components/InputEdit/InputEdit.js
+++ b/packages/input-edit/src/components/InputEdit/InputEdit.js
@@ -2,6 +2,7 @@ import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {actions, notification} from 'tocco-app-extensions'
 import {selection as selectionPropType} from 'tocco-util'
+import {GlobalStyles} from 'tocco-ui'
 
 import InputEditTable from '../InputEditTable/InputEditTableContainer'
 import InputEditSearch from '../InputEditSearch'
@@ -34,6 +35,7 @@ const InputEdit = ({
   }, [selection])
 
   return <>
+    <GlobalStyles/>
     {handleNotifications && <notification.Notifications/>}
     <StyledPaneWrapper>
       <StyledPanelWrapperLeft>

--- a/packages/merge/src/main.js
+++ b/packages/merge/src/main.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {reducer as reducerUtil} from 'tocco-util'
 import {actionEmitter, appFactory, externalEvents, notification} from 'tocco-app-extensions'
 import PropTypes from 'prop-types'
+import {GlobalStyles} from 'tocco-ui'
 
 import Merge from './components/Merge'
 import reducers, {sagas} from './modules/reducers'
@@ -22,6 +23,7 @@ const initApp = (id, input, events = {}, publicPath) => {
   notification.addToStore(store, handleNotifications)
 
   const content = <>
+    <GlobalStyles/>
     {handleNotifications && <notification.Notifications/>}
     <Merge/>
   </>

--- a/packages/resource-scheduler/src/main.js
+++ b/packages/resource-scheduler/src/main.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {reducer as reducerUtil, selection as selectionPropType} from 'tocco-util'
 import {appFactory, externalEvents, notification, errorLogging, actionEmitter} from 'tocco-app-extensions'
+import {GlobalStyles} from 'tocco-ui'
 
 import reducers, {sagas} from './modules/reducers'
 import ResourceSchedulerContainer from './containers/ResourceSchedulerContainer'
@@ -14,7 +15,10 @@ const EXTERNAL_EVENTS = [
 ]
 
 const initApp = (id, input, events, publicPath) => {
-  const content = <ResourceSchedulerContainer/>
+  const content = <>
+    <GlobalStyles/>
+    <ResourceSchedulerContainer/>
+  </>
   const store = appFactory.createStore(reducers, sagas, input, packageName)
   externalEvents.addToStore(store, events)
   actionEmitter.addToStore(store, events.emitAction)

--- a/packages/tocco-ui/src/DatePicker/DatePicker.js
+++ b/packages/tocco-ui/src/DatePicker/DatePicker.js
@@ -6,7 +6,6 @@ import {withTheme} from 'styled-components'
 import {theme} from '../utilStyles'
 import {useDatePickr} from './useDatePickr'
 import {StyledWrapper} from './StyledDatePicker'
-import {GlobalDatePickerStyles} from './GlobalDatePickerStyles'
 
 export const DatePicker = props => {
   const {value, children, intl, onChange} = props
@@ -20,7 +19,6 @@ export const DatePicker = props => {
 
   return (
     <>
-      <GlobalDatePickerStyles/>
       <StyledWrapper
         data-wrap
         ref={wrapperElement}

--- a/packages/tocco-ui/src/DatePicker/index.js
+++ b/packages/tocco-ui/src/DatePicker/index.js
@@ -1,5 +1,7 @@
 import LazyDatePicker from './LazyDatePicker'
+import {GlobalDatePickerStyles} from './GlobalDatePickerStyles'
 
 export {
-  LazyDatePicker as default
+  LazyDatePicker as default,
+  GlobalDatePickerStyles
 }

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DateAbstract.js
@@ -11,7 +11,6 @@ import {
   StyledDateAbstractWrapper,
   StyledDateAbstractOuterWrapper
 } from './StyledDateAbstract'
-import {GlobalDatePickerStyles} from '../../DatePicker/GlobalDatePickerStyles'
 import Ball from '../../Ball'
 
 class DateAbstract extends React.Component {
@@ -161,7 +160,6 @@ class DateAbstract extends React.Component {
   render() {
     return (
       <>
-        <GlobalDatePickerStyles/>
         <StyledDateAbstractOuterWrapper
           immutable={this.props.immutable}
           id={this.props.id}

--- a/packages/tocco-ui/src/GlobalStyles/GlobalStyles.js
+++ b/packages/tocco-ui/src/GlobalStyles/GlobalStyles.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import {GlobalDatePickerStyles} from '../DatePicker'
+
+const GlobalStyles = () => {
+  return <>
+    <GlobalDatePickerStyles/>
+  </>
+}
+
+export default GlobalStyles

--- a/packages/tocco-ui/src/GlobalStyles/index.js
+++ b/packages/tocco-ui/src/GlobalStyles/index.js
@@ -1,0 +1,5 @@
+import GlobalStyles from './GlobalStyles'
+
+export {
+  GlobalStyles as default
+}

--- a/packages/tocco-ui/src/index.js
+++ b/packages/tocco-ui/src/index.js
@@ -74,6 +74,7 @@ export {
 } from './utilStyles'
 
 export {default as DatePicker} from './DatePicker'
+export {default as GlobalStyles} from './GlobalStyles'
 export {default as Range} from './Range'
 export {default as BurgerButton} from './BurgerButton'
 export {default as Pagination} from './Pagination'


### PR DESCRIPTION
The datepicker has a huge global style which gets injected into the
DOM per datepicker instance. On bigger forms with a lot of datepickers this
causes some performance impacts.

Changelog: only load huge global styles once per app
Refs: TOCDEV-4148