### PR TITLE
fix(entity-browser): fix opening entity-browser the second time

### DIFF
--- a/packages/entity-browser/src/routes/list/components/ListView.js
+++ b/packages/entity-browser/src/routes/list/components/ListView.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {queryString as queryStringUtil, viewPersistor} from 'tocco-util'
+import {RouterLink} from 'tocco-ui'
+import EntityListApp from 'tocco-entity-list/src/main'
+
+import Action from '../../../components/LazyAction'
+
+const DetailLinkRelative = ({entityKey, children, relation}) =>
+  <RouterLink to={`${relation ? relation + '/' : ''}detail/${entityKey}`}>{children}</RouterLink>
+
+DetailLinkRelative.propTypes = {
+  entityKey: PropTypes.string.isRequired,
+  children: PropTypes.element.isRequired,
+  relation: PropTypes.string
+}
+
+const ListView = ({storeId, router, ...props}) => {
+  const navigateToCreate = ({history, match, relationName}) => {
+    if (relationName) {
+      history.push(`${match}/${relationName}/`)
+    } else {
+      history.push('/detail')
+    }
+  }
+
+  const navigateToAction = (history, definition, selection) => {
+    const search = queryStringUtil.toQueryString({
+      selection,
+      actionProperties: definition.properties
+    })
+    history.push({
+      pathname: '/action/' + definition.appId,
+      state: {definition, selection},
+      search
+    })
+  }
+
+  const handleRowClick = e => {
+    router.history.push(`/detail/${e.id}`)
+  }
+
+  return (
+    <EntityListApp
+      {...props}
+      onRowClick={handleRowClick}
+      showLink
+      navigationStrategy={{
+        DetailLinkRelative,
+        navigateToActionRelative: (definition, selection) =>
+          navigateToAction(router.history, definition, selection),
+        navigateToCreateRelative: relationName => navigateToCreate(
+          {relationName, history: router.history, match: router.match}
+        )
+      }}
+      searchFormPosition="top"
+      actionAppComponent={Action}
+      store={viewPersistor.viewInfoSelector(storeId).store}
+      onStoreCreate={store => {
+        viewPersistor.persistViewInfo(storeId, {store}, 0)
+      }}
+    />
+  )
+}
+
+ListView.propTypes = {
+  id: PropTypes.string.isRequired,
+  storeId: PropTypes.string.isRequired,
+  local: PropTypes.string.isRequired,
+  entityName: PropTypes.string.isRequired,
+  formName: PropTypes.string.isRequired,
+  searchFormType: PropTypes.string.isRequired,
+  limit: PropTypes.number,
+  searchFitlers: PropTypes.array,
+  preselectedSearchFields: PropTypes.array,
+  disableSimpleSearch: PropTypes.bool,
+  simpleSearchFields: PropTypes.string,
+  router: PropTypes.object.isRequired
+}
+
+export default ListView

--- a/packages/entity-browser/src/routes/list/containers/ListViewContainer.js
+++ b/packages/entity-browser/src/routes/list/containers/ListViewContainer.js
@@ -1,53 +1,20 @@
 import {connect} from 'react-redux'
-import EntityListApp from 'tocco-entity-list/src/main'
 import {actionEmitter} from 'tocco-app-extensions'
-import {queryString as queryStringUtil, viewPersistor} from 'tocco-util'
-import {RouterLink} from 'tocco-ui'
-import React from 'react'
-import PropTypes from 'prop-types'
 
-import Action from '../../../components/LazyAction'
+import ListView from '../components/ListView'
 
-const mapDispatchToProps = (dispatch, props) => ({
+const mapDispatchToProps = dispatch => ({
   emitAction: action => {
     dispatch(actionEmitter.dispatchEmittedAction(action))
   }
 })
-
-const navigateToCreate = ({history, match, relationName}) => {
-  if (relationName) {
-    history.push(`${match}/${relationName}/`)
-  } else {
-    history.push('/detail')
-  }
-}
-
-const navigateToAction = (history, definition, selection) => {
-  const search = queryStringUtil.toQueryString({
-    selection,
-    actionProperties: definition.properties
-  })
-  history.push({
-    pathname: '/action/' + definition.appId,
-    state: {definition, selection},
-    search
-  })
-}
-
-const DetailLinkRelative = ({entityKey, children, relation}) =>
-  <RouterLink to={`${relation ? relation + '/' : ''}detail/${entityKey}`}>{children}</RouterLink>
-
-DetailLinkRelative.propTypes = {
-  entityKey: PropTypes.string.isRequired,
-  children: PropTypes.element.isRequired,
-  relation: PropTypes.string
-}
 
 const mapStateToProps = (state, props) => {
   const id = `${state.entityBrowser.appId}_entity-browser-list`
   const storeId = `${id}_${props.router.history.location.pathname}`
   return {
     id,
+    storeId,
     locale: state.input.locale,
     entityName: state.entityBrowser.entityName,
     formName: state.entityBrowser.formBase,
@@ -56,27 +23,8 @@ const mapStateToProps = (state, props) => {
     searchFilters: state.input.searchFilters,
     preselectedSearchFields: state.input.preselectedSearchFields,
     disableSimpleSearch: state.input.disableSimpleSearch,
-    simpleSearchFields: state.input.simpleSearchFields,
-    onRowClick: e => {
-      props.router.history.push(`/detail/${e.id}`)
-    },
-    showLink: true,
-    navigationStrategy: {
-      DetailLinkRelative,
-      navigateToActionRelative: (definition, selection) =>
-        navigateToAction(props.router.history, definition, selection),
-      navigateToCreateRelative: relationName => navigateToCreate(
-        {relationName, history: props.router.history, match: props.router.match}
-      )
-    },
-
-    searchFormPosition: 'top',
-    actionAppComponent: Action,
-    store: viewPersistor.viewInfoSelector(storeId).store,
-    onStoreCreate: store => {
-      viewPersistor.persistViewInfo(storeId, {store}, 0)
-    }
+    simpleSearchFields: state.input.simpleSearchFields
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EntityListApp)
+export default connect(mapStateToProps, mapDispatchToProps)(ListView)


### PR DESCRIPTION
The entity-browser was broken when it was
opened the second time by e.g. navigating away and coming back to it.
The problem was that it got re-rendered with the latest persisted state as
soon as something changed. Therefore it triggered the refresh data action
instead of handling it as a normal initialisation.

Changelog: fix opening entity-browser the second time
Refs: TOCDEV-4383