### PR TITLE
refactor(tocco-ui): add responivity to buttons

### DIFF
--- a/packages/entity-detail/src/components/DetailForm/SaveButton.js
+++ b/packages/entity-detail/src/components/DetailForm/SaveButton.js
@@ -4,27 +4,36 @@ import PropTypes from 'prop-types'
 
 import modes from '../../util/modes'
 import ErrorItems from '../ErrorItems'
-import {StyledButton} from './StyledComponents'
+import {StyledSaveButton} from './StyledComponents'
 
-const SaveButton = ({submitting, mode, intl, hasErrors, formErrors, icon}) => {
+const SaveButton = ({
+  submitting,
+  mode,
+  intl,
+  hasErrors,
+  formErrors,
+  icon
+}) => {
   const msg = id => (intl.formatMessage({id}))
 
-  return <Popover
-    content={hasErrors ? <ErrorItems formErrors={formErrors}/> : null}
-    placement="bottom">
-    <StyledButton
-      data-cy="detail-form_submit-button"
-      id="detail-save_button"
-      disabled={submitting}
-      ink="primary"
-      label={msg(`client.entity-detail.${mode === modes.CREATE ? 'create' : 'save'}`)}
-      look={hasErrors ? 'flat' : 'raised'}
-      pending={submitting}
-      type="submit"
-      hasErrors={hasErrors}
-      icon={hasErrors ? 'exclamation' : icon}
-    />
-  </Popover>
+  return (
+    <Popover
+      content={hasErrors ? <ErrorItems formErrors={formErrors}/> : null}
+      placement="bottom">
+      <StyledSaveButton
+        data-cy="detail-form_submit-button"
+        id="detail-save_button"
+        disabled={submitting}
+        ink="primary"
+        label={msg(`client.entity-detail.${mode === modes.CREATE ? 'create' : 'save'}`)}
+        look={hasErrors ? 'flat' : 'raised'}
+        pending={submitting}
+        type="submit"
+        hasErrors={hasErrors}
+        icon={hasErrors ? 'exclamation' : icon}
+      />
+    </Popover>
+  )
 }
 
 SaveButton.propTypes = {

--- a/packages/entity-detail/src/components/DetailForm/StyledComponents.js
+++ b/packages/entity-detail/src/components/DetailForm/StyledComponents.js
@@ -10,14 +10,15 @@ export const StyledForm = styled.form`
   ${StyledScrollbar}
 `
 
-export const StyledButton = styled(Button)`
+export const StyledSaveButton = styled(Button)`
   ${({hasErrors}) => hasErrors && `
     background-color: ${theme.color('paper')};
-  `};
+  `}
+  display: block;
 `
 
 export const StyledActionWrapper = styled.div`
-  ${StyledButton} {
+  ${StyledSaveButton} {
     width: 100%;
     max-width: fit-content;
     justify-content: center;

--- a/packages/tocco-ui/src/Button/Button.js
+++ b/packages/tocco-ui/src/Button/Button.js
@@ -3,14 +3,25 @@ import React from 'react'
 
 import Icon from '../Icon'
 import LoadingSpinner from '../LoadingSpinner'
-import StyledButton from './StyledButton'
+import StyledButton, {StyledLabelWrapper} from './StyledButton'
 import {design} from '../utilStyles'
 
 /**
  * Use the Button to trigger any actions. Choose look and ink according Material Design.
  */
 const Button = React.forwardRef((props, ref) => {
-  const {aria, ink, label, icon, pending, look, iconPosition, iconOnly, children} = props
+  const {
+    aria,
+    ink,
+    label,
+    icon,
+    pending,
+    look,
+    iconPosition,
+    iconOnly,
+    children
+  } = props
+
   return <StyledButton
     ref={ref}
     {...aria}
@@ -27,7 +38,7 @@ const Button = React.forwardRef((props, ref) => {
       look={look}
       position={iconPosition}
       size="1em"/>}
-    {!iconOnly && label ? <span>{label}</span> : children || '\u200B' }
+    {!iconOnly && label ? <StyledLabelWrapper>{label}</StyledLabelWrapper> : children || '\u200B'}
   </StyledButton>
 })
 
@@ -87,8 +98,8 @@ Button.propTypes = {
    */
   'onClick': PropTypes.func,
   /**
-  * If true, an animated spinner icon is prepended.
-  */
+   * If true, an animated spinner icon is prepended.
+   */
   'pending': PropTypes.bool,
   /**
    * Describe button action in detail to instruct users. It is shown as popover on mouse over.

--- a/packages/tocco-ui/src/Button/StyledButton.js
+++ b/packages/tocco-ui/src/Button/StyledButton.js
@@ -2,6 +2,8 @@ import styled from 'styled-components'
 
 import {buttonStyle} from './buttonStyle'
 
+export const StyledLabelWrapper = styled.span``
+
 const StyledButton = styled.button`
   ${buttonStyle}
 `

--- a/packages/tocco-ui/src/Button/buttonStyle.js
+++ b/packages/tocco-ui/src/Button/buttonStyle.js
@@ -1,8 +1,13 @@
 import {css} from 'styled-components'
 
+import {StyledLabelWrapper} from './StyledButton'
 import {declareFont, design, interactiveStyling, scale, theme as themeSelector} from '../utilStyles'
 
-const declareIconPosition = ({icon, pending, iconPosition}) => {
+const declareIconPosition = ({
+  icon,
+  pending,
+  iconPosition
+}) => {
   if (icon || pending) {
     if (iconPosition === design.position.APPEND) {
       return `
@@ -20,7 +25,11 @@ const declareIconPosition = ({icon, pending, iconPosition}) => {
       `
   }
 }
-const getDensityStyle = ({dense, theme}) =>
+
+const getDensityStyle = ({
+  dense,
+  theme
+}) =>
   dense
     ? css`
   line-height: ${themeSelector.lineHeight('dense')({theme})};
@@ -52,7 +61,6 @@ export const buttonStyle = css`
   margin-right: ${scale.space(-1.38)};
   padding: ${scale.space(-2.1)} ${scale.space(0)};
   cursor: pointer;
-  height: fit-content;
   ${declareFont()}
   ${props => props.withoutBackground ? transparentBackground() : interactiveStyling(props)}
   ${props => getDensityStyle(props)}
@@ -62,4 +70,11 @@ export const buttonStyle = css`
   & > span:first-child {
     margin-left: 0;
   }
+  ${({icon}) => icon && `
+    @media screen and (max-width: 1024px) {
+      ${StyledLabelWrapper} {
+        display: none;
+      }
+    }
+  `}
 `

--- a/packages/tocco-ui/src/Menu/ButtonMenu.js
+++ b/packages/tocco-ui/src/Menu/ButtonMenu.js
@@ -3,12 +3,20 @@ import PropTypes from 'prop-types'
 
 import {Button, ButtonGroup, Icon, Menu} from '../'
 import {StyledIconButtonWrapper, StyledIconWrapper} from './StyledComponents'
+import {StyledLabelWrapper} from '../Button/StyledButton'
 
 /**
  *  Button with a menu that pops out on click.
  */
 const ButtonMenu = props => {
-  const {onOpen, children, onClick, buttonProps, label, icon} = props
+  const {
+    onOpen,
+    children,
+    onClick,
+    buttonProps,
+    label,
+    icon
+  } = props
   const referenceElement = useRef(null)
   const [menuOpen, setMenuOpen] = useState(false)
   const [onOpenCalled, setOnOpenCalled] = useState(false)
@@ -52,7 +60,7 @@ const ButtonMenu = props => {
       onClick={handleClick}
       icon={icon}
     >
-      <span>{label}</span>
+      <StyledLabelWrapper>{label}</StyledLabelWrapper>
       <StyledIconWrapper>
         <Icon icon={chevronIcon}/>
       </StyledIconWrapper>


### PR DESCRIPTION
Refs: TOCDEV-3414
Changelog: Add responsivity to all buttons so that the label disappears on smaller screens and only the icon is displayed