### PR TITLE
fix(entity-list): only reload on explicit store updates

### DIFF
--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -155,9 +155,7 @@ class DocsBrowserApp extends React.Component {
 
   componentDidUpdate(prevProps) {
     const changedProps = _pickBy(this.props, (value, key) => !_isEqual(value, prevProps[key]))
-    if (changedProps.store) {
-      this.app = initApp(this.props.id, this.props, getEvents(this.props))
-    } else if (!_isEmpty(changedProps)) {
+    if (!_isEmpty(changedProps)) {
       getDispatchActions(changedProps).forEach(action => {
         this.app.store.dispatch(action)
       })

--- a/packages/entity-list/src/main.js
+++ b/packages/entity-list/src/main.js
@@ -131,7 +131,16 @@ class EntityListApp extends React.Component {
 
   componentDidUpdate(prevProps) {
     const changedProps = _pickBy(this.props, (value, key) => !_isEqual(value, prevProps[key]))
-    if (changedProps.store) {
+    if (changedProps.store && typeof prevProps.store !== 'undefined') {
+      /**
+       * Whenever the store gets explicitly changed from outside
+       * the entity-list needs to be re-initialized in order to show correct information.
+       *   - e.g. docs-browser: start a search, navigate to folder and then go back to search
+       * However this should not happen, whenever the entity-list has not been initialized before.
+       *   - e.g. admin: loading preferences (e.g. searchFormCollapsed) and set prop to entity-list
+       *                 while being in initialization phase
+       *   Therefore only re-init when store has been set already.
+       */
       this.app = initApp(this.props.id, this.props, getEvents(this.props))
     } else if (!_isEmpty(changedProps)) {
       getDispatchActions(changedProps).forEach(action => {


### PR DESCRIPTION
Fixes an error when a prop changes during initialization phase. In that phase the
store prop has been changed from `undefined` to defined as well which triggers a re-initialization of the entity-list.
In this case the entity-list should not handle this update as store change and should
ignore the passed store. Therefore we distinguish between setting the store after being initalized with another store,
or when setting the store the first time because of an update from another prop.

Changelog: only reload on explicit store updates
Refs: TOCDEV-4465