### PR TITLE
refactor(tocco-ui): fix z-index of popper menu

### DIFF
--- a/packages/tocco-ui/src/Menu/StyledComponents.js
+++ b/packages/tocco-ui/src/Menu/StyledComponents.js
@@ -25,7 +25,7 @@ export const StyledPopper = styled.div`
   background: ${theme.color('paper')};
   box-shadow: 0 0 5px rgba(0, 0, 0, .3);
   border: 1px solid ${theme.color('secondaryLight')};
-  z-index: 1101; /* higher than .bm-menu-wrap 1100 */
+  z-index: 9999999; /* higher than StyledModalHolder */
   ${StyledScrollbar}
 `
 


### PR DESCRIPTION
Refs: TOCDEV-4479
Changelog: increase z-index of popper menu to prevent it slipping behind modal