### PR TITLE
fix(tocco-ui): fix jumping datepicker on Safari

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/StyledDatePicker.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/StyledDatePicker.js
@@ -8,6 +8,7 @@ import {
 export const StyledDatePickerInput = styled.input`
   &&& {
     ${StyledInputCss}
+    margin: 0;
   }
 `
 


### PR DESCRIPTION
- remove native margin from input to have same height
as non-initialized datepickers

Changelog: fix jumping datepicker on Safari
Refs: TOCDEV-4483