### PR TITLE
feat(tocco-ui): debounce autosize on textarea

### DIFF
--- a/packages/tocco-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/tocco-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -1,13 +1,27 @@
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import {userAgent} from 'tocco-util'
+import _debounce from 'lodash/debounce'
 
 import {StyledSizeWrapper, StyledTextarea} from './StyledComponents'
 
-const TextareaAutosize = ({value, onChange, name, id, disabled, immutable}) => (
+const TextareaAutosize = ({value, onChange, name, id, disabled, immutable}) => {
+  const [replicatedValue, setReplicatedValue] = useState(value)
+  
+  // remove autosize feature for Safari to be able to type fluently
+  const useAutosizeFeature = !userAgent.isSafari()
+  
+  const setDebouncedReplicatedValue = _debounce(setReplicatedValue, 500)
+
+  useEffect(() => {
+    if (useAutosizeFeature) {
+      setDebouncedReplicatedValue(value)
+    }
+  }, [value])
+
+  return (
     <StyledSizeWrapper
-      // remove autosize feature for safari to be able to type fluently
-      data-replicated-value={userAgent.isSafari() ? '' : value}
+      {...(useAutosizeFeature ? {'data-replicated-value': replicatedValue} : {})}
     >
       <StyledTextarea
         value={value}
@@ -19,7 +33,8 @@ const TextareaAutosize = ({value, onChange, name, id, disabled, immutable}) => (
         rows="1"
       />
     </StyledSizeWrapper>
-)
+  )
+}
 
 TextareaAutosize.propTypes = {
   onChange: PropTypes.func,

--- a/packages/tocco-ui/src/TextareaAutosize/TextareaAutosize.spec.js
+++ b/packages/tocco-ui/src/TextareaAutosize/TextareaAutosize.spec.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import {intlEnzyme} from 'tocco-test-util'
+import {userAgent} from 'tocco-util'
+
+import {StyledSizeWrapper} from './StyledComponents'
+import TextareaAutosize from './TextareaAutosize'
+
+describe('tocco-ui', () => {
+  describe('TextareaAutosize', () => {
+    describe('TextareaAutosize', () => {
+      test('should have replicated value', () => {
+        const value = 'abcd'
+        const wrapper = intlEnzyme.mountWithIntl(
+          <TextareaAutosize value={value}/>
+        )
+
+        expect(wrapper.find(StyledSizeWrapper).prop('data-replicated-value')).to.equal(value)
+      })
+
+      test('should skip replicated value for Safari', () => {
+        const stub = sinon.stub(userAgent, 'isSafari').returns(true)
+
+        const value = 'abcd'
+        const wrapper = intlEnzyme.mountWithIntl(
+          <TextareaAutosize value={value}/>
+        )
+
+        stub.restore()
+
+        expect(wrapper.find(StyledSizeWrapper).prop('data-replicated-value')).to.be.undefined
+      })
+
+      test('should update replicated value', () => {
+        const clock = sinon.useFakeTimers()
+        const value = 'abcd'
+        const wrapper = intlEnzyme.mountWithIntl(
+          <TextareaAutosize value={value}/>
+        )
+        wrapper.setProps({value: 'test'})
+
+        clock.tick(1000)
+        wrapper.update()
+
+        expect(wrapper.find(StyledSizeWrapper).prop('data-replicated-value')).to.equal('test')
+      })
+    })
+  })
+})


### PR DESCRIPTION
For better and smoother typing experience in Firefox the autosize does not get triggered on each
key stroke.

Changelog: debounce autosize on textarea
Refs: TOCDEV-4491