### PR TITLE
fix(docs-browser): Show create form for remote fields again

### DIFF
--- a/packages/docs-browser/src/components/Action/actions/CreateDomain.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateDomain.js
@@ -7,9 +7,11 @@ import getNode from '../../../utils/getNode'
 import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
+  const isActionBlocked = action =>
+    action.payload?.toaster?.title === 'client.entity-detail.createSuccessfulTitle'
+
   const emitActionBarrier = action => {
-    if (action.payload && action.payload.toaster
-      && action.payload.toaster.title !== 'client.entity-detail.createSuccessfulTitle') {
+    if (!isActionBlocked(action)) {
       emitAction(action)
     }
   }

--- a/packages/docs-browser/src/components/Action/actions/CreateFolder.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateFolder.js
@@ -7,9 +7,11 @@ import getNode from '../../../utils/getNode'
 import getDetailFormName from '../../../utils/getDetailFormName'
 
 const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
+  const isActionBlocked = action =>
+    action.payload?.toaster?.title === 'client.entity-detail.createSuccessfulTitle'
+
   const emitActionBarrier = action => {
-    if (action.payload && action.payload.toaster
-      && action.payload.toaster.title !== 'client.entity-detail.createSuccessfulTitle') {
+    if (!isActionBlocked(action)) {
       emitAction(action)
     }
   }

--- a/packages/docs-browser/src/components/Action/actions/Edit.js
+++ b/packages/docs-browser/src/components/Action/actions/Edit.js
@@ -7,8 +7,11 @@ import {selection} from 'tocco-util'
 import getDetailFormName from '../../../utils/getDetailFormName'
 
 const EditAction = ({selection, onSuccess, onCancel, intl, context, emitAction}) => {
+  const isActionBlocked = action =>
+    action.payload?.toaster?.title === 'client.entity-detail.createSuccessfulTitle'
+
   const emitActionBarrier = action => {
-    if (action.payload && action.payload.title !== 'client.entity-detail.saveSuccessfulTitle') {
+    if (!isActionBlocked(action)) {
       emitAction(action)
     }
   }


### PR DESCRIPTION
No create form was shown in the folder create form when the user clicked
on the "+" of the remote fields for the mailbox senders and receivers.

The barrier that swallowed some propagated actions in the CreateDomain
and CreateFolder actions was too greedy and swallowed the modal notification
actions that should show the create form for the mailbox sender and receiver
roles.

The barrier should *only* swallow the action that shows the notification
with the title "client.entity-detail.createSuccessfulTitle".

Refs: TOCDEV-4410
Changelog: Show create form for remote fields again in the folder creation form