### PR TITLE
fix(app-extension): Set correct value after creation in remote field

### DIFF
--- a/packages/app-extensions/src/field/editableTypeConfigs/remote.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/remote.js
@@ -51,6 +51,6 @@ export default {
       : null,
     createPermission: formField.relationName
       && _get(formData, ['entityModel', 'paths', formField.relationName, 'createPermission'], false),
-    openRemoteCreate: () => formData.openRemoteCreate(formField, formName, formData)
+    openRemoteCreate: value => formData.openRemoteCreate(formField, formName, value)
   })
 }

--- a/packages/app-extensions/src/formData/remoteCreate/actions.js
+++ b/packages/app-extensions/src/formData/remoteCreate/actions.js
@@ -1,10 +1,10 @@
 export const OPEN_REMOTE_CREATE = 'formData/OPEN_REMOTE_CREATE'
-export const FINISH_CREATION = 'formData/FINISH_CREATION'
 
-export const openRemoteCreate = (formField, formName) => ({
+export const openRemoteCreate = (formField, formName, value) => ({
   type: OPEN_REMOTE_CREATE,
   payload: {
     formField,
-    formName
+    formName,
+    value
   }
 })

--- a/packages/app-extensions/src/formData/remoteCreate/sagas.js
+++ b/packages/app-extensions/src/formData/remoteCreate/sagas.js
@@ -15,7 +15,7 @@ export default function* sagas(config) {
   ])
 }
 
-export function* openRemoteCreate({detailApp}, {payload: {formName, formField}}) {
+export function* openRemoteCreate({detailApp}, {payload: {formName, formField, value}}) {
   const answerChannel = yield call(channel)
   const modalId = yield call(uuid)
   const buildCreateForm = ({close}) => <RemoteCreate
@@ -27,5 +27,7 @@ export function* openRemoteCreate({detailApp}, {payload: {formName, formField}})
 
   const {id} = yield take(answerChannel)
   const display = yield call(rest.fetchDisplay, formField.targetEntity, id)
-  yield put(valueActions.changeFieldValue(formName, formField.path, {key: id, display}))
+  const newEntry = {key: id, model: formField.targetEntity, version: 0, display}
+  const newValue = formField.dataType === 'multi-remote-field' ? [...(value || []), newEntry] : newEntry
+  yield put(valueActions.changeFieldValue(formName, formField.path, newValue))
 }

--- a/packages/app-extensions/src/formData/remoteCreate/sagas.spec.js
+++ b/packages/app-extensions/src/formData/remoteCreate/sagas.spec.js
@@ -29,14 +29,12 @@ describe('app-extensions', () => {
         })
 
         describe('openRemoteCreate', () => {
-          test('should prompt a modal and spawn close saga', () => {
+          const runTest = (dataType, currentValue, expectedId, expectedDisplay, expectedValue) => {
             const DetailApp = () => <div>ListApp</div>
-            const formField = {label: 'Person', path: 'relUser', targetEntity: 'User'}
+            const formField = {label: 'Person', path: 'relUser', targetEntity: 'User', dataType}
             const formName = 'detailForm'
-            const expectedId = 'some-id'
-            const expectedDisplay = 'display'
 
-            const action = remoteCreateActions.openRemoteCreate(formField, formName)
+            const action = remoteCreateActions.openRemoteCreate(formField, formName, currentValue)
             const config = {DetailApp}
             return expectSaga(sagas.openRemoteCreate, config, action)
               .provide([
@@ -50,9 +48,36 @@ describe('app-extensions', () => {
               ])
               .call(rest.fetchDisplay, formField.targetEntity, expectedId)
               .put.actionType(notification.modal().type)
-              .put(valueActions.changeFieldValue(formName, formField.path, {key: expectedId, display: expectedDisplay}))
+              .put(valueActions.changeFieldValue(
+                formName,
+                formField.path,
+                expectedValue
+              ))
               .run()
-          })
+          }
+
+          test('should prompt a modal and spawn close saga for single-remote-fields', () =>
+            runTest(
+              'single-remote-field',
+              {key: 'old-id', display: 'old display', model: 'User', version: 0},
+              'some-id',
+              'display',
+              {key: 'some-id', display: 'display', model: 'User', version: 0}
+            )
+          )
+
+          test('should prompt a modal and spawn close saga for multi-remote-fields', () =>
+            runTest(
+              'multi-remote-field',
+              [{key: 'existing-id', display: 'existing display', model: 'User', version: 0}],
+              'some-id',
+              'display',
+              [
+                {key: 'existing-id', display: 'existing display', model: 'User', version: 0},
+                {key: 'some-id', display: 'display', model: 'User', version: 0}
+              ]
+            )
+          )
         })
       })
     })

--- a/packages/tocco-ui/src/Select/IndicatorsContainer.js
+++ b/packages/tocco-ui/src/Select/IndicatorsContainer.js
@@ -10,13 +10,13 @@ const handleAdvancedSearch = (openAdvancedSearch, value) => event => {
   event.stopPropagation()
 }
 
-const handleCreate = openCreate => event => {
-  openCreate()
+const handleCreate = (openCreate, value) => event => {
+  openCreate(value)
   event.stopPropagation()
 }
 
 const IndicatorsContainer = props => {
-  const {openAdvancedSearch, openRemoteCreate, isDisabled, createPermission} = props.selectProps
+  const {openAdvancedSearch, openRemoteCreate, isDisabled, createPermission, value} = props.selectProps
 
   return (
     <StyledIndicatorsContainerWrapper>
@@ -38,7 +38,7 @@ const IndicatorsContainer = props => {
         && <span
           onTouchEnd={e => e.stopPropagation()}
           onMouseDown={e => e.stopPropagation()}
-          onMouseUp={handleCreate(openRemoteCreate)}>
+          onMouseUp={handleCreate(openRemoteCreate, value)}>
         <Ball
           icon="plus"
           tabIndex={-1}
@@ -63,7 +63,11 @@ IndicatorsContainer.propTypes = {
     openAdvancedSearch: PropTypes.func,
     openRemoteCreate: PropTypes.func,
     isDisabled: PropTypes.bool,
-    createPermission: PropTypes.bool
+    createPermission: PropTypes.bool,
+    value: PropTypes.oneOfType([
+      ItemPropType,
+      PropTypes.arrayOf(ItemPropType)
+    ])
   }),
   value: PropTypes.oneOfType([
     ItemPropType,


### PR DESCRIPTION
After a new record was created directly in a remote field via the "+" button,
the new record was set as value.

This was the correct behavior for single-remote-fields. However, it led to
the error that is described in TOCDEV-4546 in multi-remote-fields.

In multi-remote-fields, we have to set an *array* value instead of a single object.
Furthermore, the new object should be *appended* to the entries that are already
set in the field (they shouldn't be overridden completely).

Refs: TOCDEV-4546
Changelog: Fix creating related entities in multi-remote-fields