### PR TITLE
fix(admin): save active menu tab on shortcut navigation

### DIFF
--- a/packages/admin/src/modules/navigation/reducer.js
+++ b/packages/admin/src/modules/navigation/reducer.js
@@ -12,8 +12,7 @@ export const toogleMenu = state => (
 export const toggleShortcutMenu = (state, {payload: {activeMenuTab}}) => (
   {
     ...state,
-    menuOpen: state.activeMenuTab === activeMenuTab ? !state.menuOpen : true,
-    activeMenuTab
+    menuOpen: state.activeMenuTab === activeMenuTab ? !state.menuOpen : true
   }
 )
 

--- a/packages/admin/src/shortcuts.js
+++ b/packages/admin/src/shortcuts.js
@@ -1,25 +1,25 @@
-import {toggleShortcutMenu} from './modules/navigation/actions'
+import {setActiveMenuTab, toggleShortcutMenu} from './modules/navigation/actions'
 
 export default [
   {
     ctrl: true,
     alt: true,
     code: 'KeyM',
-    actions: [toggleShortcutMenu('modules')],
+    actions: [toggleShortcutMenu('modules'), setActiveMenuTab('modules')],
     global: true
   },
   {
     ctrl: true,
     alt: true,
     code: 'KeyN',
-    actions: [toggleShortcutMenu('settings')],
+    actions: [toggleShortcutMenu('settings'), setActiveMenuTab('settings')],
     global: true
   },
   {
     ctrl: true,
     alt: true,
     code: 'KeyO',
-    actions: [toggleShortcutMenu('complete')],
+    actions: [toggleShortcutMenu('complete'), setActiveMenuTab('complete')],
     global: true
   }
 ]


### PR DESCRIPTION
Active menu tab is saved when navigating by clicking on the tab buttons. It was not saved when navigating by using
shortcuts.

Changelog: save active menu tab on shortcut navigation
Refs: TOCDEV-4550