### PR TITLE
chore: update references to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![gitlab-ci Build Status](https://gitlab.com/toccoag/tocco-client/badges/master/pipeline.svg)](https://gitlab.com/toccoag/tocco-client/-/pipelines/latest)
 [![codecov](https://codecov.io/gh/tocco/tocco-client/branch/master/graph/badge.svg)](https://codecov.io/gh/tocco/tocco-client)
 [![devDependencies Status](https://david-dm.org/tocco/tocco-client/dev-status.svg)](https://david-dm.org/tocco/tocco-client?type=dev)
-[![Documentation Status](https://readthedocs.org/projects/tocco-docs/badge/?version=latest)](http://tocco-docs.readthedocs.io/?badge=latest)
+[![Documentation Status](https://img.shields.io/static/v1?label=docs&message=Sphinx&color=blue&logoColor=white&logo=readthedocs)](https://gitlab.com/toccoag/tocco-client/-/pipelines/latest)
 [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://tocco.github.io/tocco-client)
 
 This repository contains the web client for the [Tocco Business Framework](https://www.tocco.ch).
@@ -20,11 +20,10 @@ Initial project structure is based on:
 https://github.com/davezuko/react-redux-starter-kit.
 
 ## Documentation
-How to setup the project, to contribute and much more is documented in the [Read the docs Client Documentation](https://tocco-docs.readthedocs.io/en/latest/framework/client/index.html)
+How to setup the project, to contribute and much more is documented in the [Read the docs Client Documentation](https://docs.tocco.ch/framework/client/index.html)
 
 Since this project heavily uses Redux and Sagas, you should be aware of it's concepts and also ES6.
 A good starting point can be found in these docs:
-* http://redux.js.org/
+* https://redux.js.org/
 * https://medium.com/sons-of-javascript/javascript-an-introduction-to-es6-1819d0d89a0f
 * https://davidwalsh.name/es6-generators
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![gitlab-ci Build Status](https://gitlab.com/toccoag/tocco-client/badges/master/pipeline.svg)](https://gitlab.com/toccoag/tocco-client/-/pipelines/latest)
 [![codecov](https://codecov.io/gh/tocco/tocco-client/branch/master/graph/badge.svg)](https://codecov.io/gh/tocco/tocco-client)
 [![devDependencies Status](https://david-dm.org/tocco/tocco-client/dev-status.svg)](https://david-dm.org/tocco/tocco-client?type=dev)
-[![Documentation Status](https://img.shields.io/static/v1?label=docs&message=Sphinx&color=blue&logoColor=white&logo=readthedocs)](https://gitlab.com/toccoag/tocco-client/-/pipelines/latest)
+[![Documentation Status](https://img.shields.io/static/v1?label=docs&message=Sphinx&color=blue&logoColor=white&logo=readthedocs)](https://docs.tocco.ch/framework/client/)
 [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://tocco.github.io/tocco-client)
 
 This repository contains the web client for the [Tocco Business Framework](https://www.tocco.ch).


### PR DESCRIPTION
• https://docs.tocco.ch has been the canonical URL for some time.
• Replace badge as documentation is now built via GitLab CI. Rather
  than using the GitLab CI pipeline badge, I decided to go with a
  static badge. Using the GitLab CI badge, we'd end up with two
  badges labeled "pipeline" which would be more confusing than
  helpful.