### PR TITLE
fix(app-extension): Load default values for search forms again

### DIFF
--- a/packages/app-extensions/src/rest/helpers.js
+++ b/packages/app-extensions/src/rest/helpers.js
@@ -222,7 +222,7 @@ export function* fetchForm(formName, scope, allowNotFound = false, forceLoad = f
   }
 
   const options = {
-    ...(scope === 'create' ? {queryParams: {_display: true}} : {}),
+    ...(['create', 'search'].includes(scope) ? {queryParams: {_display: true}} : {}),
     ...(allowNotFound && {acceptedStatusCodes: [404]})
   }
 

--- a/packages/app-extensions/src/rest/helpers.spec.js
+++ b/packages/app-extensions/src/rest/helpers.spec.js
@@ -489,6 +489,25 @@ describe('app-extensions', () => {
             .run()
         })
 
+        test('should fetch create form with default values', () => {
+          const gen = helpers.fetchForm('Address', 'create')
+          expect(gen.next().value).to.eql(call(requestSaga, 'forms/Address/create', {
+            queryParams: {_display: true}
+          }))
+        })
+
+        test('should fetch search form with default values', () => {
+          const gen = helpers.fetchForm('Address', 'search')
+          expect(gen.next().value).to.eql(call(requestSaga, 'forms/Address/search', {
+            queryParams: {_display: true}
+          }))
+        })
+
+        test('should fetch update form without default values', () => {
+          const gen = helpers.fetchForm('Address', 'update')
+          expect(gen.next().value).to.eql(call(requestSaga, 'forms/Address/update', {}))
+        })
+
         describe('defaulFormTransformer', () => {
           test('should return form propery', () => {
             const inputForm = {form: {children: []}}


### PR DESCRIPTION
Since TOCDEV-3421, the REST API doesn't return default values for forms
anymore unless requested explicitly (by query param `_display=true`).
Back then, the default values were requested for create forms.

However, we also need them for search forms (e.g. PublicInputEdit_search);
this is fixed now.

Refs: TOCDEV-4461, TOCDEV-3421
Changelog: Default values that are defined in search forms are taken into account again
Cherry-pick: Up