### PR TITLE
fix(admin): fix duplicated search entries

### DIFF
--- a/packages/admin/src/components/MenuTree/MenuTree.js
+++ b/packages/admin/src/components/MenuTree/MenuTree.js
@@ -21,9 +21,9 @@ const MenuTree = ({
 
   const actualItems = prepareMenuTree(items, searchFilter, typeMapping)
 
-  const MenuItems = actualItems.map(item => (
+  const MenuItems = actualItems.map((item, index) => (
     <MenuItem
-      key={item.name}
+      key={index}
       item={item}
       typeMapping={typeMapping}
       menuTreePath={item.name}


### PR DESCRIPTION
`name` is not a unique property and that's why React sometimes duplicated the entries in the list or did not remove them properly.

Changelog: fix duplicated search entries
Refs: TOCDEV-4555