### PR TITLE
fix(app-extensions): prevent default behaviour on shortcuts

### DIFF
--- a/packages/app-extensions/src/keyDown/Components/KeyDownWatcher/KeyDownWatcher.js
+++ b/packages/app-extensions/src/keyDown/Components/KeyDownWatcher/KeyDownWatcher.js
@@ -1,7 +1,9 @@
 import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import _pick from 'lodash/pick'
+
+import {getMatchingConfig} from '../../utils'
+
 const StyledDiv = styled.div`
   display: contents;
 
@@ -10,14 +12,19 @@ const StyledDiv = styled.div`
   }
 `
 
-const KeyDownWatcher = ({children, keyDownHandler}) => {
-  const onKeyDown = event => {
-    keyDownHandler({..._pick(event, ['altKey', 'metaKey', 'ctrlKey', 'key', 'code'])})
+const KeyDownWatcher = ({config, children, keyDownHandler}) => {
+  const handleKeyDown = (event, global) => {
+    const matchingConfig = getMatchingConfig(config, event, global)
+    if (matchingConfig) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    keyDownHandler(matchingConfig)
   }
 
-  const onDocumentKeyDown = event => {
-    keyDownHandler({..._pick(event, ['altKey', 'metaKey', 'ctrlKey', 'key', 'code']), global: true})
-  }
+  const onKeyDown = event => handleKeyDown(event)
+
+  const onDocumentKeyDown = event => handleKeyDown(event, true)
 
   useEffect(() => {
     document.addEventListener('keydown', onDocumentKeyDown)
@@ -25,13 +32,14 @@ const KeyDownWatcher = ({children, keyDownHandler}) => {
     return () => {
       document.removeEventListener('keydown', onDocumentKeyDown)
     }
-  }, [])
+  }, [onDocumentKeyDown])
 
   return <StyledDiv tabIndex="0" onKeyDown={onKeyDown}>{children}</StyledDiv>
 }
 
 KeyDownWatcher.propTypes = {
   children: PropTypes.node,
+  config: PropTypes.array.isRequired,
   keyDownHandler: PropTypes.func.isRequired
 }
 

--- a/packages/app-extensions/src/keyDown/Components/KeyDownWatcher/KeyDownWatcherContainer.js
+++ b/packages/app-extensions/src/keyDown/Components/KeyDownWatcher/KeyDownWatcherContainer.js
@@ -7,4 +7,10 @@ const mapActionCreators = {
   keyDownHandler: keyDown
 }
 
-export default connect(null, mapActionCreators)(KeyDownWatcher)
+const mapStateToProps = state => {
+  return {
+    config: state.keyDown?.config || []
+  }
+}
+
+export default connect(mapStateToProps, mapActionCreators)(KeyDownWatcher)

--- a/packages/app-extensions/src/keyDown/actionEmitter.js
+++ b/packages/app-extensions/src/keyDown/actionEmitter.js
@@ -1,5 +1,15 @@
+import {reducer as reducerUtil} from 'tocco-util'
+
+import reducer from './reducer'
 import sagas from './sagas'
 
 export const addToStore = (store, config) => {
+  reducerUtil.injectReducers(
+    store,
+    {
+      keyDown: reducer
+    }
+  )
+
   store.sagaMiddleware.run(sagas, config)
 }

--- a/packages/app-extensions/src/keyDown/actions.js
+++ b/packages/app-extensions/src/keyDown/actions.js
@@ -1,8 +1,16 @@
-export const KEY_DOWN = 'KEY_DOWN'
+export const SET_CONFIG = 'keyDown/SET_CONFIG'
+export const KEY_DOWN = 'keyDown/KEY_DOWN'
 
-export const keyDown = event => ({
+export const setConfig = config => ({
+  type: SET_CONFIG,
+  payload: {
+    config
+  }
+})
+
+export const keyDown = config => ({
   type: KEY_DOWN,
   payload: {
-    event
+    config
   }
 })

--- a/packages/app-extensions/src/keyDown/reducer.js
+++ b/packages/app-extensions/src/keyDown/reducer.js
@@ -1,0 +1,16 @@
+import {reducer as reducerUtil} from 'tocco-util'
+
+import * as actions from './actions'
+
+const ACTION_HANDLERS = {
+  [actions.SET_CONFIG]: reducerUtil.singleTransferReducer('config')
+}
+
+const initialState = {
+  config: []
+}
+
+export default function reducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+  return handler ? handler(state, action) : state
+}

--- a/packages/app-extensions/src/keyDown/sagas.js
+++ b/packages/app-extensions/src/keyDown/sagas.js
@@ -1,22 +1,20 @@
-import {takeEvery, all, put} from 'redux-saga/effects'
+import {takeEvery, all, put, call} from 'redux-saga/effects'
 
 import * as actions from './actions'
 
-export default function* sagas(configs) {
+export default function* sagas(config) {
   yield all([
-    takeEvery(actions.KEY_DOWN, emitAction, configs)
+    call(init, config),
+    takeEvery(actions.KEY_DOWN, emitAction)
   ])
 }
 
-export function* emitAction(configs, {payload}) {
-  const {event} = payload
-  const config = configs.find(
-    config =>
-      (config.code === event.code || config.key === event.key)
-      && (!config.ctrl || (event.ctrlKey || event.metaKey))
-      && (!config.alt || (event.altKey))
-      && event.global === config.global
-  )
+export function* init(config) {
+  yield put(actions.setConfig(config))
+}
+
+export function* emitAction({payload}) {
+  const {config} = payload
 
   if (config) {
     yield all(config.actions.map(action => put(action)))

--- a/packages/app-extensions/src/keyDown/utils.js
+++ b/packages/app-extensions/src/keyDown/utils.js
@@ -1,0 +1,8 @@
+
+export const getMatchingConfig = (configs, event, global) => configs.find(
+  config => (config.code === event.code || config.key === event.key)
+      && (config.ctrl
+        ? (config.ctrl === event.ctrlKey || config.ctrl === event.metaKey)
+        : (config.ctrl === event.ctrlKey && config.ctrl === event.metaKey))
+      && config.alt === event.altKey
+      && global === config.global)

--- a/packages/app-extensions/src/keyDown/utils.spec.js
+++ b/packages/app-extensions/src/keyDown/utils.spec.js
@@ -1,0 +1,260 @@
+import {getMatchingConfig} from './utils'
+
+describe('app-extensions', () => {
+  describe('keyDown', () => {
+    describe('utils', () => {
+      describe('getMatchingConfig', () => {
+        test('should match config with code', () => {
+          const configs = [
+            {
+              ctrl: true,
+              alt: true,
+              code: 'KeyM',
+              key: 'foo',
+              global: false
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: true,
+            metaKey: false,
+            altKey: true
+          }
+          const global = false
+
+          const expectedConfig = configs[0]
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.deep.equal(expectedConfig)
+        })
+
+        test('should match config with key', () => {
+          const configs = [
+            {
+              ctrl: true,
+              alt: true,
+              code: 'foo',
+              key: 'm',
+              global: false
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: true,
+            metaKey: false,
+            altKey: true
+          }
+          const global = false
+
+          const expectedConfig = configs[0]
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.deep.equal(expectedConfig)
+        })
+
+        test('should match config with meta key (CMD on OSX)', () => {
+          const configs = [
+            {
+              ctrl: true,
+              alt: true,
+              code: 'KeyM',
+              key: 'm',
+              global: false
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: false,
+            metaKey: true,
+            altKey: true
+          }
+          const global = false
+
+          const expectedConfig = configs[0]
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.deep.equal(expectedConfig)
+        })
+
+        test('should match config without any ctrl, alt, meta keys', () => {
+          const configs = [
+            {
+              ctrl: false,
+              alt: false,
+              code: 'KeyM',
+              key: 'm',
+              global: false
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: false,
+            metaKey: false,
+            altKey: false
+          }
+          const global = false
+
+          const expectedConfig = configs[0]
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.deep.equal(expectedConfig)
+        })
+
+        test('should match config with global', () => {
+          const configs = [
+            {
+              ctrl: false,
+              alt: false,
+              code: 'KeyM',
+              key: 'm',
+              global: true
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: false,
+            metaKey: false,
+            altKey: false
+          }
+          const global = true
+
+          const expectedConfig = configs[0]
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.deep.equal(expectedConfig)
+        })
+
+        test('should not match config with unequal global', () => {
+          const configs = [
+            {
+              ctrl: false,
+              alt: false,
+              code: 'KeyM',
+              key: 'm',
+              global: true
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: false,
+            metaKey: false,
+            altKey: false
+          }
+          const global = false
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.be.undefined
+        })
+
+        test('should not match config with unequal alt key', () => {
+          const configs = [
+            {
+              ctrl: false,
+              alt: false,
+              code: 'KeyM',
+              key: 'm',
+              global: true
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: false,
+            metaKey: false,
+            altKey: true
+          }
+          const global = true
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.be.undefined
+        })
+
+        test('should not match config with unequal ctrl key', () => {
+          const configs = [
+            {
+              ctrl: false,
+              alt: false,
+              code: 'KeyM',
+              key: 'm',
+              global: true
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: true,
+            metaKey: false,
+            altKey: false
+          }
+          const global = true
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.be.undefined
+        })
+
+        test('should not match config with unequal meta key', () => {
+          const configs = [
+            {
+              ctrl: false,
+              alt: false,
+              code: 'KeyM',
+              key: 'm',
+              global: true
+            }
+          ]
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: false,
+            metaKey: true,
+            altKey: false
+          }
+          const global = true
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.be.undefined
+        })
+
+        test('should not match config with unequal alt key', () => {
+          const configs = [
+            {
+              ctrl: true,
+              alt: true,
+              code: 'KeyM',
+              key: 'm',
+              global: true
+            }
+          ]
+
+          const event = {
+            code: 'KeyM',
+            key: 'm',
+            ctrlKey: false,
+            metaKey: true,
+            altKey: false
+          }
+          const global = true
+
+          const matchingConfig = getMatchingConfig(configs, event, global)
+
+          expect(matchingConfig).to.be.undefined
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
In Safari some registered shortcuts did print invisible characters
in the menu search field. This resulted in strange menu behaviour.
As soon as there is an registered shortcut the default
behaviour should be prevented.

Changelog: prevent default behaviour on shortcuts
Refs: TOCDEV-4486