### PR TITLE
fix(app-extension): remove queryOrderBy from legacy action selection

### DIFF
--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -137,15 +137,10 @@ export const listSelector = state => state.list
 export const entityListSelector = state => state.entityList
 export const entityDetailSelector = state => state.entityDetail
 
-export const getOrderByString = sortingArray => sortingArray && sortingArray.length > 0
-  ? rest.createSortingString(sortingArray)
-  : null
-
-export const getManualQuery = (selection, listState) => ({
+export const getManualQuery = selection => ({
   ...new window.nice2.netui.ManualQuery(),
   entityName: selection.entityName,
-  queryWhere: selection.query.where,
-  queryOrderBy: getOrderByString(listState.sorting)
+  queryWhere: selection.query.where
 })
 
 export const getListFormId = listState => ({
@@ -166,7 +161,7 @@ export function* getSelection(selection) {
     const listState = yield select(listSelector)
 
     legacySelection.selectionType = 'NEW_CLIENT_QUERY'
-    legacySelection.manualQuery = getManualQuery(selection, listState)
+    legacySelection.manualQuery = getManualQuery(selection)
     legacySelection.listForm = getListFormId(listState)
     legacySelection.searchFilters = selection.query.filter
   } else {

--- a/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
+++ b/packages/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
@@ -218,8 +218,7 @@ describe('app-extensions', () => {
               const expectedManualQuery = {
                 ...new window.nice2.netui.ManualQuery(),
                 entityName: 'User',
-                queryWhere: 'firstname == "Hans"',
-                queryOrderBy: 'firstname desc, lastname asc'
+                queryWhere: 'firstname == "Hans"'
               }
 
               const expectedListForm = {


### PR DESCRIPTION
a legacy action didn't successfully finished if no selection was made and the list was sorted by a column which belongs to a relation (for example if the reservation list was sorted by the relReservation_status). for legacy actions just the same sorting string was used as for the entities 2.0 rest endpoint. however the endpoint supports as sorting string "relReservation_status asc" while the legacy client does only support fields (e.g. "relReservation_status.label asc"). if in the legacy client the list is sorted and an action called the sorting is not passed to the backend (only if query tab is used).

Refs: TOCDEV-4085
Changelog: remove queryOrderBy from legacy action selection