### PR TITLE
fix(admin): set focus to search input on menu change

### DIFF
--- a/packages/admin/src/components/Navigation/Navigation.js
+++ b/packages/admin/src/components/Navigation/Navigation.js
@@ -138,9 +138,16 @@ const Navigation = ({
         setActiveMenuTab(menuTabs.MODULES)
       }
       inputEl.current.select()
-      setFocusToSearchInput()
     }
   }, [menuOpen])
+
+  useEffect(() => {
+    if (menuOpen) {
+      if (inputEl.current) {
+        inputEl.current.focus()
+      }
+    }
+  }, [activeMenuTab, menuOpen])
 
   const handleCursorNavigation = key => {
     const focusableElements = navigationEl.current.querySelectorAll('a[data-quick-navigation="true"], input')
@@ -182,15 +189,8 @@ const Navigation = ({
     }
   }
 
-  const setFocusToSearchInput = () => {
-    if (inputEl.current) {
-      inputEl.current.focus()
-    }
-  }
-
   const changeMenuTab = tab => {
     setActiveMenuTab(tab)
-    setFocusToSearchInput()
   }
 
   return (


### PR DESCRIPTION
As soon as the menu tab changes the focus should
be set to the serach input. No matter if it has been
changed by clicking on the menu icon or by using
the shortcut. It was only working by clicking on the icon.

Changelog: set focus to search input on menu change
Refs: TOCDEV-4551