### PR TITLE
fix(admin): reset selectedRelation in relationsView on initialization

### DIFF
--- a/packages/admin/src/routes/entities/modules/path/sagas.js
+++ b/packages/admin/src/routes/entities/modules/path/sagas.js
@@ -219,6 +219,7 @@ export function* initMultiRelations(model, key) {
     )
     .sort((a, b) => a.relationDisplay.order > b.relationDisplay.order ? 1 : -1)
 
+  yield put(actions.selectRelation(null))
   yield put(actions.setRelations(relationsTransformed))
   yield call(loadRelationInfos, model.name, key)
 }


### PR DESCRIPTION
- without a relation selected it gets loaded from url or persist store

Refs: TOCDEV-4572