### PR TITLE
fix(admin): refactor selection of relation in RelationsView

### DIFF
--- a/packages/admin/src/routes/entities/components/RelationsView/RelationBox.js
+++ b/packages/admin/src/routes/entities/components/RelationsView/RelationBox.js
@@ -1,53 +1,30 @@
-import React, {useEffect} from 'react'
+import React from 'react'
 import {AdminLink as StyledLink, Icon} from 'tocco-ui'
-import queryString from 'query-string'
-import _get from 'lodash/get'
 import PropTypes from 'prop-types'
 
-import {getRelation, setRelation} from '../../utils/relationPersistor'
+import {setRelation} from '../../utils/relationPersistor'
 import {StyledRelationBox, StyledRelationLabel, StyledRelationLinks} from './StyledComponents'
-import {currentViewPropType} from '../../utils/propTypes'
 
 const RelationBox = ({
   relation,
   history,
   match,
-  currentViewInfo,
-  relations,
   relationsInfo,
   selectRelation,
   selectedRelation,
-  intl
+  intl,
+  entityName
 }) => {
-  useEffect(
-    () => {
-      if (!selectedRelation && relations?.length > 0) {
-        const queryRelation = queryString.parse(history.location.search).relation
-        if (queryRelation) {
-          selectRelation(relations.find(r => r.relationName === queryRelation))
-        } else {
-          const persistedSelectedRelation = getRelation(entityName)
-          if (persistedSelectedRelation) {
-            selectRelation(relations.find(r => r.relationName === persistedSelectedRelation))
-          } else {
-            selectRelation(relations[0])
-          }
-        }
-      }
-    },
-    [relations, selectedRelation]
-  )
-
-  const msg = id => intl.formatMessage({id})
-  const entityName = _get(currentViewInfo, 'model.name')
-  const hasCreateRights = relationName => relationsInfo[relationName]?.createPermission
   const {
     relationName,
     targetEntity,
     relationDisplay
   } = relation
 
-  const getRelationCountLabel = relationName => relationsInfo[relationName]?.count > 0
+  const msg = id => intl.formatMessage({id})
+  const hasCreateRights = () => relationsInfo[relationName]?.createPermission
+
+  const getRelationCountLabel = () => relationsInfo[relationName]?.count > 0
     ? <StyledRelationLabel>&nbsp;({relationsInfo[relationName].count})</StyledRelationLabel>
     : null
 
@@ -65,14 +42,14 @@ const RelationBox = ({
       onClick={handleBoxClick}
     >
       <StyledRelationLabel title={relationDisplay.label}>
-        {relationDisplay.label}</StyledRelationLabel>{getRelationCountLabel(relationName)}
+        {relationDisplay.label}</StyledRelationLabel>{getRelationCountLabel()}
       <StyledRelationLinks>
         <StyledLink
           aria-label={msg('client.admin.entities.relationsView.relationLinkView')}
           to={match.url.replace(/(relations|detail)$/, relationName)}>
           <Icon icon="arrow-right"/>
         </StyledLink>
-        {hasCreateRights(relationName) && targetEntity !== 'Resource'
+        {hasCreateRights() && targetEntity !== 'Resource'
         && <StyledLink
           aria-label={msg('client.admin.entities.relationsView.relationLinkCreate')}
           to={match.url.replace(/(relations|detail)$/, relationName) + '/create'}>
@@ -88,15 +65,14 @@ RelationBox.propTypes = {
   relation: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   match: PropTypes.object.isRequired,
-  currentViewInfo: currentViewPropType,
-  relations: PropTypes.array,
   relationsInfo: PropTypes.objectOf(PropTypes.shape({
     count: PropTypes.number,
     createPermission: PropTypes.bool
   })),
   intl: PropTypes.object.isRequired,
   selectRelation: PropTypes.func.isRequired,
-  selectedRelation: PropTypes.object
+  selectedRelation: PropTypes.object,
+  entityName: PropTypes.string
 }
 
 export default RelationBox

--- a/packages/admin/src/routes/entities/components/RelationsView/RelationsView.js
+++ b/packages/admin/src/routes/entities/components/RelationsView/RelationsView.js
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {Icon, Typography} from 'tocco-ui'
 import {js} from 'tocco-util'
+import _get from 'lodash/get'
+import queryString from 'query-string'
 
 import {
   StyledPlaceHolder,
@@ -16,6 +18,7 @@ import {currentViewPropType} from '../../utils/propTypes'
 import ListView from './ListView'
 import DocsViewAdapter from './DocsViewAdapter'
 import RelationBox from './RelationBox'
+import {getRelation} from '../../utils/relationPersistor'
 
 const RelationsView = props => {
   const {
@@ -28,9 +31,30 @@ const RelationsView = props => {
     intl,
     isCollapsed,
     toggleCollapse,
-    selectedRelation
+    selectedRelation,
+    selectRelation
+  } = props
+  const entityName = _get(currentViewInfo, 'model.name')
+
+  const updateSelectedRelation = () => {
+    if (relations?.length > 0) {
+      const queryRelation = queryString.parse(history.location.search).relation
+      if (queryRelation) {
+        selectRelation(relations.find(r => r.relationName === queryRelation))
+      } else {
+        const persistedSelectedRelation = getRelation(entityName)
+        if (persistedSelectedRelation) {
+          selectRelation(relations.find(r => r.relationName === persistedSelectedRelation))
+        } else {
+          selectRelation(relations[0])
+        }
+      }
+    }
   }
-  = props
+
+  useEffect(updateSelectedRelation, [relations])
+  useEffect(() => !selectedRelation ? updateSelectedRelation() : null, [selectedRelation])
+
   if (!relations || relations.length === 0 || !currentViewInfo) {
     return null
   }
@@ -45,6 +69,7 @@ const RelationsView = props => {
     <RelationBox
       key={`relation-${relation.relationName}`}
       relation={relation}
+      entityName={entityName}
       {...props}
     />
   )


### PR DESCRIPTION
- move initial setting back out into RelationsView
-- no reason for this to happen in each RelationBox
- always reset relation when available relations change

Refs: TOCDEV-4572