### PR TITLE
refactor(tocco-ui): align dropdown buttons in multiselect field

### DIFF
--- a/packages/tocco-ui/src/Select/IndicatorsContainer.js
+++ b/packages/tocco-ui/src/Select/IndicatorsContainer.js
@@ -5,29 +5,43 @@ import PropTypes from 'prop-types'
 import Ball from '../Ball'
 import {StyledIndicatorsContainerWrapper} from './StyledComponents'
 
-const handleAdvancedSearch = (openAdvancedSearch, value) => event => {
+const handleAdvancedSearch = (openAdvancedSearch, value) => e => {
   openAdvancedSearch(value)
-  event.stopPropagation()
+  e.stopPropagation()
 }
 
-const handleCreate = (openCreate, value) => event => {
+const handleCreate = (openCreate, value) => e => {
   openCreate(value)
-  event.stopPropagation()
+  e.stopPropagation()
+}
+
+const handlePropagation = e => {
+  e.stopPropagation()
 }
 
 const IndicatorsContainer = props => {
-  const {openAdvancedSearch, openRemoteCreate, isDisabled, createPermission, value} = props.selectProps
+  const {
+    openAdvancedSearch,
+    openRemoteCreate,
+    isDisabled,
+    createPermission,
+    value,
+    isMulti,
+    wrapperHeight
+  } = props.selectProps
+  const rowHeight = 30 // roughly the height of a single row in px
+  const isBottomAligned = isMulti && value?.length && wrapperHeight > rowHeight
 
   return (
-    <StyledIndicatorsContainerWrapper>
+    <StyledIndicatorsContainerWrapper isBottomAligned={isBottomAligned}>
       <components.IndicatorsContainer {...props}>
         {props.children}
         {openAdvancedSearch
-      && !isDisabled
-      && <span
-        onTouchEnd={e => e.stopPropagation()}
-        onMouseDown={e => e.stopPropagation()}
-        onMouseUp={handleAdvancedSearch(openAdvancedSearch, props.value)}>
+        && !isDisabled
+        && <span
+          onTouchEnd={handlePropagation}
+          onMouseDown={handlePropagation}
+          onMouseUp={handleAdvancedSearch(openAdvancedSearch, props.value)}>
         <Ball
           icon="search"
           tabIndex={-1}
@@ -36,8 +50,8 @@ const IndicatorsContainer = props => {
         {createPermission
         && !isDisabled
         && <span
-          onTouchEnd={e => e.stopPropagation()}
-          onMouseDown={e => e.stopPropagation()}
+          onTouchEnd={handlePropagation}
+          onMouseDown={handlePropagation}
           onMouseUp={handleCreate(openRemoteCreate, value)}>
         <Ball
           icon="plus"
@@ -63,6 +77,8 @@ IndicatorsContainer.propTypes = {
     openAdvancedSearch: PropTypes.func,
     openRemoteCreate: PropTypes.func,
     isDisabled: PropTypes.bool,
+    isMulti: PropTypes.bool,
+    wrapperHeight: PropTypes.number,
     createPermission: PropTypes.bool,
     value: PropTypes.oneOfType([
       ItemPropType,

--- a/packages/tocco-ui/src/Select/Select.js
+++ b/packages/tocco-ui/src/Select/Select.js
@@ -12,7 +12,12 @@ import Menu from './Menu'
 import MenuList from './MenuList'
 import MultiValueLabel from './MultiValueLabel'
 import SingleValue from './SingleValue'
-import {reactSelectStyles, reactSelectTheme} from './StyledComponents'
+import {
+  reactSelectStyles,
+  reactSelectTheme,
+  StyledReactSelectOuterWrapper,
+  StyledReactSelectInnerWrapper
+} from './StyledComponents'
 
 const SEARCH_DEBOUNCE = 300
 
@@ -60,24 +65,22 @@ const Select = ({
     }
   }
 
-  const debouncedSearchOptions
-    = searchOptions ? _debounce(searchOptions, SEARCH_DEBOUNCE) : () => {}
+  const handleFocus = () => {
+    selectComponent.current.focus()
+  }
+
+  const debouncedSearchOptions = searchOptions ? _debounce(searchOptions, SEARCH_DEBOUNCE) : () => {}
 
   const wrapperWidth = selectWrapper.current ? selectWrapper.current.clientWidth : 300
   const wrapperHeight = selectWrapper.current ? selectWrapper.current.clientHeight : 35
 
   return (
-    <div
+    <StyledReactSelectOuterWrapper
       tabIndex="-1"
       id={id}
-      onFocus={() => {
-        selectComponent.current.focus()
-      }}
-      style={{
-        outlineStyle: 'none',
-        cursor: immutable ? 'not-allowed' : 'default'
-      }}>
-      <div ref={selectWrapper} style={{outlineStyle: 'none'}}>
+      onFocus={handleFocus}
+    >
+      <StyledReactSelectInnerWrapper ref={selectWrapper}>
         <ReactSelect
           getOptionLabel={option => option.display}
           getOptionValue={option => option.key}
@@ -98,7 +101,7 @@ const Select = ({
           isMulti={isMulti}
           closeMenuOnSelect={!isMulti}
           isSearchable
-          {...(searchOptions ? {filterOption: () => (true)} : {})}
+          {...(searchOptions ? {filterOption: () => true} : {})}
           isClearable
           loadingMessage={() => null}
           placeholder=""
@@ -124,8 +127,8 @@ const Select = ({
           createPermission={createPermission}
           openRemoteCreate={openRemoteCreate}
         />
-      </div>
-    </div>
+      </StyledReactSelectInnerWrapper>
+    </StyledReactSelectOuterWrapper>
   )
 }
 

--- a/packages/tocco-ui/src/Select/StyledComponents.js
+++ b/packages/tocco-ui/src/Select/StyledComponents.js
@@ -7,10 +7,20 @@ import Ball from '../Ball'
 import {declareFont, generateDisabledShade, generateShades, scale, theme} from '../utilStyles'
 import {StyledScrollbar} from '../Layout'
 
+export const StyledReactSelectOuterWrapper = styled.div`
+  outline-style: none;
+  cursor: ${({immutable}) => immutable ? 'not-allowed' : 'default'};
+`
+
+export const StyledReactSelectInnerWrapper = styled.div`
+  outline-style: none;
+`
+
 export const StyledIndicatorsContainerWrapper = styled.div`
   position: relative;
   z-index: 1;
   background-color: ${theme.color('paper')};
+  ${({isBottomAligned}) => isBottomAligned && 'align-self: flex-end'};
 `
 
 export const StyledTether = styled(TetherComponent)`
@@ -33,7 +43,7 @@ export const StyledMenu = styled(components.Menu)`
 
 export const StyledMoreOptionsAvailable = styled.div`
   && {
-    ${props => declareFont(props, {
+    ${declareFont({
       color: theme.color('signal.warning.text'),
       lineHeight: 'normal'
     })}


### PR DESCRIPTION
Refs: TOCDEV-4390
Changelog: enable select dropdown indicators to be aligned at bottom of multiselect fields