### PR TITLE
fix(tocco-ui): correctly initialize ace editor in create form

### DIFF
--- a/packages/tocco-ui/src/CodeEditor/AceEditor.js
+++ b/packages/tocco-ui/src/CodeEditor/AceEditor.js
@@ -77,7 +77,7 @@ const AceEditor = props => {
 
   useEffect(() => {
     const aceEditor = ace.edit(containerReference.current)
-    aceEditor.getSession().setValue(value)
+    aceEditor.getSession().setValue(value || '')
     aceEditor.on('change', () => onChange(aceEditor.getValue()))
     setEditorConfiguration(aceEditor, props)
     editorReference.current = aceEditor


### PR DESCRIPTION
- passing something other than a string to ACE crashes it
-- our string fields are never null after saving, but on create all fields are initialized with their default or undefined