### PR TITLE
fix(tocco-ui): throttle autosize to fix performance issues

### DIFF
--- a/packages/tocco-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/tocco-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -1,7 +1,7 @@
-import React, {useEffect, useState} from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import {userAgent} from 'tocco-util'
-import _debounce from 'lodash/debounce'
+import _throttle from 'lodash/throttle'
 
 import {StyledSizeWrapper, StyledTextarea} from './StyledComponents'
 
@@ -11,11 +11,11 @@ const TextareaAutosize = ({value, onChange, name, id, disabled, immutable}) => {
   // remove autosize feature for Safari to be able to type fluently
   const useAutosizeFeature = !userAgent.isSafari()
   
-  const setDebouncedReplicatedValue = _debounce(setReplicatedValue, 500)
+  const setThrottledReplicatedValue = useCallback(_throttle(setReplicatedValue, 500, {trailing: true}), [])
 
   useEffect(() => {
     if (useAutosizeFeature) {
-      setDebouncedReplicatedValue(value)
+      setThrottledReplicatedValue(value)
     }
   }, [value])
 


### PR DESCRIPTION
- debounce was still firing the same amount of resizes
- throttle only triggers resize once per 500ms
- improve performance issues on Firefox

Changelog: throttle autosize to fix performance issues
Refs: TOCDEV-4491