### PR TITLE
feat(entity-list): focus first search field in admin search form

### DIFF
--- a/packages/entity-detail/src/components/DetailForm/DetailForm.js
+++ b/packages/entity-detail/src/components/DetailForm/DetailForm.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
-import React, {useEffect, useLayoutEffect, useMemo, useRef} from 'react'
+import React, {useEffect, useMemo, useRef} from 'react'
 import {reduxForm} from 'redux-form'
 import {form} from 'tocco-app-extensions'
+import {react as customHooks} from 'tocco-util'
 
 import SubGrid from '../../util/detailView/fromFieldFactories/subGrid'
 import SaveButton from './SaveButton'
@@ -32,13 +33,7 @@ const DetailForm = props => {
     fireTouched(dirty && anyTouched)
   }, [dirty, anyTouched])
 
-  useLayoutEffect(() => {
-    const firstInput = formEl.current.querySelector('input:not([disabled]),textarea:not([disabled])')
-
-    if (firstInput != null) {
-      firstInput.focus()
-    }
-  }, [])
+  customHooks.useAutofocus(formEl)
 
   const customRenderedActions = useMemo(() => (
     {

--- a/packages/entity-list/src/components/AdminSearchForm/AdminSearchForm.js
+++ b/packages/entity-list/src/components/AdminSearchForm/AdminSearchForm.js
@@ -1,19 +1,19 @@
-import React, {useRef, useEffect, useState} from 'react'
+import React, {useEffect, useRef, useState} from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
-import {Icon, Ball, BallMenu, MenuItem, Popover} from 'tocco-ui'
+import {Ball, BallMenu, Icon, MenuItem, Popover} from 'tocco-ui'
 import {withTheme} from 'styled-components'
 import {FormattedMessage, injectIntl} from 'react-intl'
 
 import {
-  StyledSplit,
   AdminSearchGrid,
   Box,
   StyledGutter,
   StyledHeader,
+  StyledPlaceHolder,
+  StyledSplit,
   StyledSplitWrapper,
-  StyledToggleCollapseButton,
-  StyledPlaceHolder
+  StyledToggleCollapseButton
 } from './StyedComponents'
 import BasicSearchFormContainer from '../../containers/BasicSearchFormContainer'
 import SearchFilterList from '../SearchFilterList'
@@ -47,9 +47,17 @@ const AdminSearchForm = ({
   toggleCollapse
 }) => {
   const splitWrapperEl = useRef(null)
+  const searchFormEl = useRef(null)
   const [size, setSize] = useState([MAX_SIZE_SEARCH_FILTER, 100 - MAX_SIZE_SEARCH_FILTER])
   const [searchFilterExpanded, setSearchFilterExpanded] = useState(false)
   const [showExpandSearchFilter, setShowExpandSearchFilter] = useState(false)
+
+  useEffect(() => {
+    if (searchFormEl.current) {
+      const firstTextInput = searchFormEl.current.querySelector('input[type = "text"]')
+      firstTextInput.focus()
+    }
+  }, [])
 
   const msg = id => intl.formatMessage({id})
 
@@ -118,7 +126,7 @@ const AdminSearchForm = ({
           <Box>
             <SearchFilterList/>
           </Box>
-          <Box>
+          <Box ref={searchFormEl}>
             <BasicSearchFormContainer disableSimpleSearch={true}/>
           </Box>
         </StyledSplit>

--- a/packages/entity-list/src/components/AdminSearchForm/AdminSearchForm.js
+++ b/packages/entity-list/src/components/AdminSearchForm/AdminSearchForm.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import {Ball, BallMenu, Icon, MenuItem, Popover} from 'tocco-ui'
 import {withTheme} from 'styled-components'
 import {FormattedMessage, injectIntl} from 'react-intl'
+import {react as customHooks} from 'tocco-util'
 
 import {
   AdminSearchGrid,
@@ -52,12 +53,7 @@ const AdminSearchForm = ({
   const [searchFilterExpanded, setSearchFilterExpanded] = useState(false)
   const [showExpandSearchFilter, setShowExpandSearchFilter] = useState(false)
 
-  useEffect(() => {
-    if (searchFormEl.current) {
-      const firstTextInput = searchFormEl.current.querySelector('input[type = "text"]')
-      firstTextInput.focus()
-    }
-  }, [])
+  customHooks.useAutofocus(searchFormEl)
 
   const msg = id => intl.formatMessage({id})
 

--- a/packages/tocco-util/src/react/index.js
+++ b/packages/tocco-util/src/react/index.js
@@ -1,9 +1,11 @@
+import useAutofocus from './useAutofocus'
 import useDebounce from './useDebounce'
 import Debouncer from './Debouncer'
 import useUserActive from './useUserActive'
 import usePrevious from './usePrevious'
 
 export default {
+  useAutofocus,
   useDebounce,
   Debouncer,
   useUserActive,

--- a/packages/tocco-util/src/react/useAutofocus.js
+++ b/packages/tocco-util/src/react/useAutofocus.js
@@ -1,0 +1,14 @@
+import {useEffect} from 'react'
+
+const useAutofocus = reference =>
+  useEffect(() => {
+    if (reference.current) {
+      const firstInput = reference.current
+        .querySelector('input[type = "text"]:not([disabled]), textarea:not([disabled])')
+      if (firstInput) {
+        firstInput.focus()
+      }
+    }
+  }, [])
+
+export default useAutofocus


### PR DESCRIPTION
- filtering for inputs with type text does not only include our text fields, but pretty much anything that isn't a checkbox
-- this als works for things like selects and remote fields, since the search box is still a html text input

Refs: TOCDEV-4463
Changelog: the first search field in admin search forms now gets automatically focused on opening