### PR TITLE
Pr/dynamic backend url

### DIFF
--- a/packages/admin/src/modules/session/sagas.js
+++ b/packages/admin/src/modules/session/sagas.js
@@ -26,7 +26,7 @@ export function* delayByTimeout(timeout) {
 }
 
 export function* doLogoutRequest() {
-  return yield call(login.doRequest, `${__BACKEND_URL__}/nice2/logout`, login.getOptions())
+  return yield call(login.doRequest, 'logout', {method: 'POST'})
 }
 
 export function* loginSuccessful({payload}) {

--- a/packages/app-extensions/src/errorLogging/handlers/remoteHandler.js
+++ b/packages/app-extensions/src/errorLogging/handlers/remoteHandler.js
@@ -1,10 +1,7 @@
 import {call} from 'redux-saga/effects'
+import {request} from 'tocco-util'
 
 export default function* remoteLogger(title, description, error) {
   const message = `ERROR MESSAGE: ${error.message} \nSTACK: ${error.stack ? error.stack.substring(0, 1000) : '-'}`
-  const options = {
-    method: 'POST',
-    credentials: 'include'
-  }
-  yield call(fetch, `${__BACKEND_URL__}/nice2/log?level=error&message=${encodeURI(message)}`, options)
+  yield call(request.executeRequest, `log?level=error&message=${encodeURI(message)}`, {method: 'POST'})
 }

--- a/packages/app-extensions/src/formData/upload/documents.js
+++ b/packages/app-extensions/src/formData/upload/documents.js
@@ -1,6 +1,5 @@
 import _pick from 'lodash/pick'
-
-const UPLOAD_ENDPOINT_URL = `${__BACKEND_URL__}/nice2/upload`
+import {request} from 'tocco-util'
 
 /**
  * Upload a file.
@@ -21,14 +20,8 @@ export const uploadRequest = file => {
   const data = new FormData()
   data.append('file', file)
 
-  const fetchOptions = {
-    method: 'POST',
-    credentials: 'include',
-    body: data
-  }
-
-  return fetch(UPLOAD_ENDPOINT_URL, fetchOptions)
-    .then(response => response.json())
+  const fetchOptions = {method: 'POST', body: data}
+  return request.executeRequest('upload', fetchOptions).then(request.extractBody)
 }
 
 export const documentToFormValueTransformer = (uploadResponse, file) => {

--- a/packages/app-extensions/src/intl/intl.js
+++ b/packages/app-extensions/src/intl/intl.js
@@ -1,4 +1,5 @@
 import {updateIntl} from 'react-intl-redux'
+import {request} from 'tocco-util'
 
 import cache from '../cache'
 
@@ -33,14 +34,6 @@ export const setLocale = async(store, modules, locale) => {
   }))
 }
 
-const fetchOptions = {
-  method: 'GET',
-  headers: new Headers({
-    'Content-Type': 'application/json'
-  }),
-  credentials: 'include'
-}
-
 export const getUserLocale = async() => {
   const cachedUserLocale = cache.getLongTerm('user', 'locale')
 
@@ -62,8 +55,7 @@ export const hasUserLocaleChanged = async() => {
 }
 
 const loadUserLocale = async() => {
-  const response = await fetch(`${__BACKEND_URL__}/nice2/username`, fetchOptions)
-  const userInfo = await response.json()
+  const userInfo = await request.executeRequest('username').then(request.extractBody)
   let {locale, username} = userInfo
   if (username === 'anonymous') {
     locale = getBrowserLocale()
@@ -103,11 +95,10 @@ export const loadTextResources = async(locale, modules) => {
   return result
 }
 
-const fetchTextResources = async(locale, modules) => {
+const fetchTextResources = (locale, modules) => {
   const moduleRegex = `(${modules.join('|')})`
   const moduleParam = moduleRegex ? `&module=${moduleRegex}` : ''
-  const url = `${__BACKEND_URL__}/nice2/textresource?locale=${locale}${moduleParam}`
+  const url = `textresource?locale=${locale}${moduleParam}`
 
-  const response = await fetch(url, fetchOptions)
-  return response.json()
+  return request.executeRequest(url).then(request.extractBody)
 }

--- a/packages/app-extensions/src/login/index.js
+++ b/packages/app-extensions/src/login/index.js
@@ -1,5 +1,5 @@
 import {addToStore} from './login'
-import {doRequest, doSessionRequest, getOptions} from './sagas'
+import {doRequest, doSessionRequest} from './sagas'
 import {doSessionCheck, setAdminAllowed, setLoggedIn} from './actions'
 
 export default {
@@ -8,6 +8,5 @@ export default {
   setAdminAllowed,
   doSessionCheck,
   doSessionRequest,
-  doRequest,
-  getOptions
+  doRequest
 }

--- a/packages/app-extensions/src/login/sagas.js
+++ b/packages/app-extensions/src/login/sagas.js
@@ -1,4 +1,4 @@
-import {consoleLogger} from 'tocco-util'
+import {consoleLogger, request} from 'tocco-util'
 import {all, call, put, takeLatest} from 'redux-saga/effects'
 
 import cache from '../cache'
@@ -6,8 +6,8 @@ import notification from '../notification'
 import * as actions from './actions'
 
 export function doRequest(url, options) {
-  return fetch(url, options)
-    .then(resp => resp.json())
+  return request.executeRequest(url, options)
+    .then(request.extractBody)
     .catch(e => {
       consoleLogger.logError('Failed to execute request', e)
       return ({success: false})
@@ -15,17 +15,7 @@ export function doRequest(url, options) {
 }
 
 export function* doSessionRequest() {
-  return yield call(doRequest, `${__BACKEND_URL__}/nice2/session`, getOptions())
-}
-
-export function getOptions() {
-  return {
-    method: 'POST',
-    headers: new Headers({
-      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
-    }),
-    credentials: 'include'
-  }
+  return yield call(doRequest, 'session', {method: 'POST'})
 }
 
 export function* sessionCheck() {

--- a/packages/app-extensions/src/rest/index.js
+++ b/packages/app-extensions/src/rest/index.js
@@ -1,9 +1,7 @@
 import {
   requestSaga,
   requestBytesSaga,
-  setBusinessUnit,
-  simpleRequest,
-  NULL_BUSINESS_UNIT
+  simpleRequest
 } from './rest'
 import {
   fetchEntity,
@@ -43,7 +41,6 @@ import InformationError from './InformationError'
 export default {
   requestSaga,
   requestBytesSaga,
-  setBusinessUnit,
   simpleRequest,
   ClientQuestionCancelledException,
   ForbiddenException,
@@ -72,6 +69,5 @@ export default {
   fetchMarked,
   setMarked,
   setSelectionMarked,
-  NULL_BUSINESS_UNIT,
   entityExists
 }

--- a/packages/app-extensions/src/rest/rest.spec.js
+++ b/packages/app-extensions/src/rest/rest.spec.js
@@ -3,8 +3,9 @@ import {call} from 'redux-saga/effects'
 import {expectSaga} from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import {throwError} from 'redux-saga-test-plan/providers'
+import {env} from 'tocco-util'
 
-import {getParameterString, prepareRequest, requestSaga, setBusinessUnit, simpleRequest} from './rest'
+import {getParameterString, prepareRequest, requestSaga, simpleRequest} from './rest'
 import {sendRequest} from './request'
 import {handleClientQuestion} from './clientQuestions'
 import {toaster} from '../notification/modules/toaster/actions'
@@ -129,9 +130,9 @@ describe('app-extensions', () => {
         const headers = fetchMock.lastOptions().headers
         expect(headers.get('x-business-unit')).to.be.null
 
-        setBusinessUnit('my_test_bu')
+        env.setBusinessUnit('my_test_bu')
         simpleRequest('')
-        setBusinessUnit(null)
+        env.setBusinessUnit(null)
 
         const headers2 = fetchMock.lastOptions().headers
         expect(headers2.get('x-business-unit')).to.eql('my_test_bu')
@@ -301,9 +302,9 @@ describe('app-extensions', () => {
       })
 
       test('should add X-Business-Unit header if business unit set', () => {
-        setBusinessUnit('my_test_bu')
+        env.setBusinessUnit('my_test_bu')
         const requestData = prepareRequest('entities/2.0/Contact')
-        setBusinessUnit(null)
+        env.setBusinessUnit(null)
 
         expect(requestData.options.headers.get('X-Business-Unit')).to.eql('my_test_bu')
       })

--- a/packages/app-extensions/src/socket/socket.js
+++ b/packages/app-extensions/src/socket/socket.js
@@ -1,6 +1,6 @@
 import {call, put, take} from 'redux-saga/effects'
 import {eventChannel} from 'redux-saga'
-import {consoleLogger} from 'tocco-util'
+import {consoleLogger, env} from 'tocco-util'
 
 const WEBSOCKET_SUCCESSFUL_CLOSE_CODE = 1000
 const sockets = {}
@@ -51,7 +51,7 @@ const websocketInitChannel = params =>
   })
 
 export const getSocketUrl = name => {
-  const baseUrl = __BACKEND_URL__ || window.location.origin
+  const baseUrl = env.getBackendUrl() || window.location.origin
   const socketUrl = baseUrl.replace('http://', 'ws://').replace('https://', 'wss://')
   return `${socketUrl}/nice2/websocket/${name}`
 }

--- a/packages/docs-browser/README.md
+++ b/packages/docs-browser/README.md
@@ -31,6 +31,7 @@ React-registry name: `docs-browser`
 | `sortable`             |           | Attribute will be passed along to entity-list.
 | `noLeftPadding`        |           | If false, a left padding will be applied to the Breadcrumbs. Per default false.
 | `searchFormCollapsed`  |           | If true, the admin search form is collapsed and thus not visible by default                                                                                                                               | Boolean
+| `backendUrl`           |           | Set backend url dynamic to point to nice2 installation. If not set it fallbacks to the build time environment __BACKEND_URL__.
 
 ### Events
 

--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -52,16 +52,20 @@ const createHistory = (store, memoryHistory) => {
 const initApp = (id, input, events = {}, publicPath) => {
   const store = appFactory.createStore(reducers, sagas, input, packageName)
 
+  if (input.backendUrl) {
+    env.setBackendUrl(input.backendUrl)
+  }
+
+  if (input.businessUnit) {
+    env.setBusinessUnit(input.businessUnit)
+  }
+
   externalEvents.addToStore(store, events)
   actionEmitter.addToStore(store)
   errorLogging.addToStore(store, true, ['console', 'remote', 'notification'])
   const handleNotifications = !events.emitAction
   notification.addToStore(store, handleNotifications)
   cache.addToStore(store)
-
-  if (input.businessUnit) {
-    env.setBusinessUnit(input.businessUnit)
-  }
 
   const history = input.history || createHistory(store, input.memoryHistory)
 
@@ -187,6 +191,7 @@ DocsBrowserApp.propTypes = {
   getCustomLocation: PropTypes.func,
   businessUnit: PropTypes.string,
   searchFormCollapsed: PropTypes.bool,
+  backendUrl: PropTypes.string,
   ...EXTERNAL_EVENTS.reduce((propTypes, event) => {
     propTypes[event] = PropTypes.func
     return propTypes

--- a/packages/docs-browser/src/main.js
+++ b/packages/docs-browser/src/main.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {reducer as reducerUtil} from 'tocco-util'
-import {actionEmitter, appFactory, cache, errorLogging, externalEvents, notification, rest} from 'tocco-app-extensions'
+import {reducer as reducerUtil, env} from 'tocco-util'
+import {actionEmitter, appFactory, cache, errorLogging, externalEvents, notification} from 'tocco-app-extensions'
 import {searchFormTypePropTypes} from 'tocco-entity-list/src/util/searchFormTypes'
 import {selectionStylePropType} from 'tocco-entity-list/src/util/selectionStyles'
 import createHashHistory from 'history/createHashHistory'
@@ -60,7 +60,7 @@ const initApp = (id, input, events = {}, publicPath) => {
   cache.addToStore(store)
 
   if (input.businessUnit) {
-    rest.setBusinessUnit(input.businessUnit)
+    env.setBusinessUnit(input.businessUnit)
   }
 
   const history = input.history || createHistory(store, input.memoryHistory)

--- a/packages/entity-browser/README.md
+++ b/packages/entity-browser/README.md
@@ -21,6 +21,7 @@ React-registry name: `entity-browser`
 | `nullBusinessUnit`     |           | If true, all REST-request have the null business unit header (X-Business-Unit: __n-u-l-l__)
 | `runInBusinessUnit`    |           | The unique id of a business unit. If present, all REST request will use this in their business unit header (X-Business-Unit). If `nullBusinessUnit` is set as well, it has precedence.
 | `memoryHistory`        |           | If set to true in-memory history is used instead of hash history. This is useful in testing and non-DOM environments.
+| `backendUrl`           |           | Set backend url dynamic to point to nice2 installation. If not set it fallbacks to the build time environment __BACKEND_URL__.
 
 ### Events
 

--- a/packages/entity-browser/src/main.js
+++ b/packages/entity-browser/src/main.js
@@ -6,13 +6,12 @@ import {
   errorLogging,
   externalEvents,
   login,
-  notification,
-  rest
+  notification
 } from 'tocco-app-extensions'
 import createHashHistory from 'history/createHashHistory'
 import createMemoryHistory from 'history/createMemoryHistory'
 import PropTypes from 'prop-types'
-import {route} from 'tocco-util'
+import {route, env} from 'tocco-util'
 import {GlobalStyles} from 'tocco-ui'
 
 import {sagas} from './modules/reducers'
@@ -60,9 +59,9 @@ const navigateToDetailIfKeySet = (history, input) => {
 const initApp = (id, input, events, publicPath) => {
   input = {...input, id}
   if (input.nullBusinessUnit) {
-    rest.setBusinessUnit(rest.NULL_BUSINESS_UNIT)
+    env.setBusinessUnit(env.NULL_BUSINESS_UNIT)
   } else if (input.runInBusinessUnit) {
-    rest.setBusinessUnit(input.runInBusinessUnit)
+    env.setBusinessUnit(input.runInBusinessUnit)
   }
 
   const store = appFactory.createStore(undefined, sagas, input, packageName)

--- a/packages/entity-browser/src/main.js
+++ b/packages/entity-browser/src/main.js
@@ -58,6 +58,11 @@ const navigateToDetailIfKeySet = (history, input) => {
 
 const initApp = (id, input, events, publicPath) => {
   input = {...input, id}
+
+  if (input.backendUrl) {
+    env.setBackendUrl(input.backendUrl)
+  }
+
   if (input.nullBusinessUnit) {
     env.setBusinessUnit(env.NULL_BUSINESS_UNIT)
   } else if (input.runInBusinessUnit) {
@@ -151,7 +156,8 @@ EntityBrowserApp.propTypes = {
   initialKey: PropTypes.string,
   nullBusinessUnit: PropTypes.bool,
   runInBusinessUnit: PropTypes.string,
-  memoryHistory: PropTypes.bool
+  memoryHistory: PropTypes.bool,
+  backendUrl: PropTypes.string
 }
 
 export default EntityBrowserApp

--- a/packages/installation-delta-action/src/components/Header/Header.js
+++ b/packages/installation-delta-action/src/components/Header/Header.js
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import {Typography} from 'tocco-ui'
+import {rest} from 'tocco-app-extensions'
 import styled from 'styled-components'
 
 const DICTIONARY = {
@@ -17,11 +18,9 @@ const Header = ({keys, delta}) => {
   const [labelDelta, setLabelDelta] = useState('')
   const [statusDelta, setStatusDelta] = useState('')
 
-  const getFetchRequest = async key => {
-    const options = {credentials: 'include'}
-    const url = `${__BACKEND_URL__}/nice2/rest/entities/2.0/Installation/${key}?relations=!&_fields=!`
-    const response = await fetch(url, options)
-    return response.json()
+  const getFetchRequest = key => {
+    const url = `entities/2.0/Installation/${key}?relations=!&_fields=!`
+    return rest.simpleRequest(url)
   }
 
   const fetchLabels = async() => {

--- a/packages/installation-delta-action/src/components/InstallationDelta/InstallationDelta.js
+++ b/packages/installation-delta-action/src/components/InstallationDelta/InstallationDelta.js
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import {rest} from 'tocco-app-extensions'
 import {LoadMask} from 'tocco-ui'
 
 import CommitMsg from '../CommitMsg'
@@ -25,11 +26,9 @@ const StyledRow = styled.div`
 const InstallationDelta = ({keys}) => {
   const [delta, setDelta] = useState(null)
 
-  const fetchData = async() => {
-    const options = {credentials: 'include'}
-    const url = `${__BACKEND_URL__}/nice2/rest/tocco/commit-info/installation/${keys[0]}/delta?installation=${keys[1]}`
-    const response = await fetch(url, options)
-    return response.json()
+  const fetchData = () => {
+    const url = `tocco/commit-info/installation/${keys[0]}/delta?installation=${keys[1]}`
+    return rest.simpleRequest(url)
   }
 
   useEffect(() => {

--- a/packages/login/src/modules/sagas.js
+++ b/packages/login/src/modules/sagas.js
@@ -1,4 +1,4 @@
-import {consoleLogger} from 'tocco-util'
+import {consoleLogger, request} from 'tocco-util'
 import {cache, externalEvents, intl, rest} from 'tocco-app-extensions'
 import {takeLatest, put, select, call, all} from 'redux-saga/effects'
 
@@ -18,8 +18,9 @@ export const loginSelector = state => state.login
 
 export function doRequest(url, options) {
   return new Promise(resolve => {
-    fetch(url, options)
-      .then(resp => resp.json().then(json => resolve(json)))
+    request.executeRequest(url, options)
+      .then(request.extractBody)
+      .then(json => resolve(json))
       .catch(e => {
         consoleLogger.logError('Failed to execute request', e)
         resolve({success: false})
@@ -28,11 +29,11 @@ export function doRequest(url, options) {
 }
 
 export function* doLoginRequest(data) {
-  return yield call(doRequest, `${__BACKEND_URL__}/nice2/login`, getOptions(data))
+  return yield call(doRequest, 'login', getOptions(data))
 }
 
 export function* doSessionRequest() {
-  return yield call(doRequest, `${__BACKEND_URL__}/nice2/session`, getOptions())
+  return yield call(doRequest, 'session', {method: 'POST'})
 }
 
 function getOptions(data = {}) {
@@ -41,7 +42,6 @@ function getOptions(data = {}) {
     headers: new Headers({
       'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
     }),
-    credentials: 'include',
     body: Object.keys(data)
       .filter(k => !!data[k])
       .sort()

--- a/packages/sso-login/src/utils/loginWindow.js
+++ b/packages/sso-login/src/utils/loginWindow.js
@@ -1,7 +1,9 @@
+import {env} from 'tocco-util'
+
 import {getPopUpFeatures} from './popUp'
 
 export const openLoginWindow = (loginEndpoint, loginCompleted, provider) => {
-  const baseUrl = __DEV__ ? '' : __BACKEND_URL__
+  const baseUrl = __DEV__ ? '' : env.getBackendUrl()
   const encodedWindowUrl = encodeURIComponent(window.location.href)
   const url = `${baseUrl}${loginEndpoint}?provider=${provider.unique_id}&sourceUri=${encodedWindowUrl}`
 

--- a/packages/tocco-ui/src/CodeEditor/TqlAutoCompleter.js
+++ b/packages/tocco-ui/src/CodeEditor/TqlAutoCompleter.js
@@ -1,5 +1,5 @@
 import ace from 'ace-builds/src-min-noconflict/ace'
-import {originId} from 'tocco-util'
+import {request} from 'tocco-util'
 
 import {functions, placeholders, types} from './TqlMode'
 
@@ -94,14 +94,7 @@ export const findCurrentModelScope = iterator => backtrack(iterator, findLastMod
  **/
 const defaultScore = 1000
 
-const getFetchOptions = () => ({
-  headers: {
-    'X-Origin-Id': originId.getOriginId()
-  },
-  credentials: 'include'
-})
-
-const sendRequest = endpoint => fetch(`${__BACKEND_URL__}/nice2/rest/${endpoint}`, getFetchOptions())
+const sendRequest = endpoint => request.executeRequest(`rest/${endpoint}`)
 
 const extractBody = response => response.status === 200 ? response.json() : null
 

--- a/packages/tocco-util/src/env/env.js
+++ b/packages/tocco-util/src/env/env.js
@@ -1,0 +1,23 @@
+
+export const NULL_BUSINESS_UNIT = '__n-u-l-l__'
+
+const env = {
+  backendUrl: undefined,
+  businessUnit: undefined
+}
+
+export const getBackendUrl = () => {
+  return env.backendUrl || __BACKEND_URL__
+}
+
+export const setBackendUrl = value => {
+  env.backendUrl = value
+}
+
+export const getBusinessUnit = () => {
+  return env.businessUnit
+}
+
+export const setBusinessUnit = value => {
+  env.businessUnit = value
+}

--- a/packages/tocco-util/src/env/env.spec.js
+++ b/packages/tocco-util/src/env/env.spec.js
@@ -1,0 +1,38 @@
+import {
+  getBackendUrl,
+  getBusinessUnit,
+  NULL_BUSINESS_UNIT,
+  setBackendUrl,
+  setBusinessUnit
+} from './env'
+
+describe('tocco-util', () => {
+  describe('env', () => {
+    describe('backendUrl', () => {
+      test('should return __BACKEND_URL__ as initial backend url', () => {
+        expect(getBackendUrl()).to.equal(__BACKEND_URL__)
+      })
+
+      test('should return set backend url', () => {
+        setBackendUrl('test')
+        expect(getBackendUrl()).to.equal('test')
+      })
+    })
+
+    describe('businessUnit', () => {
+      test('should return undefined as initial business unit', () => {
+        expect(getBusinessUnit()).to.be.undefined
+      })
+
+      test('should return set business unit', () => {
+        setBusinessUnit('test')
+        expect(getBusinessUnit()).to.equal('test')
+      })
+
+      test('should have NULL_BUSINESS_UNIT', () => {
+        setBusinessUnit(NULL_BUSINESS_UNIT)
+        expect(getBusinessUnit()).to.equal('__n-u-l-l__')
+      })
+    })
+  })
+})

--- a/packages/tocco-util/src/env/index.js
+++ b/packages/tocco-util/src/env/index.js
@@ -1,0 +1,9 @@
+import {getBackendUrl, getBusinessUnit, setBackendUrl, setBusinessUnit, NULL_BUSINESS_UNIT} from './env'
+
+export default {
+  getBackendUrl,
+  setBackendUrl,
+  getBusinessUnit,
+  setBusinessUnit,
+  NULL_BUSINESS_UNIT
+}

--- a/packages/tocco-util/src/mockData/mockData.js
+++ b/packages/tocco-util/src/mockData/mockData.js
@@ -1,5 +1,6 @@
 import {Server} from 'mock-socket'
 
+import env from '../env'
 import {setupForms} from './forms'
 import {setupEntities} from './entities'
 import {setupActions} from './actions'
@@ -17,7 +18,7 @@ let webSocketServer = null
 
 const createMockSocketServer = () => {
   try {
-    const socketUrl = `${__BACKEND_URL__}`.replace('http://', 'ws://').replace('https://', 'wss://')
+    const socketUrl = env.getBackendUrl().replace('http://', 'ws://').replace('https://', 'wss://')
     const notificationWebSocketUrl = `${socketUrl}/nice2/websocket/notification`
     webSocketServer = new Server(notificationWebSocketUrl)
   } catch (e) {}

--- a/packages/tocco-util/src/request/index.js
+++ b/packages/tocco-util/src/request/index.js
@@ -1,0 +1,5 @@
+import {executeRequest, extractBody, prepareHeaders, prepareUrl} from './request'
+
+export default {
+  prepareHeaders, prepareUrl, executeRequest, extractBody
+}

--- a/packages/tocco-util/src/request/request.js
+++ b/packages/tocco-util/src/request/request.js
@@ -1,0 +1,71 @@
+import env from '../env'
+import originId from '../originId'
+
+const defaultOptions = {
+  method: 'GET',
+  credentials: 'include'
+}
+
+const getOrCreateHeaders = optionsHeader => {
+  if (optionsHeader) {
+    if (optionsHeader instanceof Headers) {
+      return optionsHeader
+    } else if (typeof optionsHeader === 'object') {
+      return new Headers(optionsHeader)
+    }
+  }
+  return new Headers()
+}
+
+export const prepareHeaders = options => {
+  const headers = getOrCreateHeaders(options.headers)
+  const body = options.body
+
+  if (!headers.has('Content-Type')) {
+    if (typeof body === 'string') {
+      headers.set('Content-Type', 'text/plain')
+    } else if (!(body instanceof FormData)) {
+      headers.set('Content-Type', 'application/json')
+    }
+  }
+
+  if (!headers.has('X-Origin-Id')) {
+    headers.set('X-Origin-Id', originId.getOriginId())
+  }
+
+  if (!headers.has('X-Business-Unit') && env.getBusinessUnit()) {
+    headers.set('X-Business-Unit', env.getBusinessUnit())
+  }
+
+  return headers
+}
+
+export const prepareUrl = (backendUrl, resource) => {
+  if (resource.startsWith('/')) {
+    resource = resource.substring(1)
+  }
+
+  if (resource.startsWith('http')) {
+    return resource
+  } else if (resource.startsWith('nice2')) {
+    return `${backendUrl}/${resource}`
+  } else {
+    return `${backendUrl}/nice2/${resource}`
+  }
+}
+
+export const prepareOptions = options => ({
+  ...defaultOptions,
+  ...options,
+  headers: prepareHeaders(options)
+})
+
+export const executeRequest = (resource, options = {}) => {
+  const fetchOptions = prepareOptions(options)
+  const backendUrl = env.getBackendUrl()
+  const url = prepareUrl(backendUrl, resource)
+
+  return fetch(url, fetchOptions)
+}
+
+export const extractBody = response => response.json()

--- a/packages/tocco-util/src/request/request.spec.js
+++ b/packages/tocco-util/src/request/request.spec.js
@@ -1,0 +1,207 @@
+import fetchMock from 'fetch-mock'
+
+import env from '../env'
+import originId from '../originId'
+import {executeRequest, extractBody, prepareHeaders, prepareOptions, prepareUrl} from './request'
+
+describe('tocco-util', () => {
+  describe('request', () => {
+    describe('prepareUrl', () => {
+      test('should handle prefixed slash', () => {
+        const backendUrl = 'https://tocco.ch'
+        const resource = '/nice2/test'
+
+        expect(prepareUrl(backendUrl, resource)).to.equal('https://tocco.ch/nice2/test')
+      })
+      
+      test('should handle non prefixed slash', () => {
+        const backendUrl = 'https://tocco.ch'
+        const resource = 'nice2/test'
+
+        expect(prepareUrl(backendUrl, resource)).to.equal('https://tocco.ch/nice2/test')
+      })
+
+      test('should handle absolute resource', () => {
+        const backendUrl = 'https://tocco.ch'
+        const resource = 'https://master.tocco.ch/nice2/test'
+
+        expect(prepareUrl(backendUrl, resource)).to.equal('https://master.tocco.ch/nice2/test')
+      })
+
+      test('should add missing nice2', () => {
+        const backendUrl = 'https://tocco.ch'
+        const resource = 'test'
+
+        expect(prepareUrl(backendUrl, resource)).to.equal('https://tocco.ch/nice2/test')
+      })
+    })
+
+    describe('prepareHeaders', () => {
+      afterEach(() => {
+        env.setBusinessUnit(undefined)
+      })
+
+      test('should handle empty headers', () => {
+        const options = {}
+
+        const headers = prepareHeaders(options)
+
+        expect(headers.get('Content-Type')).to.deep.equal('application/json')
+        expect(headers.get('X-Origin-Id')).to.deep.equal(originId.getOriginId())
+        expect(Array.from(headers).length).to.equal(2)
+      })
+
+      test('should handle text body', () => {
+        const options = {
+          body: 'foo'
+        }
+
+        const headers = prepareHeaders(options)
+
+        expect(headers.get('Content-Type')).to.deep.equal('text/plain')
+        expect(Array.from(headers).length).to.equal(2)
+      })
+
+      test('should ignore FormData body', () => {
+        const options = {
+          body: new FormData()
+        }
+
+        const headers = prepareHeaders(options)
+
+        expect(headers.get('X-Origin-Id')).to.deep.equal(originId.getOriginId())
+        expect(Array.from(headers).length).to.equal(1)
+      })
+
+      test('should add business unit header', () => {
+        env.setBusinessUnit('test')
+        const options = {}
+
+        const headers = prepareHeaders(options)
+
+        expect(headers.get('X-Business-Unit')).to.deep.equal('test')
+        expect(Array.from(headers).length).to.equal(3)
+      })
+
+      test('should be able to set content-type', () => {
+        const options = {
+          headers: new Headers({
+            'Content-Type': 'anything'
+          })
+        }
+
+        const headers = prepareHeaders(options)
+
+        expect(headers.get('Content-Type')).to.deep.equal('anything')
+        expect(Array.from(headers).length).to.equal(2)
+      })
+
+      test('should be able to set x-business-unit', () => {
+        env.setBusinessUnit('test')
+        const options = {
+          headers: new Headers({
+            'X-Business-Unit': 'anything'
+          })
+        }
+
+        const headers = prepareHeaders(options)
+
+        expect(headers.get('X-Business-Unit')).to.deep.equal('anything')
+        expect(Array.from(headers).length).to.equal(3)
+      })
+
+      test('should be able to set x-origin-id', () => {
+        const options = {
+          headers: new Headers({
+            'X-Origin-Id': 'anything'
+          })
+        }
+
+        const headers = prepareHeaders(options)
+
+        expect(headers.get('X-Origin-Id')).to.deep.equal('anything')
+        expect(Array.from(headers).length).to.equal(2)
+      })
+    })
+
+    describe('prepareOptions', () => {
+      test('should add default options', () => {
+        const options = {}
+
+        const expectedOptions = {
+          method: 'GET',
+          credentials: 'include',
+          headers: new Headers()
+        }
+        
+        const preparedOptions = prepareOptions(options)
+        expect(preparedOptions).to.deep.equal(expectedOptions)
+        expect(preparedOptions.headers.get('Content-Type')).to.deep.equal('application/json')
+        expect(preparedOptions.headers.get('X-Origin-Id')).to.deep.equal(originId.getOriginId())
+      })
+
+      test('should be able to overwrite default options', () => {
+        const options = {
+          method: 'POST',
+          credentials: 'same-origin'
+        }
+
+        const expectedOptions = {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: new Headers()
+        }
+        
+        const preparedOptions = prepareOptions(options)
+        expect(preparedOptions).to.deep.equal(expectedOptions)
+      })
+    })
+
+    describe('executeRequest', () => {
+      beforeEach(() => {
+        fetchMock.reset()
+        fetchMock.restore()
+        env.setBackendUrl(undefined)
+      })
+    
+      test('should execute fetch', () => {
+        const resource = 'username'
+        const options = {}
+
+        fetchMock.get('/nice2/username', new Response({}, {status: 200}))
+        const promise = executeRequest(resource, options)
+        return promise
+      })
+
+      test('should consider dynamic backend url', () => {
+        env.setBackendUrl('https://tocco.ch')
+        const resource = 'username'
+        const options = {}
+
+        fetchMock.get('https://tocco.ch/nice2/username', new Response({}, {status: 200}))
+        const promise = executeRequest(resource, options)
+        return promise
+      })
+
+      test('should be able to execute POST request', () => {
+        env.setBackendUrl('https://tocco.ch')
+        const resource = 'username'
+        const options = {method: 'POST'}
+
+        fetchMock.post('https://tocco.ch/nice2/username', new Response({}, {status: 200}))
+        const promise = executeRequest(resource, options)
+        return promise
+      })
+    })
+
+    describe('extractBody', () => {
+      test('should return json', async() => {
+        const response = new Response(JSON.stringify({a: 'foo'}))
+        const body = await extractBody(response)
+        
+        expect(body).to.deep.equal({a: 'foo'})
+        return body
+      })
+    })
+  })
+})

--- a/packages/two-factor-connector/src/modules/sagas.js
+++ b/packages/two-factor-connector/src/modules/sagas.js
@@ -1,5 +1,6 @@
 import {takeLatest, all, call, put, select} from 'redux-saga/effects'
 import {rest, externalEvents} from 'tocco-app-extensions'
+import {request} from 'tocco-util'
 import _get from 'lodash/get'
 
 import * as actions from './actions'
@@ -22,6 +23,10 @@ export function* requestSecret() {
   yield put(actions.goToSecret())
 }
 
+export function sendRequest(url, options) {
+  return request.executeRequest(url, options).then(request.extractBody)
+}
+
 /* the regular two-factor endpoint can only be accessed while logged in to secure against anonymous activation of
    two-factor validation on arbitrary accounts, so without a session we send a request to the login servlet which uses
    the forced two-factor authenticator to validate login data and activate the two-factor login */
@@ -32,7 +37,8 @@ function* activateTwoFactorWithoutSession(secret, userCode, username, password) 
     username,
     password
   }
-  const response = yield call(rest.requestSaga, 'nice2/login',
+
+  const response = yield call(sendRequest, 'login',
     {
       method: 'POST',
       headers: new Headers({

--- a/packages/two-factor-connector/src/modules/sagas.spec.js
+++ b/packages/two-factor-connector/src/modules/sagas.spec.js
@@ -182,13 +182,9 @@ describe('two-factor-connector', () => {
             .provide([
               [select(sagas.usernameSelector), 'dake'],
               [select(sagas.secretSelector), {secret: '7ad4b588f0774cf19ac518289c751486'}],
-              [matchers.call.fn(rest.requestSaga), {body: {TWOSTEPLOGIN_ACTIVATION: {success: true}}}],
+              [matchers.call.fn(sagas.sendRequest), {body: {TWOSTEPLOGIN_ACTIVATION: {success: true}}}],
               [select(sagas.inputSelector), {password: 'password', forced: true}]
             ])
-            .call.like({
-              fn: rest.requestSaga,
-              args: ['nice2/login']
-            })
             .put(actions.setSetupSuccessful(true))
             .put(actions.goToResult())
             .run()


### PR DESCRIPTION
- created `env` module for being able to have runtime environment variables
- created `request` module to have similar to the rest-module a common fetch wrapper for non-rest calls
  - it should consider all needed headers
  - it should consider correct backend url
 - refactor fetch calls to use either new request-module or existing rest-module
 - adjust all backend url references to consider runtime environment