### PR TITLE
fix(app-extensions): open downloadable file in new tab to avoid errors

### DIFF
--- a/packages/app-extensions/src/notification/components/NotificationBody/NotificationBody.js
+++ b/packages/app-extensions/src/notification/components/NotificationBody/NotificationBody.js
@@ -41,7 +41,13 @@ const Result = ({notification: {result}, navigationStrategy}) => {
             </a>
           </div>
           {download.downloadSupportedByBrowser() && (
-            <a href={download.addParameterToURL(file.link, 'download', true)} download={file.name} title="download">
+            <a
+              href={download.addParameterToURL(file.link, 'download', true)}
+              target="_blank"
+              rel="noreferrer"
+              download={file.name}
+              title="download"
+            >
               <StyledIconWrapper>
                 <Icon icon="arrow-to-bottom" />
               </StyledIconWrapper>


### PR DESCRIPTION
if a downloadable file (e.g. file linked to an output job) is opened in the same tab the beforeunload is triggered which calls abortController.abort() which results in a "broken" tab

Changelog: open downloadable file in new tab to avoid errors
Refs: TOCDEV-4674
Cherry-pick: Up