### PR TITLE
fix: open downloadable file in new tab to avoid errors

### DIFF
--- a/packages/app-extensions/src/notification/components/NotificationBody/NotificationBody.js
+++ b/packages/app-extensions/src/notification/components/NotificationBody/NotificationBody.js
@@ -50,7 +50,6 @@ const Result = ({
             href={download.addParameterToURL(file.link, 'download', true)}
             target="_blank"
             rel="noreferrer"
-            download={file.name}
             title="download">
             <StyledIconWrapper><Icon icon="arrow-to-bottom"/></StyledIconWrapper>
             <FormattedMessage id="client.common.notification.outputJobFileDownload"/>

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DocumentCompactFormatter.js
@@ -16,7 +16,6 @@ const DocumentCompactFormatter = ({value, options}) => {
         <span onMouseOver={() => loadTooltip && !tooltip && loadTooltip(value.resourceKey)}>
           <Link
             alt={value.alt || value.fileName}
-            download={value.fileName}
             icon="external-link"
             look="raised"
             target="_blank"
@@ -29,9 +28,9 @@ const DocumentCompactFormatter = ({value, options}) => {
       </Popover>
       <Link
         alt={value.alt || value.fileName}
-        download={value.fileName}
         icon="arrow-to-bottom"
         look="raised"
+        target="_blank"
         href={download.getDownloadUrl(value.binaryLink)}
         onClick={e => {
           e.stopPropagation()

--- a/packages/tocco-ui/src/Upload/View.js
+++ b/packages/tocco-ui/src/Upload/View.js
@@ -34,7 +34,7 @@ const View = ({value, downloadTitle, immutable, onUpload, deleteTitle}) => {
           <Link
             neutral
             icon="arrow-to-bottom"
-            download={value.fileName}
+            target="_blank"
             href={download.getDownloadUrl(value.binaryLink)}
             tabIndex={-1}
             title={downloadTitle || 'download'}


### PR DESCRIPTION
if a downloadable file (e.g. file linked to an output job) is opened in the same tab the beforeunload is triggered which calls abortController.abort() which results in a "broken" tab

Changelog: open downloadable file in new tab to avoid errors
Refs: TOCDEV-4674
Cherry-pick: Up