### PR TITLE
feat(login): add dynamic backend-url as input parameter

### DIFF
--- a/packages/login/README.md
+++ b/packages/login/README.md
@@ -28,7 +28,8 @@ React-registry name: `login`
 | `showTitle`            |           | Display a title above the dialog.
 | `locale`               |           | ISO Language Code
 | `passwordRequest`      |           | Boolean to open login app in reset mode. 
-| `username`             |           | Open login app with pre-filled username. 
+| `username`             |           | Open login app with pre-filled username.
+| `backendUrl`           |           | Set backend url dynamic to point to nice2 installation. If not set it fallbacks to the build time environment __BACKEND_URL__.
 
 ### Methods
 
@@ -76,6 +77,7 @@ React-registry name: `password-update`
 | `showOldPasswordField` |           | By default, there is no input field for the old password. Set this property to `true` to render the input field. |
 | `oldPassword`          |           | Unless the user which submits the dialog is login manager, you must either provide the old password of the user with this property or enable the old-password input (see `showOldPasswordField`) so that the user is able to enter his current password
 | `showTitle`            |           | Display a title above the dialog.
+| `backendUrl`           |           | Set backend url dynamic to point to nice2 installation. If not set it fallbacks to the build time environment __BACKEND_URL__.
 
 ### Events
 

--- a/packages/login/src/LoginApp.js
+++ b/packages/login/src/LoginApp.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import {appFactory, cache, errorLogging, externalEvents} from 'tocco-app-extensions'
+import {env} from 'tocco-util'
 
 import LoginContainer from './containers/LoginContainer'
 import * as login from './modules/login/actions'
@@ -24,6 +25,11 @@ export const initLoginApp = (id, input, events, publicPath, customTheme) => {
   const content = <LoginContainer showTitle={showTitle} />
 
   const store = appFactory.createStore(loginReducers, sagas, input, packageName)
+
+  if (input.backendUrl) {
+    env.setBackendUrl(input.backendUrl)
+  }
+
   externalEvents.addToStore(store, events)
   errorLogging.addToStore(store, true, ['console', 'remote'])
   cache.addToStore(store)
@@ -53,6 +59,7 @@ LoginApp.propTypes = {
   passwordRequest: PropTypes.bool,
   username: PropTypes.string,
   setLocale: PropTypes.func,
+  backendUrl: PropTypes.string,
   ...EXTERNAL_EVENTS.reduce((propTypes, event) => {
     propTypes[event] = PropTypes.func
     return propTypes

--- a/packages/login/src/PasswordUpdateApp.js
+++ b/packages/login/src/PasswordUpdateApp.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import {appFactory, errorLogging, externalEvents} from 'tocco-app-extensions'
-import {consoleLogger} from 'tocco-util'
+import {consoleLogger, env} from 'tocco-util'
 
 import LoginContainer from './containers/LoginContainer'
 import * as passwordUpdate from './modules/passwordUpdate/dialog/actions'
@@ -29,6 +29,11 @@ export const initPasswordUpdateApp = (id, input, events, publicPath, customTheme
   }
 
   const store = appFactory.createStore(loginReducers, sagas, input, packageName)
+  
+  if (input.backendUrl) {
+    env.setBackendUrl(input.backendUrl)
+  }
+  
   externalEvents.addToStore(store, events)
   errorLogging.addToStore(store, true, ['console', 'remote'])
 
@@ -56,6 +61,7 @@ PasswordUpdateApp.propTypes = {
   showTitle: PropTypes.bool,
   showOldPasswordField: PropTypes.bool,
   oldPassword: PropTypes.string,
+  backendUrl: PropTypes.string,
   ...EXTERNAL_EVENTS_PASSWORD_UPDATE.reduce(
     (propTypes, event) => ({
       ...propTypes,


### PR DESCRIPTION
For widget the backend url needs to set via input parameters
since the widget will most probably run on a different domain
than nice2.

Changelog: add dynamic backend-url as input parameter
Refs: TOCDEV-4655