### PR TITLE
feat(widget-utils): add new package with script to load widgets

### DIFF
--- a/packages/widget-utils/.npmignore
+++ b/packages/widget-utils/.npmignore
@@ -1,0 +1,5 @@
+src
+node_modules
+tests
+coverage
+.eslintrc

--- a/packages/widget-utils/.yarnrc
+++ b/packages/widget-utils/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "chore: publish\n\n- tocco-widget-utils@%s"
+version-tag-prefix "_tocco-widget-utils@"

--- a/packages/widget-utils/README.md
+++ b/packages/widget-utils/README.md
@@ -1,0 +1,13 @@
+# Widget Utils
+
+Contains tools that are needed to let our apps run in external websites.
+
+## bootstrap
+
+The `bootstrap` script finds all the widget containers in the website and renders the corresponding application.
+
+### Import
+
+```html
+<script src="https://${customer}.tocco.ch/js/tocco-widget-utils/dist/bootstrap.js"/>
+```

--- a/packages/widget-utils/build/webpack.js
+++ b/packages/widget-utils/build/webpack.js
@@ -1,0 +1,6 @@
+export const adjustConfig = (webpackConfig, config) => {
+  webpackConfig.entry[0] = webpackConfig.entry[0].replace('/main.js', '/bootstrap/index.js')
+  webpackConfig.output.filename = 'bootstrap.js'
+
+  return webpackConfig
+}

--- a/packages/widget-utils/package.json
+++ b/packages/widget-utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tocco-widget-utils",
+  "version": "0.1.0",
+  "description": "",
+  "scripts": {
+    "compile:prod": "cd ../../ && npm run compile:prod -- --package=widget-utils",
+    "prepublish": "npm run compile:prod"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "tocco-app-extensions": "*",
+    "tocco-test-util": "*",
+    "tocco-theme": "*",
+    "tocco-ui": "*",
+    "tocco-util": "*"
+  }
+}

--- a/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
+++ b/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
@@ -1,0 +1,27 @@
+import {buildInputFromDom, loadScriptAsync} from './utils'
+
+const bootstrapWidgets = async params => {
+  const {backendUrl} = params
+
+  const widgetContainerNodeList = document.querySelectorAll('[data-tocco-widget]')
+  const widgetContainers = Array.prototype.slice.call(widgetContainerNodeList)
+  const apps = [...new Set(widgetContainers.map(container => container.getAttribute('data-tocco-widget')))]
+
+  await Promise.all(
+    apps.map(app => {
+      return loadScriptAsync(`${backendUrl}/js/tocco-${app}/dist/index.js`)
+    })
+  )
+
+  widgetContainers.forEach(container => {
+    const app = container.getAttribute('data-tocco-widget')
+    const input = {
+        backendUrl,
+        ...buildInputFromDom(container)
+    }
+
+    window.reactRegistry.render(app, container, '', input, {}, `${backendUrl}/js/tocco-${app}/dist/`)
+  })
+}
+
+export default bootstrapWidgets

--- a/packages/widget-utils/src/bootstrap/index.js
+++ b/packages/widget-utils/src/bootstrap/index.js
@@ -1,0 +1,13 @@
+import bootstrapWidgets from './bootstrapWidgets'
+import {loadScriptAsync, getBackendUrl} from './utils'
+
+;(async () => {
+  const backendUrl = getBackendUrl(document)
+
+  const params = {
+    backendUrl
+  }
+
+  await loadScriptAsync(`${backendUrl}/nice2/javascript/nice2-react.release.js`)
+  await bootstrapWidgets(params)
+})()

--- a/packages/widget-utils/src/bootstrap/utils.js
+++ b/packages/widget-utils/src/bootstrap/utils.js
@@ -1,0 +1,41 @@
+export const snakeToCamel = s => s.replace(/(-\w)/g, m => m[1].toUpperCase())
+
+export const loadScriptAsync = src =>
+  new Promise(resolve => {
+    const tag = document.createElement('script')
+    tag.src = src
+    tag.async = true
+    tag.type = 'text/javascript'
+    tag.onload = () => {
+      resolve()
+    }
+    tag.crossorogin = true
+
+    const firstScriptTag = document.getElementsByTagName('script')[0]
+    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag)
+  })
+
+export const transformObjectValue = val => {
+  try {
+    return JSON.parse(val)
+  } catch (e) {
+    return val
+  }
+}
+
+export const getBackendUrl = document => {
+  const jsFileSource = document.currentScript.getAttribute('src')
+  const {protocol, host} = new URL(jsFileSource)
+  return protocol + '//' + host
+}
+
+export const buildInputFromDom = widgetContainer => {
+    const attributes = Array.prototype.slice.call(widgetContainer.attributes)
+    return attributes.reduce(
+      (acc, val) => ({
+        ...acc,
+        [snakeToCamel(val.name.replace('data-', ''))]: transformObjectValue(val.value)
+      }),
+      {}
+    )
+}

--- a/packages/widget-utils/src/bootstrap/utils.spec.js
+++ b/packages/widget-utils/src/bootstrap/utils.spec.js
@@ -1,0 +1,41 @@
+import {buildInputFromDom, getBackendUrl} from './utils'
+
+describe('widget-utils', () => {
+  describe('bootstrap', () => {
+    describe('getBackendUrl', () => {
+      test('should derive backend url from script source url', () => {
+        const document = {
+          currentScript: {
+            getAttribute: name =>
+              name === 'src' ? 'https://customer.tocco.ch/js/tocco-widget-utils/dist/bootstrap.js' : undefined
+          }
+        }
+        expect(getBackendUrl(document)).to.eql('https://customer.tocco.ch')
+      })
+    })
+
+    describe('buildInputFromDom', () => {
+        test('should build input object from DOM attributes', () => {
+            const container = {
+                attributes: [
+                    {name: 'data-tocco-widget', value: 'entity-browser'},
+                    {name: 'data-entity-name', value: 'User'},
+                    {name: 'style', value: 'color: red;'},
+                    {name: 'data-form-base', value: 'User'},
+                    {name: 'data-memory-history', value: 'true'}
+                ]
+            }
+            expect(buildInputFromDom(container)).to.eql({
+                entityName: 'User',
+                formBase: 'User',
+                memoryHistory: true,
+
+                // the following two aren't actually needed as input
+                // but they also shouldn't do any harm either
+                toccoWidget: 'entity-browser',
+                style: 'color: red;'
+            })
+        })
+    })
+  })
+})


### PR DESCRIPTION
- The new `bootstrap.js` script will be hosted on the Tocco instance
  and can be fetched from there by including a script tag in the external
  website:
  `<script src="https://${customer}.tocco.ch/js/tocco-widget-utils/dist/bootstrap.js"/>`
- The script selects all widget containers in the website and renders
  the corresponding React applications
- The React version that is installed on the Tocco instance is used
  (same sources are loaded that are used in the apps that run on the
  Tocco instance directly)
- By default, the bootstrap JS origin is used as backend URL for the
  widgets (could be overriden by adding a `data-backend-url` attribute
  to the widget container)

Refs: TOCDEV-4569