### PR TITLE
feat(widget-utils): add widget attribute `data-tocco-package`

### DIFF
--- a/packages/widget-utils/README.md
+++ b/packages/widget-utils/README.md
@@ -11,3 +11,26 @@ The `bootstrap` script finds all the widget containers in the website and render
 ```html
 <script src="https://${customer}.tocco.ch/js/tocco-widget-utils/dist/bootstrap.js"/>
 ```
+
+### Embed widgets
+
+To embed a widget in the website, just add a `<div>` container and decorate it with the necessary attributes.
+
+#### Attributes
+
+- `data-tocco-widget` (required): The name of the widget (e.g. 'entity-explorer')
+- `data-tocco-package` (optional): By default, the JS sources are loaded according to the given widget name. If the widget and package name are not the same, the package name can be decared explicitly.
+- `data-XXX`: Any additional attributes that are passed to the app as
+input params. Declare them in `snake-case`, they are transformed to `camelCase` (`data-` prefix is stripped).
+
+### Example
+
+```html
+<div
+    data-tocco-widget="entity-explorer"
+    data-entity-name="User"
+    data-form-base="User"
+    data-memory-history="true"
+></div>
+<script src="https://${customer.tocco.ch}/js/tocco-widget-utils/dist/bootstrap.js"></script>
+```

--- a/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
+++ b/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
@@ -1,26 +1,31 @@
 import {buildInputFromDom, loadScriptAsync} from './utils'
 
+const getWidgetName = container => container.getAttribute('data-tocco-widget')
+
+const getPackageName = container => container.getAttribute('data-tocco-package') || getWidgetName(container)
+
 const bootstrapWidgets = async params => {
   const {backendUrl} = params
 
   const widgetContainerNodeList = document.querySelectorAll('[data-tocco-widget]')
   const widgetContainers = Array.prototype.slice.call(widgetContainerNodeList)
-  const apps = [...new Set(widgetContainers.map(container => container.getAttribute('data-tocco-widget')))]
+  const packages = [...new Set(widgetContainers.map(container => getPackageName(container)))]
 
   await Promise.all(
-    apps.map(app => {
-      return loadScriptAsync(`${backendUrl}/js/tocco-${app}/dist/index.js`)
+    packages.map(packageName => {
+      return loadScriptAsync(`${backendUrl}/js/tocco-${packageName}/dist/index.js`)
     })
   )
 
   widgetContainers.forEach(container => {
-    const app = container.getAttribute('data-tocco-widget')
+    const app = getWidgetName(container)
+    const packageName = getPackageName(container)
     const input = {
-        backendUrl,
-        ...buildInputFromDom(container)
+      backendUrl,
+      ...buildInputFromDom(container)
     }
 
-    window.reactRegistry.render(app, container, '', input, {}, `${backendUrl}/js/tocco-${app}/dist/`)
+    window.reactRegistry.render(app, container, '', input, {}, `${backendUrl}/js/tocco-${packageName}/dist/`)
   })
 }
 


### PR DESCRIPTION
By default, the package JS file is derived from the widget name
(which is declared in the `data-tocco-widget` attribute).

There are some cases, where the widget and package name do
not match (e.g. because a package exports multiple widgets,
like the `login` package does (provides `login` and
`update-password` widget)). In these cases, the package name
can be declared explicitly now.

Refs: TOCDEV-4569
Changelog: add widget attribute `data-tocco-package`