### PR TITLE
fix(tocco-ui): do not execute injected JS in html field

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/HtmlEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/HtmlEdit.js
@@ -43,9 +43,11 @@ class HtmlEdit extends React.Component {
   }
 
   render() {
+    const sanitizedValue = html.sanitizeHtml(this.props.value)
+
     if (this.props.immutable) {
       return <Typography.Span>
-        <div dangerouslySetInnerHTML={{__html: html.sanitizeHtml(this.props.value)}}></div>
+        <div dangerouslySetInnerHTML={{__html: sanitizedValue}}></div>
       </Typography.Span>
     }
 
@@ -57,7 +59,7 @@ class HtmlEdit extends React.Component {
             onChange={this.handleChange}
             id={this.props.id}
             theme="snow"
-            defaultValue={this.props.value}
+            defaultValue={sanitizedValue}
             modules={{
               clipboard: {
                 matchVisual: false


### PR DESCRIPTION
- also editbale field should not execute injected js
- already worked for read-only field
- injected js only insertable by REST API

Changelog: do not execute injected JS in html field
Refs: TOCDEV-4626
Cherry-pick: Up