### PR TITLE
fix(tocco-util): no styles allowed in rendered HTML

### DIFF
--- a/packages/tocco-util/src/html/sanitizeHtml.js
+++ b/packages/tocco-util/src/html/sanitizeHtml.js
@@ -4,7 +4,7 @@ const sanitizeHtml = html => {
   if (!html) {
     return html
   }
-  return DOMPurify.sanitize(html)
+  return DOMPurify.sanitize(html, {FORBID_TAGS: ['style'], FORBID_ATTR: ['style']})
 }
 
 export default sanitizeHtml

--- a/packages/tocco-util/src/html/sanitizeHtml.spec.js
+++ b/packages/tocco-util/src/html/sanitizeHtml.spec.js
@@ -3,62 +3,51 @@ import sanitizeHtml from './sanitizeHtml'
 describe('tocco-util', () => {
   describe('html', () => {
     describe('sanitizeHtml', () => {
-      test(
-        'should remove event handlers from html tags',
-        () => {
-          const dirty = '<img src="X" onLoad="alert(\'You have won a prize!\')">'
-          const clean = '<img src="X">'
-          expect(sanitizeHtml(dirty)).to.equal(clean)
-        }
-      )
-      test(
-        'should close all open tags',
-        () => {
-          const dirty = '<div><span>Hallo'
-          const clean = '<div><span>Hallo</span></div>'
-          expect(sanitizeHtml(dirty)).to.equal(clean)
-        }
-      )
-      test(
-        'should remove single closing tags',
-        () => {
-          const dirty = '</div>Hallo'
-          const clean = 'Hallo'
-          expect(sanitizeHtml(dirty)).to.equal(clean)
-        }
-      )
-      test(
-        'should remove script tags',
-        () => {
-          const dirty = '<div>Hi!<script>alert(\'You have won a prize!\')</script></div>'
-          const clean = '<div>Hi!</div>'
-          expect(sanitizeHtml(dirty)).to.equal(clean)
-        }
-      )
-      test(
-        'should be able to handle null values',
-        () => {
-          const dirty = null
-          const clean = null
-          expect(sanitizeHtml(dirty)).to.equal(clean)
-        }
-      )
-      test(
-        'should be able to handle undefined values',
-        () => {
-          const dirty = undefined
-          const clean = undefined
-          expect(sanitizeHtml(dirty)).to.equal(clean)
-        }
-      )
-      test(
-        'should be able to handle empty strings',
-        () => {
-          const dirty = ''
-          const clean = ''
-          expect(sanitizeHtml(dirty)).to.equal(clean)
-        }
-      )
+      test('should remove event handlers from html tags', () => {
+        const dirty = '<img src="X" onLoad="alert(\'You have won a prize!\')">'
+        const clean = '<img src="X">'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should close all open tags', () => {
+        const dirty = '<div><span>Hallo'
+        const clean = '<div><span>Hallo</span></div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove single closing tags', () => {
+        const dirty = '</div>Hallo'
+        const clean = 'Hallo'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove script tags', () => {
+        const dirty = "<div>Hi!<script>alert('You have won a prize!')</script></div>"
+        const clean = '<div>Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should be able to handle null values', () => {
+        const dirty = null
+        const clean = null
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should be able to handle undefined values', () => {
+        const dirty = undefined
+        const clean = undefined
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should be able to handle empty strings', () => {
+        const dirty = ''
+        const clean = ''
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove style tags', () => {
+        const dirty = '<div>Hi!<style>a {border: 1px solid red;}</style></div>'
+        const clean = '<div>Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove style attributes', () => {
+        const dirty = '<div style="border: 1px solid red;">Hi!</div>'
+        const clean = '<div>Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
     })
   })
 })


### PR DESCRIPTION
Changelog: no styles allowed in rendered HTML
Refs: TOCDEV-4626
Cherry-pick: Up