### PR TITLE
fix(tocco-util): no styles allowed in rendered HTML

### DIFF
--- a/packages/tocco-util/src/html/sanitizeHtml.js
+++ b/packages/tocco-util/src/html/sanitizeHtml.js
@@ -4,7 +4,7 @@ const sanitizeHtml = html => {
   if (!html) {
     return html
   }
-  return DOMPurify.sanitize(html)
+  return DOMPurify.sanitize(html, {FORBID_TAGS: ['style'], FORBID_ATTR: ['style']})
 }
 
 export default sanitizeHtml

--- a/packages/tocco-util/src/html/sanitizeHtml.spec.js
+++ b/packages/tocco-util/src/html/sanitizeHtml.spec.js
@@ -38,6 +38,16 @@ describe('tocco-util', () => {
         const clean = ''
         expect(sanitizeHtml(dirty)).to.equal(clean)
       })
+      test('should remove style tags', () => {
+        const dirty = '<div>Hi!<style>a {border: 1px solid red;}</style></div>'
+        const clean = '<div>Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove style attributes', () => {
+        const dirty = '<div style="border: 1px solid red;">Hi!</div>'
+        const clean = '<div>Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
     })
   })
 })


### PR DESCRIPTION
Changelog: no styles allowed in rendered HTML
Refs: TOCDEV-4626
Cherry-pick: Up