### PR TITLE
feat(widget-utils): add support for ext. event handlers for widgets

### DIFF
--- a/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
+++ b/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
@@ -1,4 +1,4 @@
-import {buildInputFromDom, loadScriptAsync} from './utils'
+import {buildInputFromDom, getEventHandlers, loadScriptAsync} from './utils'
 
 const getWidgetName = container => container.getAttribute('data-tocco-widget')
 
@@ -24,8 +24,9 @@ const bootstrapWidgets = async params => {
       backendUrl,
       ...buildInputFromDom(container)
     }
+    const eventHandlers = getEventHandlers(container)
 
-    window.reactRegistry.render(app, container, '', input, {}, `${backendUrl}/js/tocco-${packageName}/dist/`)
+    window.reactRegistry.render(app, container, '', input, eventHandlers, `${backendUrl}/js/tocco-${packageName}/dist/`)
   })
 }
 

--- a/packages/widget-utils/src/bootstrap/utils.js
+++ b/packages/widget-utils/src/bootstrap/utils.js
@@ -1,3 +1,5 @@
+export const EVENT_HANDLERS_OBJ_NAME = 'customerEventHandlers'
+
 export const snakeToCamel = s => s.replace(/(-\w)/g, m => m[1].toUpperCase())
 
 export const loadScriptAsync = src =>
@@ -30,12 +32,34 @@ export const getBackendUrl = document => {
 }
 
 export const buildInputFromDom = widgetContainer => {
-    const attributes = Array.prototype.slice.call(widgetContainer.attributes)
-    return attributes.reduce(
-      (acc, val) => ({
-        ...acc,
-        [snakeToCamel(val.name.replace('data-', ''))]: transformObjectValue(val.value)
-      }),
-      {}
-    )
+  const attributes = Array.prototype.slice.call(widgetContainer.attributes)
+  return attributes.reduce(
+    (acc, val) => ({
+      ...acc,
+      [snakeToCamel(val.name.replace('data-', ''))]: transformObjectValue(val.value)
+    }),
+    {}
+  )
+}
+
+export const isMapOfFunctions = obj =>
+  obj && Object.keys(obj).length > 0 && typeof obj[Object.keys(obj)[0]] === 'function'
+
+export const getEventHandlers = container => {
+  const handlers = window[EVENT_HANDLERS_OBJ_NAME]
+  if (isMapOfFunctions(handlers)) {
+    return handlers
+  }
+
+  if (handlers) {
+    const id = container.getAttribute('data-id')
+    if (id) {
+      const handlersOfId = handlers[id]
+      if (isMapOfFunctions(handlersOfId)) {
+        return handlersOfId
+      }
+    }
+  }
+
+  return {}
 }

--- a/packages/widget-utils/src/bootstrap/utils.spec.js
+++ b/packages/widget-utils/src/bootstrap/utils.spec.js
@@ -1,4 +1,4 @@
-import {buildInputFromDom, getBackendUrl} from './utils'
+import {EVENT_HANDLERS_OBJ_NAME, buildInputFromDom, getBackendUrl, getEventHandlers} from './utils'
 
 describe('widget-utils', () => {
   describe('bootstrap', () => {
@@ -15,27 +15,80 @@ describe('widget-utils', () => {
     })
 
     describe('buildInputFromDom', () => {
-        test('should build input object from DOM attributes', () => {
-            const container = {
-                attributes: [
-                    {name: 'data-tocco-widget', value: 'entity-browser'},
-                    {name: 'data-entity-name', value: 'User'},
-                    {name: 'style', value: 'color: red;'},
-                    {name: 'data-form-base', value: 'User'},
-                    {name: 'data-memory-history', value: 'true'}
-                ]
-            }
-            expect(buildInputFromDom(container)).to.eql({
-                entityName: 'User',
-                formBase: 'User',
-                memoryHistory: true,
+      test('should build input object from DOM attributes', () => {
+        const container = {
+          attributes: [
+            {name: 'data-tocco-widget', value: 'entity-browser'},
+            {name: 'data-entity-name', value: 'User'},
+            {name: 'style', value: 'color: red;'},
+            {name: 'data-form-base', value: 'User'},
+            {name: 'data-memory-history', value: 'true'}
+          ]
+        }
+        expect(buildInputFromDom(container)).to.eql({
+          entityName: 'User',
+          formBase: 'User',
+          memoryHistory: true,
 
-                // the following two aren't actually needed as input
-                // but they also shouldn't do any harm either
-                toccoWidget: 'entity-browser',
-                style: 'color: red;'
-            })
+          // the following two aren't actually needed as input
+          // but they also shouldn't do any harm either
+          toccoWidget: 'entity-browser',
+          style: 'color: red;'
         })
+      })
+    })
+
+    describe('getEventHandlers', () => {
+      test('should return empty object if global map not defined', () => {
+        delete window[EVENT_HANDLERS_OBJ_NAME]
+        const container = {}
+
+        expect(getEventHandlers(container)).to.eql({})
+      })
+
+      test('should return event handlers if global map is defined (one-dimensional)', () => {
+        window[EVENT_HANDLERS_OBJ_NAME] = {
+          loginSuccess: () => {},
+          resize: () => {}
+        }
+        const container = {}
+
+        expect(getEventHandlers(container)).to.eql(window[EVENT_HANDLERS_OBJ_NAME])
+      })
+
+      test('should return event handlers for id (two-dimensional)', () => {
+        window[EVENT_HANDLERS_OBJ_NAME] = {
+          'my-widget-id': {
+            loginSuccess: () => {},
+            resize: () => {}
+          }
+        }
+        const container = {
+          getAttribute: name => {
+            expect(name).to.eql('data-id')
+            return 'my-widget-id'
+          }
+        }
+
+        expect(getEventHandlers(container)).to.eql(window[EVENT_HANDLERS_OBJ_NAME]['my-widget-id'])
+      })
+
+      test('should return empty object if no handlers defined for widget id', () => {
+        window[EVENT_HANDLERS_OBJ_NAME] = {
+          'my-widget-id': {
+            loginSuccess: () => {},
+            resize: () => {}
+          }
+        }
+        const container = {
+          getAttribute: name => {
+            expect(name).to.eql('data-id')
+            return 'my-other-widget-id'
+          }
+        }
+
+        expect(getEventHandlers(container)).to.eql({})
+      })
     })
   })
 })


### PR DESCRIPTION
Similar to the theme, website builders can define the event
handlers in a map called `customerEventHandlers` on the global
window scope. If this map is defined, it is taken into account
automatically.

Example:

HTML:
`<div data-id="myWidgetId" data-tocco-widget="login"></div>`

JS:
```
window.customerEventHandlers = {
  myWidgetId: {
    loginSuccess: () => { console.log('login was successful!') }
  }
}
```

Refs: TOCDEV-4739
Changelog: add support for ext. event handlers for widgets