### PR TITLE
style(admin): fix clickability of expand/collapse all in module menu

### DIFF
--- a/packages/admin/src/components/Navigation/StyledComponents.js
+++ b/packages/admin/src/components/Navigation/StyledComponents.js
@@ -91,9 +91,10 @@ export const StyledMenuWrapper = styled.div`
 
 export const StyledMenuButtonsWrapper = styled.div`
   position: absolute;
+  right: ${scale.space(0.6)};
+  z-index: 1;
   display: flex;
   justify-content: flex-end;
-  width: calc(100% - 2 * ${scale.space(0.6)}); // subtract StyledMenuWrapper padding
   padding: 0;
 `
 


### PR DESCRIPTION
- When user scrolled down, the expand/collapse all were positioned
  behind the module menu items (the buttons were still visible, but
  not clickable anymore)
- To fix the issue, `z-index` was increased to `1` (now, the
  expand/collapse all buttons are on top of the menu items)
- Now in turn the expand/collapse buttons container covered the
  menu items, which wasn't good either. To avoid that, the `width`
  property was removed, so that the button container doesn't
  take up the whole width of the menu items container anymore
  (but rather only the space it actually needs). Instead, the `right`
  property is used to position it correctly at the right border of
  the menu items container.

Cherry-pick: Up
Refs: TOCDEV-4731
Changelog: clickability fixed of expand/collapse all in module menu