### PR TITLE
fix(app-extensions): fix (strange) validation error in location fields

### DIFF
--- a/packages/app-extensions/src/field/editableTypeConfigs/location.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/location.js
@@ -24,7 +24,8 @@ export default {
     const onChange = locationObject => {
       for (const key in locationMapping) {
         if (locationMapping[key] && locationObject[key] !== undefined) {
-          formData.changeFieldValue(formName, locationMapping[key], locationObject[key])
+          const value = locationObject[key] !== null ? locationObject[key] : ''
+          formData.changeFieldValue(formName, locationMapping[key], value)
         }
       }
     }

--- a/packages/app-extensions/src/field/editableTypeConfigs/location.spec.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/location.spec.js
@@ -1,0 +1,56 @@
+import location from './location'
+
+describe('app-extensions', () => {
+  describe('field', () => {
+    describe('editableTypeConfigs', () => {
+      describe('location', () => {
+        describe('getEvents', () => {
+          describe('onChange', () => {
+            const testOnChange = (
+              locationObject,
+              expectedChangeFieldValueCalls
+            ) => {
+              const formField = {
+                locationMapping: {
+                  district: 'admincode2'
+                }
+              }
+              const formName = 'test-form-name'
+              const changeFieldValue = jest.fn()
+              const formData = {
+                changeFieldValue
+              }
+
+              const {onChange} = location.getEvents({
+                formField,
+                formName,
+                formData
+              })
+              onChange(locationObject)
+
+              expect(changeFieldValue.mock.calls).to.eql(
+                expectedChangeFieldValueCalls
+              )
+            }
+
+            test('should set location property according to location mapping', () =>
+              testOnChange(
+                {
+                  district: 'Zürich'
+                },
+                [['test-form-name', 'admincode2', 'Zürich']]
+              ))
+
+            test('should set empty string if location property is null', () =>
+              testOnChange(
+                {
+                  district: null
+                },
+                [['test-form-name', 'admincode2', '']]
+              ))
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
The string fields in the location mapping are non nullable. Therefore,
we need to set an empty string instead of `null` if the location object
contains `null` as value for them.

Refs: TOCDEV-4633
Cherry-pick: Up
Changelog: validation errors fixed for location fields