### PR TITLE
chore: fix tocco-* dependencies

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "js-cookie": "^3.0.1",
     "path-to-regexp": "^3.0.0",
-    "react-burger-menu": "^2.6.11",
+    "react-burger-menu": "^2.6.11"
+  },
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-copy": "*",
     "tocco-dashboard": "*",
@@ -23,12 +25,10 @@
     "tocco-merge": "*",
     "tocco-resource-scheduler": "*",
     "tocco-sso-login": "*",
+    "tocco-test-util": "*",
     "tocco-two-factor-connector": "*",
     "tocco-ui": "*",
     "tocco-user-qr-action": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/app-extensions/package.json
+++ b/packages/app-extensions/package.json
@@ -7,12 +7,12 @@
   "dependencies": {
     "es6-error": "^4.1.1",
     "redux-thunk": "^2.4.1",
-    "tocco-theme": "*",
-    "tocco-ui": "*",
-    "tocco-util": "*",
     "validator": "10.0.0"
   },
   "devDependencies": {
-    "tocco-test-util": "*"
+    "tocco-test-util": "*",
+    "tocco-theme": "*",
+    "tocco-ui": "*",
+    "tocco-util": "*"
   }
 }

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -8,10 +8,9 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=copy",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -8,13 +8,11 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=dashboard",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-entity-list": "*",
+    "tocco-test-util": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/delete/package.json
+++ b/packages/delete/package.json
@@ -8,12 +8,10 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=delete",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
+    "tocco-test-util": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/devcon/package.json
+++ b/packages/devcon/package.json
@@ -7,10 +7,9 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=devcon",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/docs-browser/package.json
+++ b/packages/docs-browser/package.json
@@ -7,13 +7,12 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=docs-browser",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-delete": "*",
     "tocco-entity-detail": "*",
     "tocco-entity-list": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/entity-browser/package.json
+++ b/packages/entity-browser/package.json
@@ -7,17 +7,15 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=entity-browser",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-delete": "*",
     "tocco-entity-detail": "*",
     "tocco-entity-list": "*",
     "tocco-input-edit": "*",
+    "tocco-test-util": "*",
     "tocco-ui": "*",
     "tocco-user-qr-action": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/entity-detail/package.json
+++ b/packages/entity-detail/package.json
@@ -8,14 +8,12 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=entity-detail",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-entity-list": "*",
     "tocco-simple-form": "*",
+    "tocco-test-util": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/entity-list/package.json
+++ b/packages/entity-list/package.json
@@ -9,13 +9,13 @@
     "prepublish": "npm run compile:prod"
   },
   "dependencies": {
-    "react-split": "^2.0.7",
-    "tocco-app-extensions": "*",
-    "tocco-simple-form": "*",
-    "tocco-ui": "*",
-    "tocco-util": "*"
+    "react-split": "^2.0.7"
   },
   "devDependencies": {
-    "tocco-test-util": "*"
+    "tocco-app-extensions": "*",
+    "tocco-simple-form": "*",
+    "tocco-test-util": "*",
+    "tocco-ui": "*",
+    "tocco-util": "*"
   }
 }

--- a/packages/input-edit/package.json
+++ b/packages/input-edit/package.json
@@ -7,11 +7,10 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=input-edit",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-simple-form": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/installation-delta-action/package.json
+++ b/packages/installation-delta-action/package.json
@@ -7,10 +7,9 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=installation-delta-action",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -8,13 +8,13 @@
     "prepublish": "npm run compile"
   },
   "dependencies": {
-    "react-google-recaptcha": "^2.1.0",
+    "react-google-recaptcha": "^2.1.0"
+  },
+  "devDependencies": {
     "tocco-app-extensions": "*",
+    "tocco-test-util": "*",
     "tocco-two-factor-connector": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -7,10 +7,9 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=merge",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/resource-scheduler/package.json
+++ b/packages/resource-scheduler/package.json
@@ -8,12 +8,13 @@
     "prepublish": "npm run compile:prod"
   },
   "dependencies": {
-    "react-split-pane": "^0.1.84",
+    "react-split-pane": "^0.1.84"
+  },
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-entity-list": "*",
     "tocco-scheduler": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -14,12 +14,12 @@
     "@fullcalendar/interaction": "^5.5.0",
     "@fullcalendar/react": "^5.5.0",
     "@fullcalendar/resource-timeline": "^5.5.0",
-    "tocco-app-extensions": "*",
-    "tocco-ui": "*",
-    "tocco-util": "*",
     "twix": "^1.2.1"
   },
   "devDependencies": {
-    "tocco-test-util": "*"
+    "tocco-app-extensions": "*",
+    "tocco-test-util": "*",
+    "tocco-ui": "*",
+    "tocco-util": "*"
   }
 }

--- a/packages/simple-form/package.json
+++ b/packages/simple-form/package.json
@@ -8,12 +8,10 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=simple-form",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
+    "tocco-test-util": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/sso-login/package.json
+++ b/packages/sso-login/package.json
@@ -7,12 +7,10 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=sso-login",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
+    "tocco-test-util": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }

--- a/packages/tocco-test-util/package.json
+++ b/packages/tocco-test-util/package.json
@@ -8,7 +8,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-theme": "*"
   }
 }

--- a/packages/tocco-ui/package.json
+++ b/packages/tocco-ui/package.json
@@ -29,12 +29,12 @@
     "react-quill": "^1.3.5",
     "react-select": "^5.1.0",
     "react-simple-focus-within": "^1.1.4",
-    "react-tether": "^1.0.2",
-    "tocco-theme": "*",
-    "tocco-util": "*"
+    "react-tether": "^1.0.2"
   },
   "devDependencies": {
     "fuse.js": "^6.4.6",
-    "tocco-test-util": "*"
+    "tocco-test-util": "*",
+    "tocco-theme": "*",
+    "tocco-util": "*"
   }
 }

--- a/packages/two-factor-connector/package.json
+++ b/packages/two-factor-connector/package.json
@@ -7,10 +7,9 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=two-factor-connector",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/user-qr-action/package.json
+++ b/packages/user-qr-action/package.json
@@ -8,10 +8,9 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=user-qr-action",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/plop/templates/package/package.json
+++ b/plop/templates/package/package.json
@@ -7,13 +7,11 @@
     "compile:prod": "cd ../../ && npm run compile:prod -- --package={{kebabCase package}}",
     "prepublish": "npm run compile:prod"
   },
-  "dependencies": {
+  "devDependencies": {
     "tocco-app-extensions": "*",
+    "tocco-test-util": "*",
     "tocco-theme": "*",
     "tocco-ui": "*",
     "tocco-util": "*"
-  },
-  "devDependencies": {
-    "tocco-test-util": "*"
   }
 }


### PR DESCRIPTION
- lerna (or tocco-*) packages has to be in `devDependencies`
- dependent tocco packages are already bundled inside package
- therefore tocco packages do not have to be installed as normal
  dependencies

Changelog: fix tocco-* dependencies
Ref: TOCDEV-4640