### PR TITLE
fix(app-extensions): prevent null pointer in document field formatter

### DIFF
--- a/packages/app-extensions/src/field/formattedTypeConfigs/document.js
+++ b/packages/app-extensions/src/field/formattedTypeConfigs/document.js
@@ -5,9 +5,14 @@ export default {
     tooltips: ['Resource'],
     navigationStrategy: true
   }),
-  getOptions: ({formData}) => ({
-    downloadTitle: formData.intl.formatMessage({id: 'client.component.upload.downloadTitle'}),
-    tooltips: _get(formData.tooltips, 'Resource', null),
-    loadTooltip: id => formData.loadTooltip('Resource', id)
-  })
+  getOptions: ({formData}) =>
+    formData
+      ? {
+          downloadTitle: formData.intl.formatMessage({
+            id: 'client.component.upload.downloadTitle'
+          }),
+          tooltips: _get(formData.tooltips, 'Resource', null),
+          loadTooltip: id => formData.loadTooltip('Resource', id)
+        }
+      : {}
 }


### PR DESCRIPTION
If merge action was opened for 2 users with document fields, the action
crashed because of a null pointer in `getOptions`, because `formData`
is not available in the table (to compare the field values) in the merge
action (was caused by TOCDEV-4474, commit 1e4d02a).

Refs: TOCDEV-4646
Cherry-pick: Up
Changelog: null pointer fixed in document field formatter (resp. merge action)