### PR TITLE
refactor(tocco-ui): use throttle for select

### DIFF
--- a/packages/tocco-ui/src/Select/Select.js
+++ b/packages/tocco-ui/src/Select/Select.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
-import React, {useRef} from 'react'
+import React, {useRef, useCallback} from 'react'
 import ReactSelect from 'react-select'
-import _debounce from 'lodash/debounce'
+import _throttle from 'lodash/throttle'
 import {withTheme} from 'styled-components'
 
 import ClearIndicator from './ClearIndicator'
@@ -18,8 +18,6 @@ import {
   StyledReactSelectOuterWrapper,
   StyledReactSelectInnerWrapper
 } from './StyledComponents'
-
-const SEARCH_DEBOUNCE = 300
 
 /**
  * To select between multiple options. Loading of options and so on are remotely controlled.
@@ -52,7 +50,7 @@ const Select = ({
 
   const handleInputChange = (searchTerm, event) => {
     if (searchOptions && searchTerm) {
-      debouncedSearchOptions(searchTerm)
+      throttledSearchOptions(searchTerm)
     }
     if (searchTerm === '' && event.action === 'input-change') {
       fetchOptions()
@@ -69,10 +67,10 @@ const Select = ({
     selectComponent.current.focus()
   }
 
-  const debouncedSearchOptions = searchOptions ? _debounce(searchOptions, SEARCH_DEBOUNCE) : () => {}
+  const throttledSearchOptions = useCallback(_throttle(searchOptions, 800, {trailing: true}), [])
 
-  const wrapperWidth = selectWrapper.current ? selectWrapper.current.clientWidth : 300
-  const wrapperHeight = selectWrapper.current ? selectWrapper.current.clientHeight : 35
+  const wrapperWidth = selectWrapper.current?.clientWidth || 300
+  const wrapperHeight = selectWrapper.current?.clientHeight || 35
 
   return (
     <StyledReactSelectOuterWrapper
@@ -139,6 +137,10 @@ const ItemPropType = PropTypes.shape({
   ]).isRequired,
   display: PropTypes.string
 })
+
+Select.defaultProps = {
+  searchOptions: () => {}
+}
 
 Select.propTypes = {
   /**
@@ -213,7 +215,7 @@ Select.propTypes = {
    */
   immutable: PropTypes.bool,
   /**
-   * Id of outter element
+   * Id of outer element
    */
   id: PropTypes.string,
   /**


### PR DESCRIPTION
Cherry-pick: Up
Refs: TOCDEV-4131
Changelog: use throttle for select instead of debounce to prevent flickering of dropdown