### PR TITLE
refactor(widget-utils): prefix global objects with `tocco`

### DIFF
--- a/packages/widget-utils/README.md
+++ b/packages/widget-utils/README.md
@@ -34,3 +34,17 @@ input params. Declare them in `snake-case`, they are transformed to `camelCase` 
 ></div>
 <script src="https://${customer.tocco.ch}/js/tocco-widget-utils/dist/bootstrap.js"></script>
 ```
+
+### Theme
+
+A theme can be configured by defining a global theme object on `window.toccoTheme`.
+```js
+window.toccoTheme = {
+  colors: {
+    primary: '#BB8800'
+  },
+  fontSize: {
+    base: 1.3
+  }
+}
+```

--- a/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
+++ b/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
@@ -1,13 +1,14 @@
-import {buildInputFromDom, getEventHandlers, loadScriptAsync} from './utils'
+import {ATTRIBUTE_PACKAGE, ATTRIBUTE_WIDGET} from './constants'
+import {buildInputFromDom, getEventHandlers, getTheme, loadScriptAsync} from './utils'
 
-const getWidgetName = container => container.getAttribute('data-tocco-widget')
+const getWidgetName = container => container.getAttribute(ATTRIBUTE_WIDGET)
 
-const getPackageName = container => container.getAttribute('data-tocco-package') || getWidgetName(container)
+const getPackageName = container => container.getAttribute(ATTRIBUTE_PACKAGE) || getWidgetName(container)
 
 const bootstrapWidgets = async params => {
   const {backendUrl} = params
 
-  const widgetContainerNodeList = document.querySelectorAll('[data-tocco-widget]')
+  const widgetContainerNodeList = document.querySelectorAll(`[${ATTRIBUTE_WIDGET}]`)
   const widgetContainers = Array.prototype.slice.call(widgetContainerNodeList)
   const packages = [...new Set(widgetContainers.map(container => getPackageName(container)))]
 
@@ -20,8 +21,10 @@ const bootstrapWidgets = async params => {
   widgetContainers.forEach(container => {
     const app = getWidgetName(container)
     const packageName = getPackageName(container)
+    const customTheme = getTheme()
     const input = {
       backendUrl,
+      ...(customTheme ? {customTheme} : {}),
       ...buildInputFromDom(container)
     }
     const eventHandlers = getEventHandlers(container)

--- a/packages/widget-utils/src/bootstrap/bootstrapWidgets.spec.js
+++ b/packages/widget-utils/src/bootstrap/bootstrapWidgets.spec.js
@@ -1,0 +1,146 @@
+import {mount} from 'enzyme'
+import React from 'react'
+
+import bootstrapWidgets from './bootstrapWidgets'
+import {EVENT_HANDLERS_OBJ_NAME, THEME_OBJ_NAME} from './constants'
+import * as utils from './utils'
+
+let stub
+let wrapper
+
+describe('widget-utils', () => {
+  describe('boostrap', () => {
+    describe('bootstrapWidgets', () => {
+      beforeEach(() => {
+        stub = sinon.stub(utils, 'loadScriptAsync').returns({})
+      })
+
+      afterEach(() => {
+        if (stub) {
+          stub.restore()
+        }
+
+        if (wrapper) {
+          wrapper.detach()
+        }
+
+        delete window[THEME_OBJ_NAME]
+        delete window[EVENT_HANDLERS_OBJ_NAME]
+      })
+
+      test('should initialize and render widget', async () => {
+        const renderSpy = sinon.spy()
+        window.reactRegistry = {
+          render: renderSpy
+        }
+
+        wrapper = mount(<div data-tocco-widget="entity-browser" data-widget-param="test"></div>, {
+          attachTo: document.body
+        })
+        const container = wrapper.getDOMNode()
+
+        const backendUrl = 'http://localhost:8080'
+        await bootstrapWidgets({backendUrl})
+
+        const expectedInput = {
+          backendUrl,
+          toccoWidget: 'entity-browser',
+          widgetParam: 'test'
+        }
+        expect(renderSpy).to.have.been.calledWith(
+          'entity-browser',
+          container,
+          '',
+          expectedInput,
+          {},
+          'http://localhost:8080/js/tocco-entity-browser/dist/'
+        )
+      })
+
+      test('should apply tocco theme as input parameter', async () => {
+        const renderSpy = sinon.spy()
+        window.reactRegistry = {
+          render: renderSpy
+        }
+        window[THEME_OBJ_NAME] = {fontSize: 30}
+
+        wrapper = mount(<div data-tocco-widget="entity-browser"></div>, {attachTo: document.body})
+        const container = wrapper.getDOMNode()
+
+        const backendUrl = 'http://localhost:8080'
+        await bootstrapWidgets({backendUrl})
+
+        const expectedInput = {
+          backendUrl,
+          customTheme: window[THEME_OBJ_NAME],
+          toccoWidget: 'entity-browser'
+        }
+        expect(renderSpy).to.have.been.calledWith(
+          'entity-browser',
+          container,
+          '',
+          expectedInput,
+          {},
+          'http://localhost:8080/js/tocco-entity-browser/dist/'
+        )
+      })
+
+      test('should apply event handlers', async () => {
+        const renderSpy = sinon.spy()
+        window.reactRegistry = {
+          render: renderSpy
+        }
+        window[EVENT_HANDLERS_OBJ_NAME] = {someEvent: () => {}}
+
+        wrapper = mount(<div data-tocco-widget="entity-browser"></div>, {attachTo: document.body})
+        const container = wrapper.getDOMNode()
+
+        const backendUrl = 'http://localhost:8080'
+        await bootstrapWidgets({backendUrl})
+
+        const expectedInput = {
+          backendUrl,
+          toccoWidget: 'entity-browser'
+        }
+        expect(renderSpy).to.have.been.calledWith(
+          'entity-browser',
+          container,
+          '',
+          expectedInput,
+          window[EVENT_HANDLERS_OBJ_NAME],
+          'http://localhost:8080/js/tocco-entity-browser/dist/'
+        )
+      })
+
+      test('should consider package name', async () => {
+        const renderSpy = sinon.spy()
+        window.reactRegistry = {
+          render: renderSpy
+        }
+        window[EVENT_HANDLERS_OBJ_NAME] = {someEvent: () => {}}
+
+        wrapper = mount(<div data-tocco-widget="passwort-change" data-tocco-package="login"></div>, {
+          attachTo: document.body
+        })
+        const container = wrapper.getDOMNode()
+
+        const backendUrl = 'http://localhost:8080'
+        await bootstrapWidgets({backendUrl})
+
+        const expectedInput = {
+          backendUrl,
+          toccoWidget: 'passwort-change',
+          toccoPackage: 'login'
+        }
+        expect(renderSpy).to.have.been.calledWith(
+          'passwort-change',
+          container,
+          '',
+          expectedInput,
+          window[EVENT_HANDLERS_OBJ_NAME],
+          'http://localhost:8080/js/tocco-login/dist/'
+        )
+      })
+    })
+  })
+})

--- a/packages/widget-utils/src/bootstrap/constants.js
+++ b/packages/widget-utils/src/bootstrap/constants.js
@@ -1,0 +1,5 @@
+export const EVENT_HANDLERS_OBJ_NAME = 'toccoEventHandlers'
+export const THEME_OBJ_NAME = 'toccoTheme'
+export const ATTRIBUTE_ID = 'data-id'
+export const ATTRIBUTE_WIDGET = 'data-tocco-widget'
+export const ATTRIBUTE_PACKAGE = 'data-tocco-package'

--- a/packages/widget-utils/src/bootstrap/utils.js
+++ b/packages/widget-utils/src/bootstrap/utils.js
@@ -1,4 +1,4 @@
-export const EVENT_HANDLERS_OBJ_NAME = 'customerEventHandlers'
+import {ATTRIBUTE_ID, EVENT_HANDLERS_OBJ_NAME, THEME_OBJ_NAME} from './constants'
 
 export const snakeToCamel = s => s.replace(/(-\w)/g, m => m[1].toUpperCase())
 
@@ -42,6 +42,15 @@ export const buildInputFromDom = widgetContainer => {
   )
 }
 
+export const getTheme = () => {
+  const theme = window[THEME_OBJ_NAME]
+  if (theme && typeof theme === 'object') {
+    return theme
+  }
+
+  return undefined
+}
+
 export const isMapOfFunctions = obj =>
   obj && Object.keys(obj).length > 0 && typeof obj[Object.keys(obj)[0]] === 'function'
 
@@ -52,7 +61,7 @@ export const getEventHandlers = container => {
   }
 
   if (handlers) {
-    const id = container.getAttribute('data-id')
+    const id = container.getAttribute(ATTRIBUTE_ID)
     if (id) {
       const handlersOfId = handlers[id]
       if (isMapOfFunctions(handlersOfId)) {

--- a/packages/widget-utils/src/bootstrap/utils.spec.js
+++ b/packages/widget-utils/src/bootstrap/utils.spec.js
@@ -1,4 +1,5 @@
-import {EVENT_HANDLERS_OBJ_NAME, buildInputFromDom, getBackendUrl, getEventHandlers} from './utils'
+import {EVENT_HANDLERS_OBJ_NAME, THEME_OBJ_NAME} from './constants'
+import {buildInputFromDom, getBackendUrl, getEventHandlers, getTheme} from './utils'
 
 describe('widget-utils', () => {
   describe('bootstrap', () => {
@@ -35,6 +36,26 @@ describe('widget-utils', () => {
           toccoWidget: 'entity-browser',
           style: 'color: red;'
         })
+      })
+    })
+
+    describe('getTheme', () => {
+      test('should return undefined if global theme is not defined', () => {
+        delete window[THEME_OBJ_NAME]
+
+        expect(getTheme()).to.be.undefined
+      })
+
+      test('should return undefined if global theme is not an object', () => {
+        window[THEME_OBJ_NAME] = 'abc'
+
+        expect(getTheme()).to.be.undefined
+      })
+
+      test('should return theme object', () => {
+        window[THEME_OBJ_NAME] = {fontSize: 30}
+
+        expect(getTheme()).to.eql(window[THEME_OBJ_NAME])
       })
     })
 


### PR DESCRIPTION
- rename `customerEventHandlers` to `toccoEventHandlers`
- rename `customerTheme` to `toccoTheme`
- add theme handling to script

Changelog: prefix global objects with `tocco`
Refs: TOCDEV-4749