### PR TITLE
fix: do not remove css after page transition

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -40,7 +40,10 @@ module.exports = function (api) {
         {
           displayName: true,
           fileName: false,
-          namespace: 'Tocco'
+          namespace: 'Tocco',
+          ssr: false,
+          transpileTemplateLiterals: false,
+          minify: false
         }
       ],
       'lodash'


### PR DESCRIPTION
- styled-components babel plugin
  removed css after page transition
- do not minify to have all css applied properly

Refs: TOCDEV-388, TOCDEV-4758
Changelog: do not remove css after page transition