### PR TITLE
fix(tocco-util): allow whitelisted inline css for nice tooltips

### DIFF
--- a/packages/tocco-util/src/html/sanitizeHtml.js
+++ b/packages/tocco-util/src/html/sanitizeHtml.js
@@ -1,10 +1,43 @@
 import DOMPurify from 'dompurify'
 
+const allowedCssProperties = ['border', 'border-spacing', 'padding', 'margin', 'text-align', 'width']
+
+const isCssFunction = value => /\w+\(/.test(value)
+
+const sanitizeInlineStyle = styles =>
+  allowedCssProperties
+    .map(prop => {
+      const value = styles[prop]
+      return value && typeof value === 'string' && !isCssFunction(value) ? `${prop}:${value};` : null
+    })
+    .filter(Boolean)
+    .join('')
+
+const handleAfterSanitizeAttributes = node => {
+  if (node && typeof node.hasAttribute === 'function' && node.hasAttribute('style')) {
+    const sanitizedStyle = sanitizeInlineStyle(node.style)
+    if (sanitizedStyle) {
+      node.setAttribute('style', sanitizedStyle)
+    } else {
+      node.removeAttribute('style')
+    }
+  }
+
+  return node
+}
+
+DOMPurify.addHook('afterSanitizeAttributes', handleAfterSanitizeAttributes)
+
+/**
+ * Does not allow javascript and styles, except some whitelisted inline styles.
+ * @param {*} html
+ * @returns sanitized html
+ */
 const sanitizeHtml = html => {
   if (!html) {
     return html
   }
-  return DOMPurify.sanitize(html, {FORBID_TAGS: ['style'], FORBID_ATTR: ['style']})
+  return DOMPurify.sanitize(html, {FORBID_TAGS: ['style']})
 }
 
 export default sanitizeHtml

--- a/packages/tocco-util/src/html/sanitizeHtml.spec.js
+++ b/packages/tocco-util/src/html/sanitizeHtml.spec.js
@@ -44,8 +44,28 @@ describe('tocco-util', () => {
         expect(sanitizeHtml(dirty)).to.equal(clean)
       })
       test('should remove style attributes', () => {
-        const dirty = '<div style="border: 1px solid red;">Hi!</div>'
+        const dirty = '<div style="border:1px solid red;">Hi!</div>'
+        const clean = '<div style="border:1px solid red;">Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove invalid style properties', () => {
+        const dirty = '<div style="border:1px solid red;position:absolute;">Hi!</div>'
+        const clean = '<div style="border:1px solid red;">Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove style attributes when no style property is valid', () => {
+        const dirty = '<div style="position:absolute;">Hi!</div>'
         const clean = '<div>Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should remove css functions', () => {
+        const dirty = '<div style="width:calc(100% - 50px);">Hi!</div>'
+        const clean = '<div>Hi!</div>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should ignore malformed css', () => {
+        const dirty = '<div style="border:1px;width:100%">Hi!</div>'
+        const clean = '<div style="border:1px;width:100%;">Hi!</div>'
         expect(sanitizeHtml(dirty)).to.equal(clean)
       })
     })


### PR DESCRIPTION
- css can be dangerous and were not allowed
- however some inline css is used for nice tooltips
- to still support those a defined set of inline css is valid

Changelog: allow whitelisted inline css for nice tooltips
Refs: TOCDEV-4767
Cherry-pick: Up