### PR TITLE
feat(widget-utils): run bootstrap script only once

### DIFF
--- a/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
+++ b/packages/widget-utils/src/bootstrap/bootstrapWidgets.js
@@ -1,7 +1,9 @@
-import {ATTRIBUTE_WIDGET_KEY, ERROR_CODE_INVALID_DOMAIN} from './constants'
+import {consoleLogger} from 'tocco-util'
+
+import {ATTRIBUTE_WIDGET_KEY, BOOTSTRAP_SCRIPT_OBJ_NAME, ERROR_CODE_INVALID_DOMAIN} from './constants'
 import * as remoteLogger from './remoteLogger'
 import {executeRequest, enhanceExtractedBody} from './requests'
-import {attachMethods, getEventHandlers, getTheme, loadScriptAsync} from './utils'
+import {attachMethods, getEventHandlers, getTheme, getVersion, loadScriptAsync} from './utils'
 
 const getWidgetKey = container => container.getAttribute(ATTRIBUTE_WIDGET_KEY)
 
@@ -60,7 +62,35 @@ const initializeWidget = async (backendUrl, container) => {
   }
 }
 
+/**
+ * Widgets should get initialized only once.
+ * Sets global variable to block other embedded bootstrap scripts from execution.
+ * Only the first bootstrap script gets executed.
+ *
+ * @returns boolean to indicate wether script can be executed
+ */
+const initializeBootstrap = () => {
+  if (window[BOOTSTRAP_SCRIPT_OBJ_NAME]) {
+    consoleLogger.log('tocco-widget-utils - bootstrap script is already initialized')
+    return false
+  }
+
+  const version = getVersion()
+
+  window[BOOTSTRAP_SCRIPT_OBJ_NAME] = {
+    version
+  }
+  consoleLogger.log(`tocco-widget-utils - v${version} - bootstrap`)
+
+  return true
+}
+
 const bootstrapWidgets = async params => {
+  const canExecute = initializeBootstrap()
+  if (!canExecute) {
+    return
+  }
+
   const {backendUrl} = params
 
   const widgetContainerNodeList = document.querySelectorAll(`[${ATTRIBUTE_WIDGET_KEY}]`)

--- a/packages/widget-utils/src/bootstrap/constants.js
+++ b/packages/widget-utils/src/bootstrap/constants.js
@@ -1,3 +1,4 @@
+export const BOOTSTRAP_SCRIPT_OBJ_NAME = 'toccoBootstrap'
 export const EVENT_HANDLERS_OBJ_NAME = 'toccoEventHandlers'
 export const THEME_OBJ_NAME = 'toccoTheme'
 export const METHODS_OBJ_NAME = 'toccoMethods'

--- a/packages/widget-utils/src/bootstrap/index.js
+++ b/packages/widget-utils/src/bootstrap/index.js
@@ -1,13 +1,16 @@
 import bootstrapWidgets from './bootstrapWidgets'
 import {loadScriptAsync, getBackendUrl} from './utils'
 
-;(async () => {
+;(() => {
   const backendUrl = getBackendUrl(document)
 
   const params = {
     backendUrl
   }
 
-  await loadScriptAsync(`${backendUrl}/nice2/javascript/nice2-react.release.js`)
-  await bootstrapWidgets(params)
+  // guarantee to initalize all widgets on the page
+  document.addEventListener('DOMContentLoaded', async () => {
+    await loadScriptAsync(`${backendUrl}/nice2/javascript/nice2-react.release.js`)
+    await bootstrapWidgets(params)
+  })
 })()

--- a/packages/widget-utils/src/bootstrap/utils.js
+++ b/packages/widget-utils/src/bootstrap/utils.js
@@ -89,3 +89,8 @@ export const attachMethods = (container, methods) => {
     }
   }
 }
+
+export const getVersion = () => {
+  const json = require('../../package.json')
+  return json.version
+}


### PR DESCRIPTION
- it can happen that the bootstrap script gets added multiple
times on a page
- the widgets should get initialized only once to
prevent issues and strange behaviours

Changelog: run bootstrap script only once
Refs: TOCDEV-4804