### PR TITLE
fix(tocco-ui): fix display of durations

### DIFF
--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.js
@@ -1,29 +1,27 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {FormattedDate} from 'react-intl'
 import moment from 'moment'
 
 import Typography from '../../Typography'
 
 const DurationFormatter = props => {
   const milliSeconds = parseInt(props.value)
-  const date = new Date(2000, 1, 1, 0, 0, 0, milliSeconds)
-  const durationIsoMs = moment(date).format(moment.HTML5_FMT.TIME_MS)
-  const durationIsoS = moment(date).format(moment.HTML5_FMT.TIME_SECONDS)
-  return (
-    <Typography.Time
-      dateTime={durationIsoMs}
-      title={durationIsoS}
-    >
-      <FormattedDate
-        value={date}
-        hour="2-digit"
-        minute="2-digit"
-        second="2-digit"
-        hour12={false}
-      />
-    </Typography.Time>
-  )
+  const duration = moment.duration(milliSeconds)
+  const durationString = joinDurationParts([duration.asHours(), duration.minutes(), duration.seconds()])
+  const milliSecondString = `${durationString}.${removeDecimals(duration.milliseconds())}`
+  return <Typography.Time
+    dateTime={milliSecondString}
+    title={durationString}>
+    {durationString}
+  </Typography.Time>
+}
+
+const joinDurationParts = parts => {
+  return parts.map(removeDecimals).join(':')
+}
+
+const removeDecimals = number => {
+  return number.toFixed(0).padStart(2, '0')
 }
 
 DurationFormatter.propTypes = {

--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/DurationFormatter.spec.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import {mount} from 'enzyme'
-import {IntlProvider} from 'react-intl'
 
 import DurationFormatter from './DurationFormatter'
 
@@ -13,12 +12,21 @@ describe('tocco-ui', () => {
         test('should format value', () => {
           const durationMilliseconds = 83000
 
-          const durationFormatedS = '00:01:23'
+          const durationFormatted = '00:01:23'
 
-          const wrapper = mount(<IntlProvider locale="de"><DurationFormatter
-            value={durationMilliseconds}/></IntlProvider>)
+          const wrapper = mount(<DurationFormatter value={durationMilliseconds}/>)
 
-          expect(wrapper.text().replace(leftToRightMark, '')).to.equal(durationFormatedS)
+          expect(wrapper.text().replace(leftToRightMark, '')).to.equal(durationFormatted)
+        })
+
+        test('should handle 24 hour overflow', () => {
+          const durationMilliseconds = 90083000
+
+          const durationFormatted = '25:01:23'
+
+          const wrapper = mount(<DurationFormatter value={durationMilliseconds}/>)
+
+          expect(wrapper.text().replace(leftToRightMark, '')).to.equal(durationFormatted)
         })
       })
     })


### PR DESCRIPTION
Refs: TOCDEV-4762
Changelog: Display durations as hh:mm:ss consistently instead of like a timestamp