### PR TITLE
fix(tocco-ui): fix display of durations

### DIFF
--- a/packages/tocco-util/src/date/utils.js
+++ b/packages/tocco-util/src/date/utils.js
@@ -11,7 +11,7 @@ export const millisecondsToDuration = ms => {
 
   const seconds = roundDecimalPlaces((ms / 1000) % 60, 3)
   const minutes = parseInt((ms / (1000 * 60)) % 60)
-  const hours = parseInt((ms / (1000 * 60 * 60)) % 24)
+  const hours = parseInt((ms / (1000 * 60 * 60)))
   return {
     hours,
     minutes,

--- a/packages/tocco-util/src/date/utils.spec.js
+++ b/packages/tocco-util/src/date/utils.spec.js
@@ -16,8 +16,8 @@ describe('tocco-util', () => {
         })
 
         test('should handle hour overflow', () => {
-          const result = {hours: 25, minutes: 1, seconds: 22}
-          const milliSeconds = 90083000
+          const result = {hours: 25, minutes: 1, seconds: 23.036}
+          const milliSeconds = 90083036
           expect(millisecondsToDuration(milliSeconds)).to.be.eql(result)
         })
       })

--- a/packages/tocco-util/src/date/utils.spec.js
+++ b/packages/tocco-util/src/date/utils.spec.js
@@ -14,6 +14,12 @@ describe('tocco-util', () => {
           const zeroTimeObject = {hours: '', minutes: '', seconds: ''}
           expect(millisecondsToDuration()).to.be.eql(zeroTimeObject)
         })
+
+        test('should handle hour overflow', () => {
+          const result = {hours: 25, minutes: 1, seconds: 22}
+          const milliSeconds = 90083000
+          expect(millisecondsToDuration(milliSeconds)).to.be.eql(result)
+        })
       })
 
       describe('formatDuration', () => {


### PR DESCRIPTION
Refs: TOCDEV-4762
Changelog: Display overflowing hours in durations