### PR TITLE
feat(entity-list): auto focus basic search form

### DIFF
--- a/packages/entity-list/src/components/BasicSearchForm/BasicSearchForm.js
+++ b/packages/entity-list/src/components/BasicSearchForm/BasicSearchForm.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, {useRef} from 'react'
 import {reduxForm} from 'redux-form'
 import {Ball} from 'tocco-ui'
 import {form} from 'tocco-app-extensions'
+import {react as customHooks} from 'tocco-util'
 
 import {
   StyledBasicSearchForm,
@@ -24,6 +25,10 @@ const BasicSearchForm = ({
   simpleSearchFields,
   submitSearchForm
 }) => {
+  const searchFormEl = useRef(null)
+
+  customHooks.useAutofocus(searchFormEl, [searchFormDefinition])
+
   if (!searchFormDefinition.children) {
     return null
   }
@@ -65,7 +70,7 @@ const BasicSearchForm = ({
   const hasExtendedOnlySearchFields = !fields.every(field => simpleSearchFields.includes(field.id))
 
   return (
-    <StyledBasicSearchForm>
+    <StyledBasicSearchForm ref={searchFormEl}>
       <form onSubmit={handleSubmit}>
         {hasExtendedOnlySearchFields && !disableSimpleSearch
         && <StyledSearchFormButtons>


### PR DESCRIPTION
As soon as entity-list with search form is rendered
the focus should be moved to form input.
Has effect on:
- advanced remote search
- entity-browser widget

Changelog: auto focus basic search form
Refs: TOCDEV-4735
Cherry-pick: Up