### PR TITLE
fix(tocco-ui): use correct value for advanced search

### DIFF
--- a/packages/tocco-ui/src/Select/IndicatorsContainer.js
+++ b/packages/tocco-ui/src/Select/IndicatorsContainer.js
@@ -33,7 +33,7 @@ const IndicatorsContainer = props => {
           <span
             onTouchEnd={handlePropagation}
             onMouseDown={handlePropagation}
-            onMouseUp={handleAdvancedSearch(openAdvancedSearch, props.value)}
+            onMouseUp={handleAdvancedSearch(openAdvancedSearch, value)}
           >
             <Ball icon="search" tabIndex={-1} />
           </span>


### PR DESCRIPTION
Refs: TOCDEV-4912
Changelog: Using the advanced search in multi-remote fields no longer ignores the current selection.