### PR TITLE
chore: stop recording runs on cypress.io dashboard

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ cypress:
       - $CI_RUN_CYPRESS == "1"
   script:
     - npm rebuild cypress
-    - yarn cypress:master:record --parallel
+    - yarn cypress:master:run --parallel
   artifacts:
     paths:
       - cypress/videos


### PR DESCRIPTION
- cypress.io dashboard is only free for a few test runs
- but we would like to run tests more frequently
- we already publish the video artifacts on gitlab
- no need to publish test runs on cypress.io dashboard anymore