### PR TITLE
chore: fix cypress run without recording

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,13 +113,13 @@ cypress:
     - yarn_setup
   image: cypress/base:10
   variables:
-    CYPRESS_INSTALL_BINARY: "6.4.0"
+    CYPRESS_INSTALL_BINARY: "9.1.0"
   only:
     variables:
       - $CI_RUN_CYPRESS == "1"
   script:
     - npm rebuild cypress
-    - yarn cypress:master:run --parallel
+    - yarn cypress:master:run
   artifacts:
     paths:
       - cypress/videos


### PR DESCRIPTION
- cypress.io only allows to run tests in parallel when record is active
- remove parallelization for now
- use correct binary version to not have a warning/conflicts