### PR TITLE
feat(docs-browser): support `locale` input

### DIFF
--- a/packages/docs-browser/src/components/Action/actions/CreateDomain.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateDomain.js
@@ -6,7 +6,7 @@ import EntityDetailApp from 'tocco-entity-detail/src/main'
 import getDetailFormName from '../../../utils/getDetailFormName'
 import getNode from '../../../utils/getNode'
 
-const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
+const CreateDomain = ({context, onSuccess, intl, locale, emitAction}) => {
   const isActionBlocked = action => action.payload?.toaster?.title === 'client.entity-detail.createSuccessfulTitle'
 
   const emitActionBarrier = action => {
@@ -47,6 +47,7 @@ const CreateDomain = ({context, onSuccess, intl, emitAction}) => {
       formName={formName}
       mode="create"
       defaultValues={defaultValues}
+      locale={locale}
       onEntityCreated={handleEntityCreated}
       emitAction={emitActionBarrier}
     />
@@ -63,6 +64,7 @@ CreateDomain.propTypes = {
   }).isRequired,
   onSuccess: PropTypes.func.isRequired,
   intl: PropTypes.object.isRequired,
+  locale: PropTypes.string,
   emitAction: PropTypes.func.isRequired
 }
 

--- a/packages/docs-browser/src/components/Action/actions/CreateFolder.js
+++ b/packages/docs-browser/src/components/Action/actions/CreateFolder.js
@@ -6,7 +6,7 @@ import EntityDetailApp from 'tocco-entity-detail/src/main'
 import getDetailFormName from '../../../utils/getDetailFormName'
 import getNode from '../../../utils/getNode'
 
-const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
+const CreateFolder = ({context, onSuccess, intl, locale, emitAction}) => {
   const isActionBlocked = action => action.payload?.toaster?.title === 'client.entity-detail.createSuccessfulTitle'
 
   const emitActionBarrier = action => {
@@ -47,6 +47,7 @@ const CreateFolder = ({context, onSuccess, intl, emitAction}) => {
       formName={formName}
       mode="create"
       defaultValues={defaultValues}
+      locale={locale}
       onEntityCreated={handleEntityCreated}
       emitAction={emitActionBarrier}
     />
@@ -63,6 +64,7 @@ CreateFolder.propTypes = {
   }).isRequired,
   onSuccess: PropTypes.func.isRequired,
   intl: PropTypes.object.isRequired,
+  locale: PropTypes.string,
   emitAction: PropTypes.func.isRequired
 }
 

--- a/packages/docs-browser/src/components/Action/actions/Edit.js
+++ b/packages/docs-browser/src/components/Action/actions/Edit.js
@@ -1,12 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {injectIntl} from 'react-intl'
 import {selection} from 'tocco-app-extensions'
 import EntityDetailApp from 'tocco-entity-detail/src/main'
 
 import getDetailFormName from '../../../utils/getDetailFormName'
 
-const EditAction = ({selection, onSuccess, onCancel, intl, context, emitAction}) => {
+const EditAction = ({selection, onSuccess, onCancel, locale, context, emitAction}) => {
   const isActionBlocked = action => action.payload?.toaster?.title === 'client.entity-detail.createSuccessfulTitle'
 
   const emitActionBarrier = action => {
@@ -72,6 +71,7 @@ const EditAction = ({selection, onSuccess, onCancel, intl, context, emitAction})
       formName={formName}
       entityId={entityKey}
       mode="update"
+      locale={locale}
       onEntityUpdated={handleEntityUpdated}
       onEntityDeleted={handleEntityDeleted}
       emitAction={emitActionBarrier}
@@ -88,8 +88,8 @@ EditAction.propTypes = {
   }).isRequired,
   onSuccess: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  intl: PropTypes.object.isRequired,
+  locale: PropTypes.string,
   emitAction: PropTypes.func.isRequired
 }
 
-export default injectIntl(EditAction)
+export default EditAction

--- a/packages/docs-browser/src/components/Action/actions/Move.js
+++ b/packages/docs-browser/src/components/Action/actions/Move.js
@@ -34,6 +34,7 @@ export const MoveAction = ({
   domainTypes,
   rootNodes,
   businessUnit,
+  locale,
   emitAction
 }) => {
   const initialNode = getNode(context.history.location.pathname)
@@ -87,6 +88,7 @@ export const MoveAction = ({
         businessUnit={businessUnit}
         sortable={false}
         scrollBehaviour="none"
+        locale={locale}
       />
       <StyledButtonsWrapper>
         <Button
@@ -124,5 +126,6 @@ MoveAction.propTypes = {
     })
   ),
   businessUnit: PropTypes.string,
+  locale: PropTypes.string,
   emitAction: PropTypes.func.isRequired
 }

--- a/packages/docs-browser/src/components/Action/actions/MoveContainer.js
+++ b/packages/docs-browser/src/components/Action/actions/MoveContainer.js
@@ -14,7 +14,8 @@ const mapStateToProps = state => ({
   isWaiting: state.docs.move.isWaiting,
   domainTypes: state.input.domainTypes,
   rootNodes: state.input.rootNodes,
-  businessUnit: state.input.businessUnit
+  businessUnit: state.input.businessUnit,
+  locale: state.intl.locale
 })
 
 const MoveContainer = connect(mapStateToProps, mapActionCreators)(MoveAction)

--- a/packages/docs-browser/src/components/DocsView/DocsView.js
+++ b/packages/docs-browser/src/components/DocsView/DocsView.js
@@ -70,6 +70,7 @@ const DocsView = props => {
     searchMode,
     openResource,
     searchFormCollapsed,
+    locale,
     changeSelection,
     changeSearchFormCollapsed
   } = props
@@ -219,6 +220,7 @@ const DocsView = props => {
           searchFormCollapsed={searchFormCollapsed}
           scrollBehaviour={scrollBehaviour}
           onSearchFormCollapsedChange={changeSearchFormCollapsed}
+          locale={locale}
         />
       </Suspense>
       <FileInput />
@@ -255,6 +257,7 @@ DocsView.propTypes = {
   openResource: PropTypes.func,
   searchFormCollapsed: PropTypes.bool,
   scrollBehaviour: scrollBehaviourPropType,
+  locale: PropTypes.string,
   changeSelection: PropTypes.func.isRequired,
   changeSearchFormCollapsed: PropTypes.func.isRequired
 }

--- a/packages/docs-browser/src/components/DocsView/DocsViewContainer.js
+++ b/packages/docs-browser/src/components/DocsView/DocsViewContainer.js
@@ -19,7 +19,8 @@ const mapStateToProps = state => ({
   sortable: state.input.sortable,
   openResource: state.input.openResource,
   searchFormCollapsed: state.docs.list.searchFormCollapsed,
-  scrollBehaviour: state.docs.list.scrollBehaviour
+  scrollBehaviour: state.docs.list.scrollBehaviour,
+  locale: state.intl.locale
 })
 
 const mapActionCreators = {

--- a/packages/docs-browser/src/components/DocumentView/DocumentView.js
+++ b/packages/docs-browser/src/components/DocumentView/DocumentView.js
@@ -7,7 +7,7 @@ import {StyledDocumentViewWrapper} from './StyledComponents'
 
 const LazyDetailApp = React.lazy(() => import('./LazyDetailApp'))
 
-const DocumentView = ({match, history, breadcrumbs, formName, navigationStrategy, emitAction}) => {
+const DocumentView = ({match, history, breadcrumbs, formName, navigationStrategy, locale, emitAction}) => {
   const handleEntityDeleted = () => {
     const lastList = breadcrumbs
       .slice()
@@ -29,6 +29,7 @@ const DocumentView = ({match, history, breadcrumbs, formName, navigationStrategy
           navigationStrategy={navigationStrategy}
           emitAction={emitAction}
           onEntityDeleted={handleEntityDeleted}
+          locale={locale}
         />
       </Suspense>
     </StyledDocumentViewWrapper>
@@ -52,6 +53,7 @@ DocumentView.propTypes = {
   ).isRequired,
   formName: PropTypes.string,
   navigationStrategy: PropTypes.object,
+  locale: PropTypes.string,
   emitAction: PropTypes.func.isRequired
 }
 

--- a/packages/docs-browser/src/components/DocumentView/DocumentViewContainer.js
+++ b/packages/docs-browser/src/components/DocumentView/DocumentViewContainer.js
@@ -6,7 +6,8 @@ import DocumentView from './DocumentView'
 
 const mapStateToProps = state => ({
   breadcrumbs: state.docs.path.breadcrumbs,
-  formName: state.input.documentDetailFormName
+  formName: state.input.documentDetailFormName,
+  locale: state.intl.locale
 })
 
 const mapActionCreators = {


### PR DESCRIPTION
Needed if the docs-browser is rendered as standalone widget in a website.

Refs: TOCDEV-4817
Changelog: support `locale` input