### PR TITLE
chore: CI: define expiry time for artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ yarn_setup:
     paths:
     - node_modules/
     - packages/*/node_modules/
+    expire_in: 5 days
   script:
     - yarn setup:ci
   interruptible: true


### PR DESCRIPTION
These artifacts are only used to move data between jobs within
the same pipeline. There should be no need to keep them long-term.