### PR TITLE
fix(tocco-util): fix cache clearance to keep notifications session

### DIFF
--- a/packages/tocco-util/src/cache/cache.js
+++ b/packages/tocco-util/src/cache/cache.js
@@ -5,7 +5,8 @@ import nice from '../nice'
  * Long term cache is cleared if language or revision has changed
  */
 
-const getKey = (type, id) => `cache.${type}.${id}`
+const prefix = `tocco.cache`
+const getKey = (type, id) => `${prefix}.${type}.${id}`
 
 export const addShortTerm = (type, id, value) => add(type, id, value, sessionStorage)
 export const addLongTerm = (type, id, value) => add(type, id, value, localStorage)
@@ -35,10 +36,14 @@ export const removeShortTerm = (type, id) => remove(type, id, sessionStorage)
 export const removeLongTerm = (type, id) => remove(type, id, localStorage)
 const remove = (type, id, storage) => storage.removeItem(getKey(type, id))
 
-export const clearShortTerm = () => clear(sessionStorage)
-const clear = storage => storage.clear()
-
 export const clearAll = () => {
-  localStorage.clear()
-  sessionStorage.clear()
+  clearShortTerm()
+  clearLongTerm()
+}
+
+export const clearShortTerm = () => clear(sessionStorage)
+export const clearLongTerm = () => clear(localStorage)
+const clear = storage => {
+  const keys = Object.keys(storage)
+  keys.filter(key => key.startsWith(prefix)).forEach(key => storage.removeItem(key))
 }

--- a/packages/tocco-util/src/originId/originId.js
+++ b/packages/tocco-util/src/originId/originId.js
@@ -4,11 +4,11 @@ const originIdName = '_tocco_originId'
 const originIdPrefix = 'client_'
 
 const getOriginId = () => {
-  if (window[originIdName]) {
-    return window[originIdName]
+  if (sessionStorage.getItem(originIdName)) {
+    return sessionStorage.getItem(originIdName)
   }
   const id = `${originIdPrefix}_${uuid()}`
-  window[originIdName] = id
+  sessionStorage.setItem(originIdName, id)
   return id
 }
 


### PR DESCRIPTION
- origin id was originally stored in session storage
- since session storage was completely cleared
  origin id was cleared as well
- websocket call and client-id header on rest requests were out of sync
- clearing cache should only consider cache keys
  instead of whole session storage
- keeping origin id in session storage will hydrate notifications
  instead of creating a new session

Refs: TOCDEV-4729
Changelog: fix cache clearance to keep notifications session