### PR TITLE
chore: update node on gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: node:14.18.2-alpine
+image: node:16.13.2-alpine
 
 variables:
   CYPRESS_INSTALL_BINARY: "0"


### PR DESCRIPTION
- husky requires npm exec to be existent
- use v16 node on gitlab as well

Cherry-pick: Up