### PR TITLE
fix(tocco-ui): use correct value for advanced search

### DIFF
--- a/packages/tocco-ui/src/Select/IndicatorsContainer.js
+++ b/packages/tocco-ui/src/Select/IndicatorsContainer.js
@@ -36,28 +36,24 @@ const IndicatorsContainer = props => {
     <StyledIndicatorsContainerWrapper isBottomAligned={isBottomAligned}>
       <components.IndicatorsContainer {...props}>
         {props.children}
-        {openAdvancedSearch
-        && !isDisabled
-        && <span
-          onTouchEnd={handlePropagation}
-          onMouseDown={handlePropagation}
-          onMouseUp={handleAdvancedSearch(openAdvancedSearch, props.value)}>
-        <Ball
-          icon="search"
-          tabIndex={-1}
-        />
-      </span>}
-        {createPermission
-        && !isDisabled
-        && <span
-          onTouchEnd={handlePropagation}
-          onMouseDown={handlePropagation}
-          onMouseUp={handleCreate(openRemoteCreate, value)}>
-        <Ball
-          icon="plus"
-          tabIndex={-1}
-        />
-      </span>}
+        {openAdvancedSearch && !isDisabled && (
+          <span
+            onTouchEnd={handlePropagation}
+            onMouseDown={handlePropagation}
+            onMouseUp={handleAdvancedSearch(openAdvancedSearch, value)}
+          >
+            <Ball icon="search" tabIndex={-1}/>
+          </span>
+        )}
+        {createPermission && !isDisabled && (
+          <span
+            onTouchEnd={handlePropagation}
+            onMouseDown={handlePropagation}
+            onMouseUp={handleCreate(openRemoteCreate, value)}
+          >
+            <Ball icon="plus" tabIndex={-1}/>
+          </span>
+        )}
       </components.IndicatorsContainer>
     </StyledIndicatorsContainerWrapper>
   )


### PR DESCRIPTION
Changelog: Using the advanced search in multi-remote fields no longer ignores the current selection.

(cherry picked from commit fb51d05f0ba14d8f5f01410a6a27d0a0bf997759)