### PR TITLE
fix(tocco-ui): enable navigating to multi-select details

### DIFF
--- a/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.js
+++ b/packages/tocco-ui/src/FormattedValue/typeFormatters/MultiSelectFormatter.js
@@ -12,12 +12,7 @@ const MultiSelectFormatter = ({value, options, breakWords}) => {
         ? value
             .map(v =>
               options && options.DetailLink ? (
-                <span
-                  onClick={e => {
-                    e.stopPropagation()
-                    e.preventDefault()
-                  }}
-                >
+                <span onClick={e => e.stopPropagation()}>
                   <options.DetailLink entityKey={v.key}>{v.display}</options.DetailLink>
                 </span>
               ) : (


### PR DESCRIPTION
- do not prevent default, that is exactly what we do want
- same behaviour is already used in SingleSelectFormatter

Refs: TOCDEV-4991
Changelog: Navigating to detail pages through links in multi-select fields is now possible.
Cherry-pick: Up