### PR TITLE
fix(tocco-util): display tiny millisecond values correctly

### DIFF
--- a/packages/tocco-util/src/date/utils.js
+++ b/packages/tocco-util/src/date/utils.js
@@ -10,8 +10,8 @@ export const millisecondsToDuration = ms => {
   }
 
   const seconds = roundDecimalPlaces((ms / 1000) % 60, 3)
-  const minutes = parseInt((ms / (1000 * 60)) % 60)
-  const hours = parseInt(ms / (1000 * 60 * 60))
+  const minutes = Math.floor((ms / (1000 * 60)) % 60)
+  const hours = Math.floor(ms / (1000 * 60 * 60))
   return {
     hours,
     minutes,

--- a/packages/tocco-util/src/date/utils.spec.js
+++ b/packages/tocco-util/src/date/utils.spec.js
@@ -20,6 +20,13 @@ describe('tocco-util', () => {
           const milliSeconds = 90083036
           expect(millisecondsToDuration(milliSeconds)).to.be.eql(result)
         })
+
+        test('should correctly handle tiny values', () => {
+          // previously we used parseInt to cut of decimals, which has strange results when passing in small numbers
+          expect(millisecondsToDuration(1)).to.be.eql({hours: 0, minutes: 0, seconds: 0.001})
+          expect(millisecondsToDuration(2)).to.be.eql({hours: 0, minutes: 0, seconds: 0.002})
+          expect(millisecondsToDuration(3)).to.be.eql({hours: 0, minutes: 0, seconds: 0.003})
+        })
       })
 
       describe('formatDuration', () => {


### PR DESCRIPTION
- parseInt has strange results when passing in tiny values (like 1/3600000)

Refs: TOCDEV-4986
Changelog: Tiny millisecond values (1 - 3) are now displayed correctly.
Cherry-pick: Up