### PR TITLE
style(tocco-ui): right align headers of right aligned table columns

### DIFF
--- a/packages/tocco-ui/src/Table/StyledTable.js
+++ b/packages/tocco-ui/src/Table/StyledTable.js
@@ -38,7 +38,7 @@ export const StyledTableHeaderCell = styled.th`
     position: sticky;
     top: 0;
     background-color: ${theme.color('paper')};
-    text-align: left;
+    text-align: ${({rightAligned}) => rightAligned ? 'right' : 'left'};
     border-bottom: 2px solid ${borderColor};
     ${declareFont({fontWeight: theme.fontWeight('bold')})};
     user-select: none;

--- a/packages/tocco-ui/src/Table/TableHeader.js
+++ b/packages/tocco-ui/src/Table/TableHeader.js
@@ -11,7 +11,11 @@ const ThContent = ({column, data}) =>
   column.HeaderRenderer ? (
     <column.HeaderRenderer column={column} data={data} />
   ) : (
-    <div dangerouslySetInnerHTML={{__html: column.label}} title={column.label} />
+    <div
+      dangerouslySetInnerHTML={{__html: column.label}}
+      title={column.label}
+      style={{width: '100%'}} // div should take up full available width, otherwise content cannot be right aligned
+    />
   )
 
 ThContent.propTypes = {
@@ -62,6 +66,7 @@ const TableHeader = props => {
               isResizingThisCell={isResizing && column.id === resizingElement?.id}
               sortable={column.sorting && column.sorting.sortable}
               isDraggedOver={dndState.currentlyDragOver === column.id && dndState.currentlyDragging !== column.id}
+              rightAligned={column.rightAligned}
             >
               <StyledDraggable
                 id={`header-cell-drop-${column.id}`}


### PR DESCRIPTION
Refs: TOCDEV-5098
Changelog: headers of right aligned table columns are right aligned now