### PR TITLE
fix(tocco-ui): use useRef for date onBlur workaround

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditorFactory.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditorFactory.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useRef} from 'react'
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import _omit from 'lodash/omit'
@@ -48,16 +48,16 @@ export const map = {
 }
 
 const TypeEditorFactory = ({type, value, options, id, events, readOnly = false}) => {
+  const blurValue = useRef(undefined)
   if (map[type]) {
     const Component = map[type]
 
     // blur workaround for known react-select issue: https://github.com/erikras/redux-form/issues/82
     // Date component only works properly on blur if the event is called with the value saved from the change event
-    let blurValue
     if (events && events.onBlur) {
       const onBlur = events.onBlur
       events.onBlur = () => {
-        return onBlur(blurValue !== undefined ? blurValue : value)
+        return onBlur(blurValue.current !== undefined ? blurValue.current : value)
       }
     }
 
@@ -66,7 +66,7 @@ const TypeEditorFactory = ({type, value, options, id, events, readOnly = false})
         <Component
           value={value}
           onChange={v => {
-            blurValue = v
+            blurValue.current = v
             events.onChange(v)
           }}
           {...(_isEmpty(options) ? {} : {options})}


### PR DESCRIPTION
- previous workaround must have stopped working sometime in the past, blurValue was always empty

Refs: TOCDEV-5036
Changelog: onBlur of date component is called with value from onChange again
Cherry-pick: Up