### PR TITLE
feat(entity-list): show fields in simple search acc. to model flag

### DIFF
--- a/packages/entity-list/src/components/BasicSearchForm/BasicSearchForm.js
+++ b/packages/entity-list/src/components/BasicSearchForm/BasicSearchForm.js
@@ -20,7 +20,7 @@ const BasicSearchForm = ({
   searchFormDefinition,
   setShowExtendedSearchForm,
   showExtendedSearchForm,
-  simpleSearchFields,
+  simpleSearchFields: inputSimpleSearchFields,
   submitSearchForm
 }) => {
   const searchFormEl = useRef(null)
@@ -55,6 +55,10 @@ const BasicSearchForm = ({
   }
 
   const fields = form.getFieldDefinitions(searchFormDefinition)
+  const simpleSearchFields =
+    inputSimpleSearchFields && inputSimpleSearchFields.length > 0
+      ? inputSimpleSearchFields
+      : fields.filter(field => field.simpleSearch === true).map(field => field.id)
   const hasExtendedOnlySearchFields = !fields.every(field => simpleSearchFields.includes(field.id))
   const extendable = hasExtendedOnlySearchFields && searchFormType === searchFormTypes.SIMPLE_ADVANCED
 

--- a/packages/entity-list/src/components/BasicSearchForm/BasicSearchForm.spec.js
+++ b/packages/entity-list/src/components/BasicSearchForm/BasicSearchForm.spec.js
@@ -5,6 +5,7 @@ import {createStore} from 'redux'
 import {IntlStub, intlEnzyme, TestThemeProvider} from 'tocco-test-util'
 import {EditableValue, StatedValue} from 'tocco-ui'
 
+import searchFormTypes from '../../util/searchFormTypes'
 import SearchForm from './'
 
 const EMPTY_FUNC = () => {}
@@ -37,6 +38,7 @@ describe('entity-list', () => {
                 submitSearchForm={EMPTY_FUNC}
                 resetSearch={EMPTY_FUNC}
                 intl={IntlStub}
+                searchFormType={searchFormTypes.SIMPLE_ADVANCED}
                 simpleSearchFields={[]}
                 showExtendedSearchForm
                 preselectedSearchFields={[]}
@@ -80,6 +82,7 @@ describe('entity-list', () => {
                   submitSearchForm={EMPTY_FUNC}
                   resetSearch={EMPTY_FUNC}
                   intl={IntlStub}
+                  searchFormType={searchFormTypes.SIMPLE_ADVANCED}
                   simpleSearchFields={[]}
                   showExtendedSearchForm
                   preselectedSearchFields={[]}
@@ -98,7 +101,7 @@ describe('entity-list', () => {
         expect(wrapper.find(EditableValue)).to.have.length(3)
       })
 
-      test('should render only the fulltext field', () => {
+      test('should render only the simple search fields from the form definition', () => {
         const entityModel = require('../../dev/test-data/userModel.json')
         const searchFormDefinition = require('../../dev/test-data/searchFormDefinition.json')
 
@@ -128,7 +131,8 @@ describe('entity-list', () => {
                   submitSearchForm={EMPTY_FUNC}
                   resetSearch={EMPTY_FUNC}
                   intl={IntlStub}
-                  simpleSearchFields={['txtFulltext']}
+                  searchFormType={searchFormTypes.SIMPLE}
+                  simpleSearchFields={[]}
                   preselectedSearchFields={[]}
                   setShowExtendedSearchForm={EMPTY_FUNC}
                   loadSearchFilters={EMPTY_FUNC}
@@ -145,7 +149,7 @@ describe('entity-list', () => {
         expect(wrapper.find(EditableValue)).to.have.length(1)
       })
 
-      test('should render two fields', () => {
+      test('should render simple search fields from props (override form definition)', () => {
         const entityModel = require('../../dev/test-data/userModel.json')
         const searchFormDefinition = require('../../dev/test-data/searchFormDefinition.json')
 
@@ -175,6 +179,7 @@ describe('entity-list', () => {
                   submitSearchForm={EMPTY_FUNC}
                   resetSearch={EMPTY_FUNC}
                   intl={IntlStub}
+                  searchFormType={searchFormTypes.SIMPLE}
                   simpleSearchFields={['txtFulltext', 'relUser_code1']}
                   preselectedSearchFields={[]}
                   setShowExtendedSearchForm={EMPTY_FUNC}
@@ -231,6 +236,7 @@ describe('entity-list', () => {
                   intl={IntlStub}
                   formValues={{}}
                   showExtendedSearchForm
+                  searchFormType={searchFormTypes.ADVANCED}
                   simpleSearchFields={[]}
                   preselectedSearchFields={preselectedSearchFields}
                   setShowExtendedSearchForm={EMPTY_FUNC}

--- a/packages/entity-list/src/dev/test-data/searchFormDefinition.json
+++ b/packages/entity-list/src/dev/test-data/searchFormDefinition.json
@@ -12,10 +12,11 @@
       "children": [
         {
           "id": "txtFulltext",
-          "componentType": "fulltext-search",
+          "componentType": "field",
           "dataType": "fulltext-search",
           "label": null,
-          "path": null
+          "path": null,
+          "simpleSearch": true
         }
       ]
     },
@@ -29,7 +30,7 @@
         {
           "id": "relAddress_user.relAddress",
           "componentType": "field",
-          "dataType": "string",
+          "dataType": "fulltext-search",
           "label": null,
           "path": "relAddress_user.relAddress"
         }

--- a/packages/entity-list/src/modules/searchForm/reducer.js
+++ b/packages/entity-list/src/modules/searchForm/reducer.js
@@ -48,7 +48,7 @@ const initialState = {
   initialized: false,
   formDefinition: {},
   showExtendedSearchForm: false,
-  simpleSearchFields: ['txtFulltext'],
+  simpleSearchFields: [],
   valuesInitialized: false,
   searchFilters: null,
   queryViewVisible: false,

--- a/packages/entity-list/src/modules/searchForm/reducer.spec.js
+++ b/packages/entity-list/src/modules/searchForm/reducer.spec.js
@@ -5,7 +5,7 @@ const EXPECTED_INITIAL_STATE = {
   initialized: false,
   formDefinition: {},
   showExtendedSearchForm: false,
-  simpleSearchFields: ['txtFulltext'],
+  simpleSearchFields: [],
   valuesInitialized: false,
   searchFilters: null,
   queryViewVisible: false,


### PR DESCRIPTION
- There is a new boolean flag on the fields called `simpleSearch` which
  marks the fields that should be shown in the simple search form
- If `simpleSearchFields` input prop is given, it overrides the form
  definition
- "txtFulltext" is marked in form definitions as simple search fields
  automatically now; no need to handle this field explicitly

Refs: TOCDEV-4941
Changelog: fields in simple search are shown according to model flag