### PR TITLE
fix(tocco-ui): fix jumping layout on firefox

### DIFF
--- a/packages/tocco-ui/src/Layout/StyledLayoutBox.js
+++ b/packages/tocco-ui/src/Layout/StyledLayoutBox.js
@@ -3,10 +3,7 @@ import styled from 'styled-components'
 import {scale} from '../utilStyles'
 
 const StyledLayoutBox = styled.div`
-  display: grid;
   height: fit-content;
-  grid-template-rows: auto;
-  grid-template-columns: 100%;
   margin-bottom: ${scale.space(0.25)};
 `
 


### PR DESCRIPTION
- on ffox the layout was jumping randomly while mouse movements
- hovering on relations-tab was triggering the jumping
- removing unused grid styles fixes strange jumping

Refs: TOCDEV-5006
Changelog: fix jumping layout on firefox
Cherry-pick: Up