### PR TITLE
fix(docs-browser): navigate back to search view

### DIFF
--- a/packages/docs-browser/src/components/DocsView/DocsView.js
+++ b/packages/docs-browser/src/components/DocsView/DocsView.js
@@ -163,7 +163,6 @@ const DocsView = props => {
     if (!disableViewPersistor) {
       viewPersistor.persistViewInfo(entityListKey, {store})
     }
-    return null
   }
 
   return (
@@ -181,7 +180,7 @@ const DocsView = props => {
           parent={parent}
           onSearchChange={handleSearch}
           store={store}
-          onStoreCreate={handleStoreCreation(store)}
+          onStoreCreate={handleStoreCreation}
           cellRenderers={{
             'dms-label-with-icon': (rowData, column, cellRenderer) => (
               <StyledContentWrapper>


### PR DESCRIPTION
Refs: TOCDEV-5119
Changelog: fix docs browser back navigation for search view
Cherry-pick: Up