### PR TITLE
fix(app-extensions): customize hasValue for booleanSelect

### DIFF
--- a/packages/core/app-extensions/src/field/editableTypeConfigs/booleanSelect.js
+++ b/packages/core/app-extensions/src/field/editableTypeConfigs/booleanSelect.js
@@ -2,5 +2,8 @@ export default {
   getOptions: ({formData}) => ({
     trueLabel: formData.intl.formatMessage({id: 'client.common.yes'}),
     falseLabel: formData.intl.formatMessage({id: 'client.common.no'})
-  })
+  }),
+  hasValue: ({value}) => {
+    return value === true || value === false
+  }
 }

--- a/packages/core/app-extensions/src/field/editableTypeConfigs/booleanSelect.spec.js
+++ b/packages/core/app-extensions/src/field/editableTypeConfigs/booleanSelect.spec.js
@@ -1,0 +1,30 @@
+import booleanSelect from './booleanSelect'
+
+describe('app-extensions', () => {
+  describe('field', () => {
+    describe('editableTypeConfigs', () => {
+      describe('booleanSelect', () => {
+        describe('hasValue', () => {
+          test('sees true as value', () => {
+            expect(booleanSelect.hasValue({value: true})).to.be.true
+          })
+          test('sees false as value', () => {
+            expect(booleanSelect.hasValue({value: false})).to.be.true
+          })
+          test('sees null as no value', () => {
+            expect(booleanSelect.hasValue({value: null})).to.be.false
+          })
+          test('sees undefined as no value', () => {
+            expect(booleanSelect.hasValue({})).to.be.false
+          })
+          test('sees string as no value', () => {
+            expect(booleanSelect.hasValue({value: 'true'})).to.be.false
+          })
+          test('sees number as no value', () => {
+            expect(booleanSelect.hasValue({value: 1})).to.be.false
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/core/app-extensions/src/field/editableTypeConfigs/location.js
+++ b/packages/core/app-extensions/src/field/editableTypeConfigs/location.js
@@ -4,9 +4,9 @@ import _get from 'lodash/get'
  * `location` field covers `city` and `postcode` value.
  */
 export default {
-  hasValue: (value, formField) => {
+  hasValue: ({formValues, formField}) => {
     const locationMapping = formField.locationMapping
-    return !!(value[locationMapping.city] || value[locationMapping.postcode])
+    return !!(formValues[locationMapping.city] || formValues[locationMapping.postcode])
   },
   getValue: ({formField, formData}) => {
     const locationMapping = formField.locationMapping

--- a/packages/core/app-extensions/src/formField/formField.js
+++ b/packages/core/app-extensions/src/formField/formField.js
@@ -8,19 +8,15 @@ import field from '../field'
 import fromData from '../formData'
 
 const FormFieldWrapper = props => {
-  const hasOverwrite = props.typeEditable && props.typeEditable.hasValue
+  const {typeEditable, value, formData, formField, dirty, error, children} = props
+  const hasOverwrite = typeEditable && typeEditable.hasValue
   const hasValue = hasOverwrite
-    ? props.typeEditable.hasValue(props.formData.formValues, props.formField)
-    : props.hasValue
+    ? typeEditable.hasValue({formValues: formData.formValues, formField, value})
+    : value !== null && value !== undefined && value !== false && (value.length === undefined || value.length > 0)
 
   return (
-    <StatedValue
-      {...props}
-      dirty={props.formData.isDirty || props.dirty}
-      error={props.formData.errors || props.error}
-      hasValue={hasValue}
-    >
-      {React.cloneElement(props.children, {formData: props.formData})}
+    <StatedValue {...props} dirty={formData.isDirty || dirty} error={formData.errors || error} hasValue={hasValue}>
+      {React.cloneElement(children, {formData: formData})}
     </StatedValue>
   )
 }
@@ -32,7 +28,7 @@ FormFieldWrapper.propTypes = {
   formField: PropTypes.object,
   dirty: PropTypes.bool,
   error: PropTypes.object,
-  hasValue: PropTypes.bool
+  value: PropTypes.any
 }
 
 const displayFieldTypes = ['display', 'description']
@@ -77,8 +73,6 @@ export const formFieldFactory = (fieldMappingType, data, resources = {}) => {
 
     const readOnly = parentReadOnly || readonly || submitting || !_get(entityField, 'writable', true)
 
-    const hasValue =
-      value !== null && value !== undefined && value !== false && (value.length === undefined || value.length > 0)
     const isDisplay = displayFieldAsDisplayOnly(value, componentType, dataType, parentReadOnly)
 
     const type = formDefinitionField.dataType || formDefinitionField.componentType
@@ -104,7 +98,7 @@ export const formFieldFactory = (fieldMappingType, data, resources = {}) => {
           typeEditable={typeEditable}
           dirty={dirty}
           error={error}
-          hasValue={hasValue}
+          value={value}
           id={id}
           immutable={readOnly}
           isDisplay={isDisplay}


### PR DESCRIPTION
- see only exactly true and false as values
- move hasValue handling to single spot and also pass value to the overwrite

Refs: TOCDEV-2442