### PR TITLE
feat(scheduler): omit month in slot label for month view

### DIFF
--- a/packages/core/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/core/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -177,7 +177,6 @@ const FullCalendar = ({
             type: 'resourceTimelineMonth',
             slotLabelFormat: {
               weekday: 'short',
-              month: 'numeric',
               day: 'numeric',
               omitCommas: true
             }


### PR DESCRIPTION
- month view is too wide on small screens
- omit redundant value on each slot to have more space

Refs: TOCDEV-4917
Changelog: omit month in slot label for month view