### PR TITLE
chore: run tests in parallel / disable debugging features

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ test:
     - external_pull_requests
     - master
   script:
-    - yarn test --ci --forceExit --runInBand --detectOpenHandles
+    - yarn test --ci
   after_script:
     - yarn codecov
   interruptible: true


### PR DESCRIPTION
I think this options were all just added for debugging during
the migration from Travis to GitLab CI (e9abf0a844c8b6). From
the documentation:

--detectOpenHandles

Attempt to collect and print open handles preventing Jest from
exiting cleanly. Use this in cases where you need to use
--forceExit in order for Jest to exit to potentially track down
the reason. This implies --runInBand, making tests run serially.
Implemented using async_hooks. This option has a significant
performance penalty and should only be used for debugging.

--forceExit

Force Jest to exit after all tests have completed running. This
is useful when resources set up by test code cannot be adequately
cleaned up. Note: This feature is an escape-hatch. If Jest doesn't
exit at the end of a test run, it means external resources are still
being held on to or timers are still pending in your code. It is
advisedto tear down external resources after each test to make sure
Jest can shut down cleanly. You can use --detectOpenHandles to help
track it down.

--runInBand

Alias: -i. Run all tests serially in the current process, rather
than creating a worker pool of child processes that run tests.
This can be useful for debugging.