### PR TITLE
fix(app-extensions): increase z-index for modals

### DIFF
--- a/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
+++ b/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
@@ -49,7 +49,7 @@ export const StyledModalHolder = styled.div`
   left: 0;
   position: absolute;
   // higher than StyledHeader and very high value to prevent other elements blocking it when implemented as a widget
-  z-index: 999999;
+  z-index: 99999999;
 `
 
 export const StyledModalWrapper = styled.div`


### PR DESCRIPTION
- need to stay above load mask in old client
- behaviour is not present in 3.0, so no cherry-pick is necessary

Refs: BS-6936