### PR TITLE
feat(scheduler): set sorting in calendar instead of the backend

### DIFF
--- a/packages/core/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/core/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -135,7 +135,7 @@ const FullCalendar = forwardRef(
     const memoizedFullCalendar = useMemo(
       () => (
         <ReactFullCalendar
-          resourceOrder=""
+          resourceOrder="calendarType,title"
           schedulerLicenseKey={getLicense()}
           locale={locale}
           plugins={[adaptivePlugin, resourceTimelinePlugin, interactionPlugin]}


### PR DESCRIPTION
Refs: TOCDEV-4139
Changelog: calendar is now always sorted by calendar type and title