### PR TITLE
fix(admin): fix navigating to entity document

### DIFF
--- a/packages/apps/admin/src/routes/entities/components/DocsView/DocsView.js
+++ b/packages/apps/admin/src/routes/entities/components/DocsView/DocsView.js
@@ -3,7 +3,7 @@ import {useEffect, useState, useCallback} from 'react'
 import {rest} from 'tocco-app-extensions'
 import DocsBrowserApp from 'tocco-docs-browser/src/main'
 
-const DocsView = ({entityName, entityKey, showActions, noLeftPadding, openResource}) => {
+const DocsView = ({entityName, entityKey, showActions, noLeftPadding, openResource, initialLocation}) => {
   const [folderKey, setFolderKey] = useState(null)
 
   const fetchFolder = useCallback(async () => {
@@ -20,6 +20,7 @@ const DocsView = ({entityName, entityKey, showActions, noLeftPadding, openResour
     folderKey && (
       <DocsBrowserApp
         routerType="routerless"
+        initialLocation={initialLocation}
         noLeftPadding={noLeftPadding}
         sortable={false}
         searchFormType="none"
@@ -45,7 +46,8 @@ DocsView.propTypes = {
   entityKey: PropTypes.string.isRequired,
   showActions: PropTypes.bool.isRequired,
   noLeftPadding: PropTypes.bool,
-  openResource: PropTypes.func
+  openResource: PropTypes.func,
+  initialLocation: PropTypes.string
 }
 
 export default DocsView

--- a/packages/apps/admin/src/routes/entities/components/ListView/DocsViewAdapter.js
+++ b/packages/apps/admin/src/routes/entities/components/ListView/DocsViewAdapter.js
@@ -1,17 +1,21 @@
+import PropTypes from 'prop-types'
+
 import {currentViewPropType} from '../../utils/propTypes'
 import DocsView from '../DocsView'
 
-const DocsViewAdapter = ({currentViewInfo}) => (
+const DocsViewAdapter = ({currentViewInfo, initialLocation}) => (
   <DocsView
     noLeftPadding={false}
     entityName={currentViewInfo.parentModel.name}
     entityKey={currentViewInfo.parentKey}
     showActions={true}
+    initialLocation={initialLocation}
   />
 )
 
 DocsViewAdapter.propTypes = {
-  currentViewInfo: currentViewPropType
+  currentViewInfo: currentViewPropType,
+  initialLocation: PropTypes.string
 }
 
 export default DocsViewAdapter

--- a/packages/apps/admin/src/routes/entities/components/ListView/ListView.js
+++ b/packages/apps/admin/src/routes/entities/components/ListView/ListView.js
@@ -19,8 +19,10 @@ const ListView = ({match, history, currentViewInfo, emitAction, searchFormCollap
     history.push(match.url.replace(/list$/, '') + id)
   }
 
+  const initialLocation = history.location.hash ? history.location.hash.substring(1) : null
+
   if (currentViewInfo.model.name === 'Resource') {
-    return <DocsViewAdapter currentViewInfo={currentViewInfo} />
+    return <DocsViewAdapter currentViewInfo={currentViewInfo} initialLocation={initialLocation} />
   }
 
   return (


### PR DESCRIPTION
Since TOCDEV-5060 and commit c49a167 navigating to a entity document
via the hash URL didn't work anymore, as the hash URL was ignored since
then ("routerless" docs-browser instance is used, as routers cannot be
nested anymore).

To fix navigating to the document, the hash URL is passed as
`initialLocation` to the <DocsBrowser> now.

Refs: TOCDEV-5343, TOCDEV-5060
Changelog: fixed navigating to entity document