### PR TITLE
fix(app-extensions): invalidate cache on page refresh properly

### DIFF
--- a/packages/admin/src/modules/session/sagas.js
+++ b/packages/admin/src/modules/session/sagas.js
@@ -59,7 +59,7 @@ export function* changeBusinessUnitId({payload: {businessUnitId}}) {
   const {username} = yield select(sessionSelector)
   const resource = `principals/${username}/businessunit`
   yield call(rest.requestSaga, resource, {method: 'PUT', body: {businessUnit: businessUnitId}})
-  yield call(cache.clearShortTerm)
+  yield call(cache.clearAll)
   location.reload()
 }
 

--- a/packages/app-extensions/src/appFactory/App.js
+++ b/packages/app-extensions/src/appFactory/App.js
@@ -5,9 +5,11 @@ import {Provider} from 'react-redux'
 import styled from 'styled-components'
 import {LoadMask} from 'tocco-ui'
 
+import cache from '../cache'
 import keyDown from '../keyDown'
 import ThemeWrapper from './ThemeWrapper'
 import './styles.css'
+
 const StyledApp = styled.div`
   display: flex;
   flex-direction: column;
@@ -32,7 +34,9 @@ const App = ({store, initIntlPromise, content, theme}) => {
         <keyDown.KeyDownWatcher>
           <LoadMask promises={[initIntlPromise]}>
             <IntlProvider>
-              <StyledApp ref={wrapperCallback}>{content}</StyledApp>
+              <cache.CacheInitLoadMask>
+                <StyledApp ref={wrapperCallback}>{content}</StyledApp>
+              </cache.CacheInitLoadMask>
             </IntlProvider>
           </LoadMask>
         </keyDown.KeyDownWatcher>

--- a/packages/app-extensions/src/appFactory/appFactory.js
+++ b/packages/app-extensions/src/appFactory/appFactory.js
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import {consoleLogger, intl} from 'tocco-util'
 
+import cache from '../cache'
 import errorLogging from '../errorLogging'
 import App from './App'
 
@@ -24,6 +25,7 @@ export const createApp = (
     if (actions) {
       dispatchActions(actions, store)
       store.dispatch({type: inputDispatchActionType})
+      store.dispatch(cache.initialise())
     }
 
     const initIntlPromise = setupIntl(input, store, name, textResourceModules)

--- a/packages/app-extensions/src/cache/CacheInitLoadMask/CacheInitLoadMask.js
+++ b/packages/app-extensions/src/cache/CacheInitLoadMask/CacheInitLoadMask.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import {LoadMask} from 'tocco-ui'
+
+const CacheInitLoadMask = ({children, initialised}) => <LoadMask required={[initialised]}>{children}</LoadMask>
+
+CacheInitLoadMask.propTypes = {
+  children: PropTypes.any,
+  initialised: PropTypes.bool
+}
+
+export default CacheInitLoadMask

--- a/packages/app-extensions/src/cache/CacheInitLoadMask/CacheInitLoadMaskContainer.js
+++ b/packages/app-extensions/src/cache/CacheInitLoadMask/CacheInitLoadMaskContainer.js
@@ -1,0 +1,10 @@
+import {injectIntl} from 'react-intl'
+import {connect} from 'react-redux'
+
+import CacheInitLoadMask from './CacheInitLoadMask'
+
+const mapStateToProps = state => ({
+  initialised: state.cache ? state.cache.initialised : true
+})
+
+export default connect(mapStateToProps)(injectIntl(CacheInitLoadMask))

--- a/packages/app-extensions/src/cache/CacheInitLoadMask/index.js
+++ b/packages/app-extensions/src/cache/CacheInitLoadMask/index.js
@@ -1,0 +1,3 @@
+import CacheInitLoadMask from './CacheInitLoadMaskContainer'
+
+export default CacheInitLoadMask

--- a/packages/app-extensions/src/cache/actions.js
+++ b/packages/app-extensions/src/cache/actions.js
@@ -1,0 +1,13 @@
+export const INITIALISE = 'cache/INITIALISE'
+export const SET_INITIALISED = 'cache/SET_INITIALISED'
+
+export const initialise = () => ({
+  type: INITIALISE
+})
+
+export const setInitialised = initialised => ({
+  type: SET_INITIALISED,
+  payload: {
+    initialised
+  }
+})

--- a/packages/app-extensions/src/cache/cache.js
+++ b/packages/app-extensions/src/cache/cache.js
@@ -1,5 +1,10 @@
+import {reducer as reducerUtil} from 'tocco-util'
+
+import cacheReducer from './reducer'
 import sagas from './sagas'
 
 export const addToStore = store => {
+  reducerUtil.injectReducers(store, {cache: cacheReducer})
+
   store.sagaMiddleware.run(sagas)
 }

--- a/packages/app-extensions/src/cache/index.js
+++ b/packages/app-extensions/src/cache/index.js
@@ -1,5 +1,11 @@
+import {initialise} from './actions'
 import {addToStore} from './cache'
+import CacheInitLoadMask from './CacheInitLoadMask'
+import {hasInvalidCache} from './utils'
 
 export default {
-  addToStore
+  addToStore,
+  initialise,
+  CacheInitLoadMask,
+  hasInvalidCache
 }

--- a/packages/app-extensions/src/cache/reducer.js
+++ b/packages/app-extensions/src/cache/reducer.js
@@ -1,0 +1,16 @@
+import {reducer as reducerUtil} from 'tocco-util'
+
+import * as actions from './actions'
+
+const ACTION_HANDLERS = {
+  [actions.SET_INITIALISED]: reducerUtil.singleTransferReducer('initialised')
+}
+
+const initialState = {
+  initialised: false
+}
+
+export default function reducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+  return handler ? handler(state, action) : state
+}

--- a/packages/app-extensions/src/cache/reducer.spec.js
+++ b/packages/app-extensions/src/cache/reducer.spec.js
@@ -1,0 +1,22 @@
+import * as actions from './actions'
+import reducer from './reducer'
+
+const INITIAL_STATE = {
+  initialised: false
+}
+
+describe('app-extensions', () => {
+  describe('cache', () => {
+    describe('reducer', () => {
+      test('should create a valid initial state', () => {
+        expect(reducer(undefined, {})).to.deep.equal(INITIAL_STATE)
+      })
+
+      test('should set initialised', () => {
+        const stateAfter = reducer(INITIAL_STATE, actions.setInitialised(true))
+        expect(stateAfter).to.have.property('initialised')
+        expect(stateAfter.initialised).to.be.true
+      })
+    })
+  })
+})

--- a/packages/app-extensions/src/cache/sagas.js
+++ b/packages/app-extensions/src/cache/sagas.js
@@ -1,20 +1,35 @@
-import {all, call} from 'redux-saga/effects'
+import {all, call, put, takeLatest} from 'redux-saga/effects'
 import {cache} from 'tocco-util'
 
-import rest from '../rest'
+import * as actions from './actions'
+import {hasInvalidCache} from './utils'
 
 export default function* mainSagas() {
-  yield all([init()])
+  yield all([takeLatest(actions.INITIALISE, init)])
 }
 
-let clearCacheChecked = false
+let cacheInitialised = false
+export const resetCacheInitialised = () => {
+  cacheInitialised = false
+}
 
 export function* init() {
-  if (!clearCacheChecked) {
-    const revisionChanged = yield call(rest.hasRevisionIdChanged)
-    if (revisionChanged) {
-      yield call(cache.clearAll)
-    }
-    clearCacheChecked = true
+  /**
+   * Run cache initialisation only once per page request.
+   * When we nest client packages they get empty stores and do not know if parent already
+   * have initialised the cache. Use local variable in file therefore and update child store.
+   */
+  if (cacheInitialised) {
+    yield put(actions.setInitialised(true))
+    return
   }
+
+  const needsCacheInvalidation = yield call(hasInvalidCache)
+
+  if (needsCacheInvalidation) {
+    yield call(cache.clearAll)
+  }
+
+  cacheInitialised = true
+  yield put(actions.setInitialised(true))
 }

--- a/packages/app-extensions/src/cache/sagas.spec.js
+++ b/packages/app-extensions/src/cache/sagas.spec.js
@@ -1,0 +1,61 @@
+import {expectSaga, testSaga} from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import {takeLatest} from 'redux-saga/effects'
+import {cache} from 'tocco-util'
+
+import * as actions from './actions'
+import rootSaga, * as sagas from './sagas'
+import {hasInvalidCache} from './utils'
+
+describe('app-extensions', () => {
+  describe('cache', () => {
+    describe('sagas', () => {
+      describe('root saga', () => {
+        test('should fork sagas', () => {
+          const saga = testSaga(rootSaga)
+          saga.next().all([takeLatest(actions.INITIALISE, sagas.init)])
+        })
+      })
+
+      describe('init', () => {
+        beforeEach(() => {
+          sagas.resetCacheInitialised()
+        })
+
+        afterEach(() => {
+          sagas.resetCacheInitialised()
+        })
+
+        test('should clear invalid cache', () => {
+          return expectSaga(sagas.init)
+            .provide([[matchers.call(hasInvalidCache), true]])
+            .call(hasInvalidCache)
+            .call(cache.clearAll)
+            .put(actions.setInitialised(true))
+            .run()
+        })
+
+        test('should keep valid cache', () => {
+          return expectSaga(sagas.init)
+            .provide([[matchers.call(hasInvalidCache), false]])
+            .call(hasInvalidCache)
+            .not.call(cache.clearAll)
+            .put(actions.setInitialised(true))
+            .run()
+        })
+
+        test('should run only once', async () => {
+          await expectSaga(sagas.init)
+            .provide([[matchers.call(hasInvalidCache), false]])
+            .run()
+
+          return expectSaga(sagas.init)
+            .not.call(hasInvalidCache)
+            .not.call(cache.clearAll)
+            .put(actions.setInitialised(true))
+            .run()
+        })
+      })
+    })
+  })
+})

--- a/packages/app-extensions/src/cache/utils.js
+++ b/packages/app-extensions/src/cache/utils.js
@@ -1,0 +1,21 @@
+import {call} from 'redux-saga/effects'
+import {intl, cache} from 'tocco-util'
+
+import rest from '../rest'
+
+export function* hasInvalidCache() {
+  const revisionChanged = yield call(rest.hasRevisionIdChanged)
+
+  const cachedLocale = cache.getLongTerm('session', 'locale')
+  const cachedPrincipal = cache.getLongTerm('session', 'principal')
+
+  const userInfo = yield call(intl.loadUserWithLocale)
+  const {locale, username, businessUnitId} = userInfo
+
+  const hasLocaleChanged = !cachedLocale || cachedLocale !== locale
+  const hasPrincipalChanged =
+    cachedPrincipal &&
+    (cachedPrincipal.currentBusinessUnit.id !== businessUnitId || cachedPrincipal.username !== username)
+
+  return hasLocaleChanged || hasPrincipalChanged || revisionChanged
+}

--- a/packages/app-extensions/src/cache/utils.spec.js
+++ b/packages/app-extensions/src/cache/utils.spec.js
@@ -1,0 +1,133 @@
+import {expectSaga} from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import {intl, cache} from 'tocco-util'
+
+import rest from '../rest'
+import {hasInvalidCache} from './utils'
+
+describe('app-extensions', () => {
+  describe('cache', () => {
+    describe('utils', () => {
+      describe('hasInvalidCache', () => {
+        beforeEach(() => {
+          cache.clearAll()
+        })
+
+        afterEach(() => {
+          cache.clearAll()
+        })
+
+        test('should return valid if nothing has changed', () => {
+          const userInfo = {
+            locale: 'de',
+            username: 'hans',
+            businessUnitId: 'test'
+          }
+
+          cache.addLongTerm('session', 'principal', {currentBusinessUnit: {id: 'test'}, username: 'hans'})
+          cache.addLongTerm('session', 'locale', 'de')
+
+          return expectSaga(hasInvalidCache)
+            .provide([
+              [matchers.call(rest.hasRevisionIdChanged), false],
+              [matchers.call(intl.loadUserWithLocale), userInfo]
+            ])
+            .returns(false)
+            .run()
+        })
+
+        test('should return invalid if revision has changed', () => {
+          const userInfo = {
+            locale: 'de',
+            username: 'hans',
+            businessUnitId: 'test'
+          }
+
+          cache.addLongTerm('session', 'principal', {currentBusinessUnit: {id: 'test'}, username: 'hans'})
+          cache.addLongTerm('session', 'locale', 'de')
+
+          return expectSaga(hasInvalidCache)
+            .provide([
+              [matchers.call(rest.hasRevisionIdChanged), true],
+              [matchers.call(intl.loadUserWithLocale), userInfo]
+            ])
+            .returns(true)
+            .run()
+        })
+
+        test('should return invalid if username has changed', () => {
+          const userInfo = {
+            locale: 'de',
+            username: 'hans',
+            businessUnitId: 'test'
+          }
+
+          cache.addLongTerm('session', 'principal', {currentBusinessUnit: {id: 'test'}, username: 'susi'})
+          cache.addLongTerm('session', 'locale', 'de')
+
+          return expectSaga(hasInvalidCache)
+            .provide([
+              [matchers.call(rest.hasRevisionIdChanged), false],
+              [matchers.call(intl.loadUserWithLocale), userInfo]
+            ])
+            .returns(true)
+            .run()
+        })
+
+        test('should return invalid if business unit has changed', () => {
+          const userInfo = {
+            locale: 'de',
+            username: 'hans',
+            businessUnitId: 'test'
+          }
+
+          cache.addLongTerm('session', 'principal', {currentBusinessUnit: {id: '123'}, username: 'hans'})
+          cache.addLongTerm('session', 'locale', 'de')
+
+          return expectSaga(hasInvalidCache)
+            .provide([
+              [matchers.call(rest.hasRevisionIdChanged), false],
+              [matchers.call(intl.loadUserWithLocale), userInfo]
+            ])
+            .returns(true)
+            .run()
+        })
+
+        test('should return invalid if locale has changed', () => {
+          const userInfo = {
+            locale: 'de',
+            username: 'hans',
+            businessUnitId: 'test'
+          }
+
+          cache.addLongTerm('session', 'principal', {currentBusinessUnit: {id: 'test'}, username: 'hans'})
+          cache.addLongTerm('session', 'locale', 'en')
+
+          return expectSaga(hasInvalidCache)
+            .provide([
+              [matchers.call(rest.hasRevisionIdChanged), false],
+              [matchers.call(intl.loadUserWithLocale), userInfo]
+            ])
+            .returns(true)
+            .run()
+        })
+
+        test('should return invalid if nothing is in cache yet', () => {
+          const userInfo = {
+            locale: 'de',
+            username: 'hans',
+            businessUnitId: 'test'
+          }
+
+          return expectSaga(hasInvalidCache)
+            .provide([
+              [matchers.call(rest.hasRevisionIdChanged), false],
+              [matchers.call(intl.loadUserWithLocale), userInfo]
+            ])
+            .returns(true)
+            .run()
+        })
+      })
+    })
+  })
+})

--- a/packages/app-extensions/src/login/sagas.js
+++ b/packages/app-extensions/src/login/sagas.js
@@ -20,9 +20,9 @@ export function* doSessionRequest() {
 
 export function* sessionCheck() {
   const {success, businessUnit, adminAllowed} = yield call(doSessionRequest)
-  const cachedPrincipal = cache.getShortTerm('session', 'principal')
+  const cachedPrincipal = cache.getLongTerm('session', 'principal')
   if (cachedPrincipal && cachedPrincipal.currentBusinessUnit.id !== businessUnit) {
-    yield call(cache.clearShortTerm)
+    yield call(cache.clearAll)
   }
   yield put(actions.setAdminAllowed(adminAllowed))
   yield put(actions.setLoggedIn(success))

--- a/packages/app-extensions/src/login/sagas.spec.js
+++ b/packages/app-extensions/src/login/sagas.spec.js
@@ -23,14 +23,14 @@ describe('app-extensions', () => {
           const sessionResponse = {
             businessUnit: 'm2'
           }
-          cache.addShortTerm('session', 'principal', {
+          cache.addLongTerm('session', 'principal', {
             currentBusinessUnit: {
               id: 'm1'
             }
           })
           return expectSaga(sagas.sessionCheck)
             .provide([[matchers.call(sagas.doSessionRequest), sessionResponse]])
-            .call(cache.clearShortTerm)
+            .call(cache.clearAll)
             .run()
         })
         test('should not clear cache on same bu', () => {
@@ -39,14 +39,14 @@ describe('app-extensions', () => {
           const sessionResponse = {
             businessUnit: 'm1'
           }
-          cache.addShortTerm('session', 'principal', {
+          cache.addLongTerm('session', 'principal', {
             currentBusinessUnit: {
               id: 'm1'
             }
           })
           return expectSaga(sagas.sessionCheck)
             .provide([[matchers.call(sagas.doSessionRequest), sessionResponse]])
-            .not.call(cache.clearShortTerm)
+            .not.call(cache.clearAll)
             .run()
         })
         test('should set logged in', () => {

--- a/packages/app-extensions/src/rest/helpers.js
+++ b/packages/app-extensions/src/rest/helpers.js
@@ -394,7 +394,7 @@ export const flattenObjectValues = value =>
  * Helper to fetch information about the currently logged in user including username and active business unit.
  */
 export function* fetchPrincipal() {
-  const cachedPrincipal = cache.getShortTerm('session', 'principal')
+  const cachedPrincipal = cache.getLongTerm('session', 'principal')
   if (cachedPrincipal !== undefined) {
     return cachedPrincipal
   }
@@ -407,7 +407,7 @@ export function* fetchPrincipal() {
     currentBusinessUnit
   }
 
-  yield cache.addShortTerm('session', 'principal', principal)
+  yield cache.addLongTerm('session', 'principal', principal)
 
   return principal
 }

--- a/packages/app-extensions/src/rest/helpers.spec.js
+++ b/packages/app-extensions/src/rest/helpers.spec.js
@@ -712,7 +712,7 @@ describe('app-extensions', () => {
               currentBusinessUnit: 'test1'
             }
 
-            cache.addShortTerm('session', 'principal', expectedReturn)
+            cache.addLongTerm('session', 'principal', expectedReturn)
 
             return expectSaga(helpers.fetchPrincipal).returns(expectedReturn).run()
           })

--- a/packages/login/src/modules/sagas.js
+++ b/packages/login/src/modules/sagas.js
@@ -1,6 +1,6 @@
 import {takeLatest, put, select, call, all} from 'redux-saga/effects'
-import {externalEvents, rest} from 'tocco-app-extensions'
-import {consoleLogger, request, cache, intl} from 'tocco-util'
+import {externalEvents, rest, cache as cacheHelpers} from 'tocco-app-extensions'
+import {consoleLogger, request, cache} from 'tocco-util'
 
 import {Pages} from '../types/Pages'
 import * as actions from './actions'
@@ -80,8 +80,8 @@ export function* handleFailedResponse() {
 }
 
 export function* handleSuccessfulLogin(response) {
-  const localChanged = yield call(intl.hasUserLocaleChanged)
-  if (localChanged) {
+  const needsCacheInvalidation = yield call(cacheHelpers.hasInvalidCache)
+  if (needsCacheInvalidation) {
     yield call(cache.clearAll)
   } else {
     yield call(cache.clearShortTerm)

--- a/packages/login/src/modules/sagas.spec.js
+++ b/packages/login/src/modules/sagas.spec.js
@@ -1,8 +1,8 @@
 import {expectSaga} from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import {takeLatest, put, select, call, all} from 'redux-saga/effects'
-import {externalEvents, rest} from 'tocco-app-extensions'
-import {cache, intl} from 'tocco-util'
+import {externalEvents, rest, cache as cacheHelpers} from 'tocco-app-extensions'
+import {cache} from 'tocco-util'
 
 import {Pages} from '../types/Pages'
 import * as actions from './actions'
@@ -113,10 +113,7 @@ describe('login', () => {
         test('should call external event with timeout of reponse body', () => {
           const payload = {timeout: 33}
           return expectSaga(sagas.handleSuccessfulLogin, payload)
-            .provide([
-              [matchers.call.fn(intl.hasUserLocaleChanged), false],
-              [matchers.call.fn(rest.hasRevisionIdChanged), false]
-            ])
+            .provide([[matchers.call.fn(cacheHelpers.hasInvalidCache), false]])
             .put(externalEvents.fireExternalEvent('loginSuccess', payload))
             .call(cache.clearShortTerm)
             .put(setPassword(''))
@@ -125,10 +122,7 @@ describe('login', () => {
 
         test('should call external event with default timeout if none in body', () => {
           expectSaga(sagas.handleSuccessfulLogin, {})
-            .provide([
-              [matchers.call.fn(intl.hasUserLocaleChanged), false],
-              [matchers.call.fn(rest.hasRevisionIdChanged), false]
-            ])
+            .provide([[matchers.call.fn(cacheHelpers.hasInvalidCache), false]])
             .put(externalEvents.fireExternalEvent('loginSuccess', {timeout: sagas.DEFAULT_TIMEOUT}))
             .call(cache.clearShortTerm)
             .put(setPassword(''))
@@ -137,10 +131,7 @@ describe('login', () => {
 
         test('should clear long and short term cache', () => {
           expectSaga(sagas.handleSuccessfulLogin, {})
-            .provide([
-              [matchers.call.fn(intl.hasUserLocaleChanged), true],
-              [matchers.call.fn(rest.hasRevisionIdChanged), false]
-            ])
+            .provide([[matchers.call.fn(cacheHelpers.hasInvalidCache), true]])
             .put(externalEvents.fireExternalEvent('loginSuccess', {timeout: sagas.DEFAULT_TIMEOUT}))
             .call(cache.clearAll)
             .put(setPassword(''))

--- a/packages/sso-login/src/modules/sagas.js
+++ b/packages/sso-login/src/modules/sagas.js
@@ -1,6 +1,6 @@
 import {takeLatest, all, call, put, select} from 'redux-saga/effects'
-import {externalEvents, rest} from 'tocco-app-extensions'
-import {cache, intl} from 'tocco-util'
+import {externalEvents, rest, cache as cacheHelpers} from 'tocco-app-extensions'
+import {cache} from 'tocco-util'
 
 import {transformProviderEntities} from '../utils/providers'
 import * as actions from './actions'
@@ -22,8 +22,8 @@ export function* loadProviders() {
 }
 
 export function* loginCompleted({payload: {result}}) {
-  const localChanged = yield call(intl.hasUserLocaleChanged)
-  if (localChanged) {
+  const needsCacheInvalidation = yield call(cacheHelpers.hasInvalidCache)
+  if (needsCacheInvalidation) {
     yield call(cache.clearAll)
   } else {
     yield call(cache.clearShortTerm)

--- a/packages/tocco-util/src/cache/cache.js
+++ b/packages/tocco-util/src/cache/cache.js
@@ -1,8 +1,18 @@
 import nice from '../nice'
 
 /*
- * Short term caching is per browser tab. The short term cache is clear after login or business unit change
- * Long term cache is cleared if language or revision has changed
+ * Short term caching (sessionStorage) is per browser tab.
+ * Long term cache (localStorage) is shared across tabs and browser sessions.
+ *
+ * short term cache gets cleared
+ *  - individually (e.g. displays on change entity)
+ *  - whenever overall cache gets cleared
+ *
+ * overall cache gets cleared
+ *  - language change
+ *  - user change
+ *  - business unit change
+ *  - revision change
  */
 
 const getKey = (type, id) => `cache.${type}.${id}`

--- a/packages/tocco-util/src/intl/index.js
+++ b/packages/tocco-util/src/intl/index.js
@@ -1,2 +1,2 @@
-import {initIntl, setLocale, changeLocale, hasUserLocaleChanged, localeSelector} from './intl'
-export default {initIntl, setLocale, changeLocale, hasUserLocaleChanged, localeSelector}
+import {initIntl, setLocale, changeLocale, hasUserLocaleChanged, localeSelector, loadUserWithLocale} from './intl'
+export default {initIntl, setLocale, changeLocale, hasUserLocaleChanged, localeSelector, loadUserWithLocale}

--- a/packages/tocco-util/src/intl/intl.spec.js
+++ b/packages/tocco-util/src/intl/intl.spec.js
@@ -47,7 +47,7 @@ describe('tocco-util', () => {
 
       test('should read from cache after first fetch', async () => {
         const cachedLocale = 'fr'
-        cache.addLongTerm('user', 'locale', cachedLocale)
+        cache.addLongTerm('session', 'locale', cachedLocale)
 
         const result = await getUserLocale()
         expect(result).to.eql(cachedLocale)
@@ -86,9 +86,9 @@ describe('tocco-util', () => {
         const resources2 = await loadTextResources('en-GB', ['merge', 'components', 'actions.[^.]*\\.title'])
         expect(resources2).to.eql(resources)
 
-        expect(cache.getLongTerm('textResource', 'merge')).to.eql(mergeMessages)
-        expect(cache.getLongTerm('textResource', 'components')).to.eql(componentsMessages)
-        expect(cache.getLongTerm('textResource', 'actions.[^.]*\\.title')).to.eql(actionTitles)
+        expect(cache.getLongTerm('textResource', 'en-GB.merge')).to.eql(mergeMessages)
+        expect(cache.getLongTerm('textResource', 'en-GB.components')).to.eql(componentsMessages)
+        expect(cache.getLongTerm('textResource', 'en-GB.actions.[^.]*\\.title')).to.eql(actionTitles)
       })
     })
   })


### PR DESCRIPTION
On login via support-tocco or when logged in on different tab
the success login sagas do not get executed. Without the sagas the
caches did not get invalidated properly.
On every page refresh the cache invalidates itself whenever
a cache-relevant data has been changed (locale, user, bu, ...).

Changelog: invalidate cache on page refresh properly
Cherry-pick: Up
Refs: TOCDEV-5317