### PR TITLE
feat(tocco-ui): allow duration values to be negative

### DIFF
--- a/packages/app-extensions/src/field/editableTypeConfigs/duration.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/duration.js
@@ -1,6 +1,13 @@
+const allowNegative = formField =>
+  !formField.validation
+  || !formField.validation.numberRange
+  || typeof formField.validation.numberRange.fromIncluding !== 'number'
+  || formField.validation.numberRange.fromIncluding < 0
+
 export default {
-  getOptions: ({formData}) => ({
+  getOptions: ({formField, formData}) => ({
     hoursLabel: formData.intl.formatMessage({id: 'client.component.duration.hoursLabel'}),
-    minutesLabel: formData.intl.formatMessage({id: 'client.component.duration.minutesLabel'})
+    minutesLabel: formData.intl.formatMessage({id: 'client.component.duration.minutesLabel'}),
+    allowNegative: allowNegative(formField)
   })
 }

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.spec.js
@@ -48,16 +48,6 @@ describe('tocco-ui', () => {
           expect(onInputSpy).to.be.calledWith(expectedCallValue)
         })
 
-        test('should display 59 on sub zero minutes input', () => {
-          const onInputSpy = sinon.spy()
-          const wrapper = mount(
-            <DurationEdit value={null} onChange={onInputSpy}/>
-          )
-          const input = '-1'
-          wrapper.find('input').at(1).simulate('input', implyTargetObject(input))
-          expect(wrapper.find('input').at(1)).to.have.value('59')
-        })
-
         test('should set immutable prop to true', () => {
           const wrapper = mount(
             <DurationEdit value={null} onChange={EMPTY_FUNC} immutable/>
@@ -65,24 +55,16 @@ describe('tocco-ui', () => {
           expect(wrapper.find(DurationEdit).props().immutable).to.eql(true)
         })
 
-        test('should always show units', () => {
-          const wrapper = mount(
-            <DurationEdit value={0} onChange={EMPTY_FUNC}/>
-          )
-          expect(wrapper.find(Typography.Span)).to.have.length(2)
-          expect(wrapper.state('showUnits')).to.be.true
-        })
-
-        test('should show and hide units', () => {
+        test('should set focussed flag to show and hide units', () => {
           const wrapper = mount(
             <DurationEdit onChange={EMPTY_FUNC}/>
           )
           expect(wrapper.find(Typography.Span)).to.have.length(0)
-          expect(wrapper.state('showUnits')).to.be.false
+          expect(wrapper.state('focussed')).to.be.false
           wrapper.instance().handleOnFocus()
-          expect(wrapper.state('showUnits')).to.be.true
+          expect(wrapper.state('focussed')).to.be.true
           wrapper.instance().handleOnBlur()
-          expect(wrapper.state('showUnits')).to.be.false
+          expect(wrapper.state('focussed')).to.be.false
         })
       })
     })

--- a/packages/tocco-ui/src/EditableValue/utils.js
+++ b/packages/tocco-ui/src/EditableValue/utils.js
@@ -73,6 +73,8 @@ export const convertStringToNumber = stringValue => (
   !stringValue || isNaN(stringValue) ? null : parseFloat(stringValue)
 )
 
+export const ensureNegative = number => Math.abs(number) * -1
+
 /*
  * Convert two numbers as hours and minutes to milliseconds
  */
@@ -80,6 +82,12 @@ export const calculateMilliseconds = (hours, minutes) => {
   if (!hours && !minutes) {
     return null
   }
+
+  if (hours < 0 || minutes < 0) {
+    hours = ensureNegative(hours)
+    minutes = ensureNegative(minutes)
+  }
+
   const hoursMilliseconds = (hours || 0) * 60 * 60000
   const minutesMilliseconds = (minutes || 0) * 60000
   return hoursMilliseconds + minutesMilliseconds


### PR DESCRIPTION
- `options.allowNegative` will be set to true, if there is no number
  range validation or if `fromIncluding` is less than 0
- if negative values are allowed, the minus sign "-" will be displayed
  in the biggest unit that's not 0 (so, in the minutes field, if there are
  no hours, and in the hours field, if there are hours)
- other improvements:
-- hours can be greater than 24 now
-- fixed automatic growing (unit "px" was missing in styling rule) and
   added a padding of 5px
-- removed automatic rewriting of minutes to 0 or to 59 in certain
   conditions as it was rather irritating than helpful
- needs to be cherry picked to newer branches by hand, as there
  will be some merge conflicts

Changelog: allow duration values to be negative
Refs: TOCDEV-5338