### PR TITLE
fix(entity-list): use preformatted error message for tql

### DIFF
--- a/packages/entity-list/src/components/AdminSearchForm/QueryView.js
+++ b/packages/entity-list/src/components/AdminSearchForm/QueryView.js
@@ -4,7 +4,15 @@ import {FormattedMessage} from 'react-intl'
 import {Ball, BallMenu, EditableValue, FormattedValue, MenuItem, StatedValue} from 'tocco-ui'
 import {react as customHooks} from 'tocco-util'
 
-import {AdminSearchGrid, StyledHeader, StyledQueryBox} from './StyedComponents'
+import {AdminSearchGrid, StyledErrorMessage, StyledHeader, StyledQueryBox} from './StyedComponents'
+
+const detectSignal = (hasError, touched) => {
+  if (hasError) {
+    return 'danger'
+  } else if (touched) {
+    return 'info'
+  }
+}
 
 const QueryView = ({
   isCollapsed,
@@ -31,6 +39,11 @@ const QueryView = ({
   }
   const queryExists = !!query && query.trim().length > 0
   const queryHasErrors = queryError && Object.entries(queryError).length !== 0
+
+  const queryErrorValues = Object.values(queryError || {})
+
+  const signal = detectSignal(queryHasErrors, queryExists)
+
   return (
     <AdminSearchGrid isCollapsed={isCollapsed}>
       <StyledHeader>
@@ -68,14 +81,17 @@ const QueryView = ({
           <FormattedValue type="string" value={entityModel} />
         </StatedValue>
         <StatedValue
-          error={queryError}
           touched={queryExists}
           fixLabel={true}
           hasValue={queryExists}
           label={msg('client.entity-list.query.editor')}
+          signal={signal}
         >
           <EditableValue type="code" value={query} options={codeEditorOptions} events={codeEditorEvents} />
         </StatedValue>
+        {queryErrorValues.map((error, index) => (
+          <StyledErrorMessage key={index}>{error}</StyledErrorMessage>
+        ))}
       </StyledQueryBox>
     </AdminSearchGrid>
   )

--- a/packages/entity-list/src/components/AdminSearchForm/StyedComponents.js
+++ b/packages/entity-list/src/components/AdminSearchForm/StyedComponents.js
@@ -1,6 +1,6 @@
 import Split from 'react-split'
 import styled from 'styled-components'
-import {Button, Menu, scale, StyledScrollbar, theme} from 'tocco-ui'
+import {Button, declareFont, Menu, scale, StyledScrollbar, theme} from 'tocco-ui'
 
 export const StyledSplit = styled(Split)``
 
@@ -103,4 +103,16 @@ export const StyledQueryBox = styled.div`
     z-index: 3; //higher than rest to lay over query field
   }
   ${StyledScrollbar}
+`
+
+export const StyledErrorMessage = styled.pre`
+  && {
+    ${declareFont({
+      fontFamily: theme.fontFamily('monospace')
+    })}
+    margin-left: ${scale.space(-1)};
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: ${theme.color('signal.danger.text')};
+  }
 `


### PR DESCRIPTION
Error message for TQL are already preformatted
in regards of line breaks and spacing. Using the same
format helps the user to find the error way faster.

Refs: TOCDEV-5040
Changelog: use preformatted error message for tql
Cherry-pick: Up