### PR TITLE
fix(entity-list): use preformatted error message for tql

### DIFF
--- a/packages/core/entity-list/src/components/AdminSearchForm/QueryView.js
+++ b/packages/core/entity-list/src/components/AdminSearchForm/QueryView.js
@@ -4,7 +4,21 @@ import {FormattedMessage} from 'react-intl'
 import {Ball, BallMenu, EditableValue, FormattedValue, MenuItem, StatedValue} from 'tocco-ui'
 import {react as customHooks} from 'tocco-util'
 
-import {AdminSearchGrid, StyledHeader, StyledQueryBox, StyledToggleCollapseButton} from './StyedComponents'
+import {
+  AdminSearchGrid,
+  StyledErrorMessage,
+  StyledHeader,
+  StyledQueryBox,
+  StyledToggleCollapseButton
+} from './StyedComponents'
+
+const detectSignal = (hasError, touched) => {
+  if (hasError) {
+    return 'danger'
+  } else if (touched) {
+    return 'info'
+  }
+}
 
 const QueryView = ({
   isCollapsed,
@@ -34,6 +48,10 @@ const QueryView = ({
   const queryHasErrors = queryError && Object.entries(queryError).length !== 0
   const disableQueryView = () => setQueryViewVisible(false)
   const isQueryFalsy = !queryExists || queryHasErrors
+
+  const queryErrorValues = Object.values(queryError || {})
+
+  const signal = detectSignal(queryHasErrors, queryExists)
 
   return (
     <AdminSearchGrid isCollapsed={isCollapsed}>
@@ -73,14 +91,17 @@ const QueryView = ({
           <FormattedValue type="string" value={entityModel} />
         </StatedValue>
         <StatedValue
-          error={queryError}
           touched={queryExists}
           fixLabel={true}
           hasValue={queryExists}
           label={msg('client.entity-list.query.editor')}
+          signal={signal}
         >
           <EditableValue type="code" value={query} options={codeEditorOptions} events={codeEditorEvents} />
         </StatedValue>
+        {queryErrorValues.map((error, index) => (
+          <StyledErrorMessage key={index}>{error}</StyledErrorMessage>
+        ))}
       </StyledQueryBox>
     </AdminSearchGrid>
   )

--- a/packages/core/entity-list/src/components/AdminSearchForm/StyedComponents.js
+++ b/packages/core/entity-list/src/components/AdminSearchForm/StyedComponents.js
@@ -1,6 +1,6 @@
 import Split from 'react-split'
 import styled from 'styled-components'
-import {Button, Menu, scale, StyledScrollbar, theme} from 'tocco-ui'
+import {Button, declareFont, Menu, scale, StyledScrollbar, theme} from 'tocco-ui'
 
 export const StyledSplit = styled(Split)``
 
@@ -103,4 +103,16 @@ export const StyledQueryBox = styled.div`
     z-index: 3; //higher than rest to lay over query field
   }
   ${StyledScrollbar}
+`
+
+export const StyledErrorMessage = styled.pre`
+  && {
+    ${declareFont({
+      fontFamily: theme.fontFamily('monospace')
+    })}
+    margin-left: ${scale.space(-1)};
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: ${theme.color('signal.danger.text')};
+  }
 `


### PR DESCRIPTION
Error message for TQL are already preformatted
in regards of line breaks and spacing. Using the same
format helps the user to find the error way faster.

Refs: TOCDEV-5040
Changelog: use preformatted error message for tql
Cherry-pick: Up