### PR TITLE
fix(admin): do not re-initialize admin on session heartbeat

### DIFF
--- a/packages/admin/src/modules/session/sagas.spec.js
+++ b/packages/admin/src/modules/session/sagas.spec.js
@@ -58,24 +58,27 @@ describe('admin', () => {
             .run()
         })
       })
-      describe('sessionHeartBeat', () => {
+      describe('sessionHeartbeat', () => {
         test('should set flags and call itself', () => {
-          const timeout = 10
+          const sessionTimeoutInMinutes = 30
           const sessionResponse = {
             success: true,
             adminAllowed: true
           }
-          return expectSaga(sagas.sessionHeartBeat, timeout)
+
+          // after the half time of the session timeout
+          const expectedHeartbeatDelayInMilliseconds = 15 * 60 * 1000
+
+          return expectSaga(sagas.sessionHeartbeat, sessionTimeoutInMinutes)
             .provide([
               [matchers.call.fn(login.doSessionRequest), sessionResponse],
-              [matchers.call.fn(sagas.sessionHeartBeat)],
+              [matchers.call.fn(sagas.sessionHeartbeat)],
               [matchers.call.fn(sagas.delayByTimeout)]
             ])
-            .put(login.setAdminAllowed(undefined))
             .put(login.setLoggedIn(true))
             .put(login.setAdminAllowed(true))
-            .call(sagas.sessionHeartBeat, timeout)
-            .call(sagas.delayByTimeout, timeout * 45000)
+            .call(sagas.sessionHeartbeat, sessionTimeoutInMinutes)
+            .call(sagas.delayByTimeout, expectedHeartbeatDelayInMilliseconds)
             .run()
         })
       })


### PR DESCRIPTION
The session heartbeat is setup after login but will not be setup again
on a page refresh with having still a valid session.
The nice2 session timeout is set to 30 minutes but the
frontend assumed to have a session timeout of 10s.
After 22min the session heartbeat is executed, but only
when tab hasn't been refreshed after login.
The admin got completely umounted and mounted on every heartbeat.
This caused unsaved changes to be lossed completely.
To not show "no-roles" error messages right after login but
before the session has beend fetched, the `adminAllowed` variable
has to be reset after login.
This prevents to render the admin with a value of `false` and showing
the error message for a short time.

Refs: TOCDEV-5100
Changlog: do not re-initalize admin on session heartbeat
Cherry-pick: Up