### PR TITLE
feat(tocco-ui): allow duration values to be negative

### DIFF
--- a/packages/app-extensions/src/field/editableTypeConfigs/duration.js
+++ b/packages/app-extensions/src/field/editableTypeConfigs/duration.js
@@ -1,7 +1,14 @@
+const allowNegative = formField =>
+  !formField.validation ||
+  !formField.validation.numberRange ||
+  typeof formField.validation.numberRange.fromIncluding !== 'number' ||
+  formField.validation.numberRange.fromIncluding < 0
+
 export default {
-  getOptions: ({formData}) => ({
+  getOptions: ({formField, formData}) => ({
     hoursLabel: formData.intl.formatMessage({id: 'client.component.duration.hoursLabel'}),
     minutesLabel: formData.intl.formatMessage({id: 'client.component.duration.minutesLabel'}),
-    secondsLabel: formData.intl.formatMessage({id: 'client.component.duration.secondsLabel'})
+    secondsLabel: formData.intl.formatMessage({id: 'client.component.duration.secondsLabel'}),
+    allowNegative: allowNegative(formField)
   })
 }

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.js
@@ -1,33 +1,11 @@
 import PropTypes from 'prop-types'
 import React, {useRef, useState, useEffect} from 'react'
-import {react, date} from 'tocco-util'
+import {date} from 'tocco-util'
 
 import Typography from '../../Typography'
 import {StyledEditableWrapper} from '../StyledEditableValue'
 import {calculateMilliseconds} from '../utils'
 import {StyledDurationEditShadow, StyledDurationEditFocusable, StyledDurationEdit} from './StyledDurationEdit'
-
-const getDesiredInputInMinutes = target => {
-  let minutes = target.value.replace(/[^-\d]/g, '')
-
-  if (!target.validity.valid) {
-    minutes = 0
-  }
-
-  if (minutes.length > 2) {
-    minutes = minutes.slice(0, 2)
-  }
-
-  if (minutes > 59) {
-    minutes = 0
-  }
-
-  if (minutes < 0) {
-    minutes = 59
-  }
-
-  return minutes
-}
 
 const DurationEdit = ({value, immutable, onChange, options}) => {
   const hoursShadow = useRef(null)
@@ -35,78 +13,70 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
   const secondsShadow = useRef(null)
 
   const duration = date.millisecondsToDuration(value)
-  const {seconds} = duration
-
-  const [hours, setHours] = useState(duration.hours)
-  const [minutes, setMinutes] = useState(duration.minutes)
 
   const [hoursWidth, setHoursWidth] = useState(0)
   const [minutesWidth, setMinutesWidth] = useState(0)
   const secondsWidth = secondsShadow.current?.offsetWidth || 0
 
-  const [showUnits, setShowUnits] = useState(value >= 0)
-
-  const previousHours = react.usePrevious(hours)
-  const previousMinutes = react.usePrevious(minutes)
+  const [focused, setFocused] = useState(false)
 
   useEffect(() => {
     setHoursWidth(hoursShadow.current.offsetWidth)
     setMinutesWidth(minutesShadow.current.offsetWidth)
   }, [])
 
-  // previoursHours and previousMinutes can be ignored
-  useEffect(() => {
-    if (hours !== previousHours) {
-      setHoursWidth(hoursShadow.current.offsetWidth)
-    }
-    if (minutes !== previousMinutes) {
-      setMinutesWidth(minutesShadow.current.offsetWidth)
-    }
-  }, [hours, minutes]) // eslint-disable-line react-hooks/exhaustive-deps
-
   const handleHourChange = e => {
     const hours = e.target.value.replace(/[^-\d]/g, '')
-    setHours(hours)
     handleChange(hours, null)
   }
 
   const handleMinutesChange = e => {
-    const minutes = getDesiredInputInMinutes(e.target)
-    setMinutes(minutes)
+    const minutes = e.target.value.replace(/[^-\d]/g, '')
     handleChange(null, minutes)
-
-    if (minutes.toString().length === 2 || minutes === 0) {
-      e.target.select()
-    }
   }
 
   const handleChange = (hoursInput, minutesInput) => {
-    const minutesValue = minutesInput !== null ? minutesInput : minutes
-    const hoursValue = hoursInput !== null ? hoursInput : hours
+    const minutesValue = minutesInput !== null ? minutesInput : duration.minutes
+    let hoursValue = hoursInput !== null ? hoursInput : duration.hours
 
     if (minutesValue === '' && hoursValue === '') {
       onChange(null)
       return
     }
 
+    if (minutesValue >= 60) {
+      // if at least 1 hour entered in minutes, we use only the minutes and calculate hours and
+      // minutes from that value and reset the hours that were set before
+      hoursValue = 0
+    }
+
     onChange(calculateMilliseconds(hoursValue, minutesValue))
   }
 
   const handleOnBlur = () => {
-    setShowUnits(hours.toString().length >= 1 || minutes.toString().length >= 1)
+    setFocused(false)
   }
 
   const handleOnFocus = () => {
-    setShowUnits(true)
+    setFocused(true)
   }
 
-  const preventNonNumeric = e => {
-    const isNonNumericInput = !(e.charCode >= 48 && e.charCode <= 57)
-
-    if (isNonNumericInput) {
-      e.preventDefault()
+  const preventNonNumeric = event => {
+    if (event.charCode >= 48 && event.charCode <= 57) {
+      // numbers
+      return
     }
+    if (event.charCode === 45 && options.allowNegative === true) {
+      // minus sign "-"
+      return
+    }
+    event.preventDefault() // else prevent inputting character
   }
+
+  // eslint-disable-next-line no-useless-escape
+  const getPattern = () => (options.allowNegative === true ? '-?d+' : 'd+')
+
+  const unitsVisible = () => focused || typeof value === 'number'
 
   /**
    * We don't want to offer the user to enter the duration in seconds,
@@ -115,7 +85,7 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
    * Therefore, we show seconds/milliseconds only for immutable fields if such values are present.
    * (e.g. System_activity)
    */
-  const showSeconds = immutable && Boolean(seconds)
+  const showSeconds = immutable && Boolean(duration.seconds)
 
   return (
     <StyledEditableWrapper onBlur={handleOnBlur} immutable={immutable}>
@@ -123,34 +93,35 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
         <StyledDurationEdit
           disabled={immutable}
           immutable={immutable}
-          min={0}
+          min={options.allowNegative === true ? undefined : 0}
           onChange={() => {}} // Empty onChange function to prevent React internal error
           onFocus={handleOnFocus}
           onInput={handleHourChange}
           onKeyPress={preventNonNumeric}
-          pattern="\d+"
+          pattern={getPattern()}
           step={1}
           width={hoursWidth}
           type="number"
-          value={hours}
+          value={typeof duration.hours === 'number' && (duration.hours !== 0 || immutable) ? duration.hours : ''}
         />
-        {showUnits && <Typography.Span>{options.hoursLabel}</Typography.Span>}
+        {unitsVisible() && <Typography.Span>{options.hoursLabel}</Typography.Span>}
       </StyledDurationEditFocusable>
       <StyledDurationEditFocusable immutable={immutable}>
         <StyledDurationEdit
           disabled={immutable}
           immutable={immutable}
+          min={options.allowNegative === true && (duration.hours === null || duration.hours === 0) ? undefined : 0}
           onChange={() => {}} // Empty onChange function to prevent React internal error
           onFocus={handleOnFocus}
           onInput={handleMinutesChange}
           onKeyPress={preventNonNumeric}
-          pattern="\d+"
+          pattern={getPattern()}
           step={1}
           width={minutesWidth}
           type="number"
-          value={minutes}
+          value={duration.minutes}
         />
-        {showUnits && <Typography.Span>{options.minutesLabel}</Typography.Span>}
+        {unitsVisible() && <Typography.Span>{options.minutesLabel}</Typography.Span>}
       </StyledDurationEditFocusable>
       {showSeconds && (
         <StyledDurationEditFocusable immutable={immutable}>
@@ -160,14 +131,14 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
             onChange={() => {}} // Empty onChange function to prevent React internal error
             width={secondsWidth}
             type="number"
-            value={seconds}
+            value={duration.seconds}
           />
-          {showUnits && <Typography.Span>{options.secondsLabel}</Typography.Span>}
+          {unitsVisible() && <Typography.Span>{options.secondsLabel}</Typography.Span>}
         </StyledDurationEditFocusable>
       )}
-      <StyledDurationEditShadow ref={hoursShadow}>{hours}</StyledDurationEditShadow>
-      <StyledDurationEditShadow ref={minutesShadow}>{minutes}</StyledDurationEditShadow>
-      {showSeconds && <StyledDurationEditShadow ref={secondsShadow}>{seconds}</StyledDurationEditShadow>}
+      <StyledDurationEditShadow ref={hoursShadow}>{duration.hours}</StyledDurationEditShadow>
+      <StyledDurationEditShadow ref={minutesShadow}>{duration.minutes}</StyledDurationEditShadow>
+      {showSeconds && <StyledDurationEditShadow ref={secondsShadow}>{duration.seconds}</StyledDurationEditShadow>}
     </StyledEditableWrapper>
   )
 }
@@ -189,7 +160,8 @@ DurationEdit.propTypes = {
   options: PropTypes.shape({
     hoursLabel: PropTypes.string,
     minutesLabel: PropTypes.string,
-    secondsLabel: PropTypes.string
+    secondsLabel: PropTypes.string,
+    allowNegative: PropTypes.bool
   })
 }
 

--- a/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.spec.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.spec.js
@@ -41,14 +41,6 @@ describe('tocco-ui', () => {
           expect(onInputSpy).to.be.calledWith(expectedCallValue)
         })
 
-        test('should display 59 on sub zero minutes input', () => {
-          const onInputSpy = sinon.spy()
-          const wrapper = mount(<DurationEdit value={null} onChange={onInputSpy} />)
-          const input = '-1'
-          wrapper.find('input').at(1).simulate('input', implyTargetObject(input))
-          expect(wrapper.find('input').at(1)).to.have.value('59')
-        })
-
         test('should set immutable prop to true', () => {
           const wrapper = mount(<DurationEdit value={null} onChange={EMPTY_FUNC} immutable />)
           expect(wrapper.find(DurationEdit).props().immutable).to.eql(true)
@@ -79,7 +71,7 @@ describe('tocco-ui', () => {
         test('should not show seconds on small duration when editable', () => {
           const wrapper = mount(<DurationEdit value={329} onChange={EMPTY_FUNC} />)
           expect(wrapper.find(Typography.Span)).to.have.length(2)
-          expect(wrapper.find('input').at(0)).to.have.value('0')
+          expect(wrapper.find('input').at(0)).to.have.value('')
           expect(wrapper.find('input').at(1)).to.have.value('0')
         })
       })

--- a/packages/tocco-ui/src/EditableValue/utils.js
+++ b/packages/tocco-ui/src/EditableValue/utils.js
@@ -68,6 +68,8 @@ export const parseLocalePlaceholder = countryCode => {
 export const convertStringToNumber = stringValue =>
   !stringValue || isNaN(stringValue) ? null : parseFloat(stringValue)
 
+export const ensureNegative = number => Math.abs(number) * -1
+
 /*
  * Convert two numbers as hours and minutes to milliseconds
  */
@@ -75,6 +77,12 @@ export const calculateMilliseconds = (hours, minutes) => {
   if (!hours && !minutes) {
     return null
   }
+
+  if (hours < 0 || minutes < 0) {
+    hours = ensureNegative(hours)
+    minutes = ensureNegative(minutes)
+  }
+
   const hoursMilliseconds = (hours || 0) * 60 * 60000
   const minutesMilliseconds = (minutes || 0) * 60000
   return hoursMilliseconds + minutesMilliseconds

--- a/packages/tocco-util/src/date/utils.js
+++ b/packages/tocco-util/src/date/utils.js
@@ -9,9 +9,24 @@ export const millisecondsToDuration = ms => {
     }
   }
 
-  const seconds = roundDecimalPlaces((ms / 1000) % 60, 3)
-  const minutes = Math.floor((ms / (1000 * 60)) % 60)
-  const hours = Math.floor(ms / (1000 * 60 * 60))
+  let seconds = roundDecimalPlaces((ms / 1000) % 60, 3)
+
+  ms -= seconds * 1000
+
+  let minutes = parseInt((ms / (1000 * 60)) % 60)
+
+  ms -= minutes * 1000 * 60
+
+  const hours = parseInt(ms / (1000 * 60 * 60))
+
+  // only biggest unit should be negative if negative duration
+  if (minutes < 0 || hours < 0) {
+    seconds = Math.abs(seconds)
+  }
+  if (hours < 0) {
+    minutes = Math.abs(minutes)
+  }
+
   return {
     hours,
     minutes,

--- a/packages/tocco-util/src/date/utils.spec.js
+++ b/packages/tocco-util/src/date/utils.spec.js
@@ -22,10 +22,25 @@ describe('tocco-util', () => {
         })
 
         test('should correctly handle tiny values', () => {
-          // previously we used parseInt to cut of decimals, which has strange results when passing in small numbers
           expect(millisecondsToDuration(1)).to.be.eql({hours: 0, minutes: 0, seconds: 0.001})
           expect(millisecondsToDuration(2)).to.be.eql({hours: 0, minutes: 0, seconds: 0.002})
           expect(millisecondsToDuration(3)).to.be.eql({hours: 0, minutes: 0, seconds: 0.003})
+        })
+
+        test('should correctly handle negative values (milliseconds)', () => {
+          expect(millisecondsToDuration(-3)).to.be.eql({hours: 0, minutes: 0, seconds: -0.003})
+        })
+
+        test('should correctly handle negative values (seconds)', () => {
+          expect(millisecondsToDuration(-12003)).to.be.eql({hours: 0, minutes: 0, seconds: -12.003})
+        })
+
+        test('should correctly handle negative values (minutes)', () => {
+          expect(millisecondsToDuration(-1032003)).to.be.eql({hours: 0, minutes: -17, seconds: 12.003})
+        })
+
+        test('should correctly handle negative values (hours)', () => {
+          expect(millisecondsToDuration(-101832003)).to.be.eql({hours: -28, minutes: 17, seconds: 12.003})
         })
       })
 


### PR DESCRIPTION
- `options.allowNegative` will be set to true, if there is no number
  range validation or if `fromIncluding` is less than 0
- if negative values are allowed, the minus sign "-" will be displayed
  in the biggest unit that's not 0 (so, in the minutes field, if there are
  no hours, and in the hours field, if there are hours)
- other improvements:
-- minutes can also be greater or equal to 60 now -> value is converted
   to hours and minutes then (old hours value will be deleted)
-- removed automatic rewriting of minutes to 0 or to 59 in certain
   conditions as it was rather irritating than helpful

Changelog: allow duration values to be negative
Refs: TOCDEV-5338
Cherry-pick: Up