### PR TITLE
fix(tocco-util): debouncer accepts value changes from outside

### DIFF
--- a/packages/tocco-util/src/react/Debouncer.js
+++ b/packages/tocco-util/src/react/Debouncer.js
@@ -11,7 +11,7 @@ const Debouncer = (Component, delay = 200, func = 'onChange') => {
   const Comp = React.forwardRef((props, ref) => {
     const {value} = props
     const [internalValue, setInternalValue] = useState(value)
-    const debouncedValue = useDebounce(internalValue, delay)
+    const [debouncedValue, setDebouncedValue] = useDebounce(internalValue, delay)
 
     const oldValue = useRef(value)
     const callback = props[func]
@@ -20,6 +20,8 @@ const Debouncer = (Component, delay = 200, func = 'onChange') => {
     useEffect(() => {
       if (internalValue !== value && internalValue === debouncedValue) {
         setInternalValue(value)
+        // reset debounce value to accept props.value changes anytime (ignore delay in this case)
+        setDebouncedValue(value)
         oldValue.current = value
       }
     }, [value]) // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/tocco-util/src/react/Debouncer.spec.js
+++ b/packages/tocco-util/src/react/Debouncer.spec.js
@@ -7,7 +7,7 @@ import Debouncer from './Debouncer'
 
 describe('tocco-util', () => {
   describe('react', () => {
-    describe('useDebounce', () => {
+    describe('Debouncer', () => {
       let clock
 
       beforeEach(() => {
@@ -90,6 +90,23 @@ describe('tocco-util', () => {
 
         input.simulate('change', {target: {value: 'Test3'}})
         input.simulate('change', {target: {value: 'Test4'}})
+      })
+
+      test('should be able to change value from outside multiple times within the given debounce delay', async () => {
+        const value = 'Test'
+        const onChangeSpy = sinon.spy()
+
+        const wrapper = mount(<TestComponent value={value} onChange={onChangeSpy} />)
+
+        wrapper.setProps({value: 'ABC'})
+        wrapper.update()
+
+        expect(wrapper.find('input').prop('value')).to.eql('ABC')
+
+        wrapper.setProps({value: 'DEF'})
+        wrapper.update()
+
+        expect(wrapper.find('input').prop('value')).to.eql('DEF')
       })
     })
   })

--- a/packages/tocco-util/src/react/useDebounce.js
+++ b/packages/tocco-util/src/react/useDebounce.js
@@ -13,5 +13,5 @@ export default function useDebounce(value, delay) {
     }
   }, [value, delay])
 
-  return debouncedValue
+  return [debouncedValue, setDebouncedValue]
 }

--- a/packages/tocco-util/src/react/useDebounce.spec.js
+++ b/packages/tocco-util/src/react/useDebounce.spec.js
@@ -1,12 +1,23 @@
 /* eslint-disable react/prop-types */
 import {mount} from 'enzyme'
 import React, {useEffect, useState} from 'react'
+import {act} from 'react-dom/test-utils'
 
 import useDebounce from './useDebounce'
 
 describe('tocco-util', () => {
   describe('hooks', () => {
     describe('useDebounce', () => {
+      let clock
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers()
+      })
+
+      afterEach(() => {
+        clock.restore()
+      })
+
       test('should call onChange callback debounced', async () => {
         const initialValue = 'Test'
 
@@ -14,7 +25,7 @@ describe('tocco-util', () => {
 
         const TestComponent = ({value, onChange}) => {
           const [internalValue, setInternalValue] = useState(value)
-          const debouncedValue = useDebounce(internalValue, 100)
+          const [debouncedValue] = useDebounce(internalValue, 100)
 
           useEffect(() => {
             onChange(debouncedValue)
@@ -30,23 +41,39 @@ describe('tocco-util', () => {
         input.simulate('change', {target: {value: 'Test1'}})
         input.simulate('change', {target: {value: 'Test2'}})
 
-        await new Promise(resolve =>
-          setTimeout(() => {
-            input.simulate('change', {target: {value: 'Test3'}})
-            input.simulate('change', {target: {value: 'Test4'}})
-            resolve()
-          }, 250)
-        )
+        act(() => {
+          clock.tick(100)
+        })
 
-        await new Promise(resolve =>
-          setTimeout(() => {
-            expect(onChangeSpy).to.have.been.calledThrice
-            expect(onChangeSpy).to.have.been.calledWith(initialValue)
-            expect(onChangeSpy).to.have.been.calledWith('Test2')
-            expect(onChangeSpy).to.have.been.calledWith('Test4')
-            resolve()
-          }, 250)
-        )
+        input.simulate('change', {target: {value: 'Test3'}})
+        input.simulate('change', {target: {value: 'Test4'}})
+
+        act(() => {
+          clock.tick(100)
+        })
+
+        expect(onChangeSpy).to.have.been.calledThrice
+        expect(onChangeSpy).to.have.been.calledWith(initialValue)
+        expect(onChangeSpy).to.have.been.calledWith('Test2')
+        expect(onChangeSpy).to.have.been.calledWith('Test4')
+      })
+
+      test('should be able to reset debounce value from outside anytime', async () => {
+        const initialValue = 'Test'
+
+        const TestComponent = props => {
+          const [debouncedValue, setDebouncedValue] = useDebounce(props.value, 100)
+
+          return <input onChange={e => setDebouncedValue(e.target.value)} value={debouncedValue} />
+        }
+
+        const wrapper = mount(<TestComponent value={initialValue} />)
+
+        wrapper.find('input').simulate('change', {target: {value: 'Test1'}})
+        expect(wrapper.find('input').prop('value')).to.eql('Test1')
+
+        wrapper.find('input').simulate('change', {target: {value: 'Test2'}})
+        expect(wrapper.find('input').prop('value')).to.eql('Test2')
       })
     })
   })


### PR DESCRIPTION
- somehow the search form did switch to `undefined` value shortly
before settings the correct search value right again
- the debounce component only accepted changed from outside every 200ms
- now the debounce component accpets all changes from outside right away
because the `debouncedValue` gets reset

Refs: TOCDEV-5350
Changelog: debouncer accepts value changes from outside
Cherry-pick: Up