### PR TITLE
fix(tocco-ui): fix update of the values and field widths in duration

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/DurationEdit.js
@@ -1,29 +1,18 @@
 import PropTypes from 'prop-types'
-import React, {useRef, useState, useEffect} from 'react'
+import React, {useState} from 'react'
 import {date} from 'tocco-util'
 
 import Typography from '../../Typography'
 import {StyledEditableWrapper} from '../StyledEditableValue'
 import {calculateMilliseconds} from '../utils'
-import {StyledDurationEditShadow, StyledDurationEditFocusable, StyledDurationEdit} from './StyledDurationEdit'
+import {StyledDurationEditFocusable, StyledDurationEdit} from './StyledDurationEdit'
+
+const DIGIT_WIDTH = 9
 
 const DurationEdit = ({value, immutable, onChange, options}) => {
-  const hoursShadow = useRef(null)
-  const minutesShadow = useRef(null)
-  const secondsShadow = useRef(null)
-
   const duration = date.millisecondsToDuration(value)
 
-  const [hoursWidth, setHoursWidth] = useState(0)
-  const [minutesWidth, setMinutesWidth] = useState(0)
-  const secondsWidth = secondsShadow.current?.offsetWidth || 0
-
   const [focused, setFocused] = useState(false)
-
-  useEffect(() => {
-    setHoursWidth(hoursShadow.current.offsetWidth)
-    setMinutesWidth(minutesShadow.current.offsetWidth)
-  }, [])
 
   const handleHourChange = e => {
     const hours = e.target.value.replace(/[^-\d]/g, '')
@@ -78,6 +67,8 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
 
   const unitsVisible = () => focused || typeof value === 'number'
 
+  const getFieldWidth = value => (value + '').length * DIGIT_WIDTH
+
   /**
    * We don't want to offer the user to enter the duration in seconds,
    * because hours/minutes are already accurate enough.
@@ -100,9 +91,9 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
           onKeyPress={preventNonNumeric}
           pattern={getPattern()}
           step={1}
-          width={hoursWidth}
+          width={getFieldWidth(duration.hours)}
           type="number"
-          value={typeof duration.hours === 'number' && (duration.hours !== 0 || immutable) ? duration.hours : ''}
+          value={typeof duration.hours === 'number' && (duration.hours !== 0 || immutable) ? duration.hours + '' : ''}
         />
         {unitsVisible() && <Typography.Span>{options.hoursLabel}</Typography.Span>}
       </StyledDurationEditFocusable>
@@ -117,9 +108,9 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
           onKeyPress={preventNonNumeric}
           pattern={getPattern()}
           step={1}
-          width={minutesWidth}
+          width={getFieldWidth(duration.minutes)}
           type="number"
-          value={duration.minutes}
+          value={duration.minutes + ''}
         />
         {unitsVisible() && <Typography.Span>{options.minutesLabel}</Typography.Span>}
       </StyledDurationEditFocusable>
@@ -129,16 +120,13 @@ const DurationEdit = ({value, immutable, onChange, options}) => {
             disabled={immutable}
             immutable={immutable}
             onChange={() => {}} // Empty onChange function to prevent React internal error
-            width={secondsWidth}
+            width={getFieldWidth(duration.seconds)}
             type="number"
-            value={duration.seconds}
+            value={duration.seconds + ''}
           />
           {unitsVisible() && <Typography.Span>{options.secondsLabel}</Typography.Span>}
         </StyledDurationEditFocusable>
       )}
-      <StyledDurationEditShadow ref={hoursShadow}>{duration.hours}</StyledDurationEditShadow>
-      <StyledDurationEditShadow ref={minutesShadow}>{duration.minutes}</StyledDurationEditShadow>
-      {showSeconds && <StyledDurationEditShadow ref={secondsShadow}>{duration.seconds}</StyledDurationEditShadow>}
     </StyledEditableWrapper>
   )
 }

--- a/packages/tocco-ui/src/EditableValue/typeEditors/StyledDurationEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/StyledDurationEdit.js
@@ -1,7 +1,7 @@
 import _get from 'lodash/get'
 import styled from 'styled-components'
 
-import {declareFont, generateDisabledShade, scale, theme} from '../../utilStyles'
+import {generateDisabledShade, scale, theme} from '../../utilStyles'
 import {StyledInputCss} from '../StyledEditableValue'
 
 const StyledDurationEdit = styled.input`
@@ -33,17 +33,4 @@ const StyledDurationEditFocusable = styled.label`
   }
 `
 
-const StyledDurationEditShadow = styled.span`
-  && {
-    border: 1px solid transparent;
-    left: 0;
-    max-width: 100%;
-    overflow: hidden;
-    position: absolute;
-    z-index: -1;
-    visibility: hidden;
-    ${declareFont}
-  }
-`
-
-export {StyledDurationEditShadow, StyledDurationEditFocusable, StyledDurationEdit}
+export {StyledDurationEditFocusable, StyledDurationEdit}


### PR DESCRIPTION
- The value should be set as string, otherwise it's not updated for some
  reason (e.g. if the current value is 1 hr and 0 min and you append "1"
  in the minutes field, the value remains "01" if the value is given as
  a number and it changes to "1" (desired) if the value is given as
  string
- Also fixed the automatic growing of the fields as the user types. The
  `useEffect` hook was never called, so it didn't work at all. Handling
  those field widths in the state and width the additional shadow fields
  is sort of complicated overkill (which didn't even work), just giving
  every character a specific width (9 px for now) and deriving the field
  width from the number of characters should be good enough for this
  case (and more stable).

Refs: TOCDEV-5338
Cerry-pick: Up
Changelog: update of the values and field widths in duration edit fixed