### PR TITLE
feat(app-extensions,tocco-util): support selectors in forms

### DIFF
--- a/packages/core/app-extensions/src/form/reduxForm.spec.js
+++ b/packages/core/app-extensions/src/form/reduxForm.spec.js
@@ -206,27 +206,51 @@ describe('app-extensions', () => {
           expect(drityFormValues).to.deep.eql({})
         })
 
-        test('should handle multi paths correclty', () => {
+        test('should handle multi paths correctly', () => {
           const values = {
             relGender: {key: '2', version: 3, model: 'Gender'},
-            'relGender.relXy': {key: '33', version: 4},
-            'relGender.relXy.Z': 'TEST',
-            'relGender.relXy.Y': 'TEST'
+            'relGender--relXy': {key: '33', version: 4},
+            'relGender--relXy--Z': 'TEST',
+            'relGender--relXy--Y': 'TEST'
           }
 
           const initialValues = {
             relGender: {key: '2', version: 3, model: 'Gender'},
-            'relGender.relXy': {key: '33', version: 4},
-            'relGender.relXy.Z': '', // changed
-            'relGender.relXy.Y': 'TEST'
+            'relGender--relXy': {key: '33', version: 4},
+            'relGender--relXy--Z': '', // changed
+            'relGender--relXy--Y': 'TEST'
           }
 
           const drityFormValues = reduxForm.getDirtyFormValues(initialValues, values)
 
           expect(drityFormValues).to.deep.eql({
             relGender: {key: '2', version: 3, model: 'Gender'},
-            'relGender.relXy': {key: '33', version: 4},
-            'relGender.relXy.Z': 'TEST'
+            'relGender--relXy': {key: '33', version: 4},
+            'relGender--relXy--Z': 'TEST'
+          })
+        })
+
+        test('should keep meta fields for selectors', () => {
+          const values = {
+            'relAddress_user=-=publication=_=': {key: '2', version: 3, model: 'Address_user'},
+            'relAddress_user=-=publication=_=--relAddress': {key: '7', version: 1, model: 'Address'},
+            'relAddress_user=-=publication=_=--relAddress--address_c': 'Hauptrasse 7a',
+            'relAddress_user=-=publication=_=--relAddress--zip_c': '8400'
+          }
+
+          const initialValues = {
+            'relAddress_user=-=publication=_=': {key: '2', version: 3, model: 'Address_user'},
+            'relAddress_user=-=publication=_=--relAddress': {key: '7', version: 1, model: 'Address'},
+            'relAddress_user=-=publication=_=--relAddress--address_c': 'Hauptrasse 1', // changed
+            'relAddress_user=-=publication=_=--relAddress--zip_c': '8400'
+          }
+
+          const drityFormValues = reduxForm.getDirtyFormValues(initialValues, values)
+
+          expect(drityFormValues).to.deep.eql({
+            'relAddress_user=-=publication=_=': {key: '2', version: 3, model: 'Address_user'},
+            'relAddress_user=-=publication=_=--relAddress': {key: '7', version: 1, model: 'Address'},
+            'relAddress_user=-=publication=_=--relAddress--address_c': 'Hauptrasse 7a' // changed
           })
         })
       })

--- a/packages/core/tocco-util/src/api/entities.js
+++ b/packages/core/tocco-util/src/api/entities.js
@@ -102,10 +102,16 @@ export const toEntity = flattenEntity => {
     return _isObject(value) ? _pick(value, ['key', 'version', 'id', 'resourceKey']) : value
   }
 
-  const paths = Object.keys(flattenEntity).reduce((acc, path) => {
-    if (!ignoredPath(path)) {
-      const t = path.split('.').join('.paths.')
-      return _set(acc, t, valueSimplifier(flattenEntity[path]))
+  const paths = Object.keys(flattenEntity).reduce((acc, flattenEntityPath) => {
+    if (!ignoredPath(flattenEntityPath)) {
+      const entityPath = flattenEntityPath
+        .split('.')
+        // add `paths` object
+        .join('.paths.')
+        // use array to support selectors as valid object key (e.g. relAddress[publication])
+        .split('.')
+
+      return _set(acc, entityPath, valueSimplifier(flattenEntity[flattenEntityPath]))
     }
     return acc
   }, {})

--- a/packages/core/tocco-util/src/api/entities.spec.js
+++ b/packages/core/tocco-util/src/api/entities.spec.js
@@ -516,6 +516,42 @@ describe('tocco-util', () => {
         expect(result.model).to.eql('User')
         expect(result.version).to.eql(3)
       })
+
+      test('should set selectors correctly', () => {
+        const values = {
+          __version: 3,
+          __key: '2',
+          __model: 'User',
+          'relAddress_user[publication]': {key: '33', version: 4, model: 'Address_user'},
+          'relAddress_user[publication].relAddress': {key: '7', version: 1, model: 'Address'},
+          'relAddress_user[publication].relAddress.address_c': 'Hauptstrasse 1'
+        }
+
+        const result = toEntity(values)
+
+        const expected = {
+          key: '2',
+          version: 3,
+          model: 'User',
+          paths: {
+            'relAddress_user[publication]': {
+              key: '33',
+              version: 4,
+              paths: {
+                relAddress: {
+                  key: '7',
+                  version: 1,
+                  paths: {
+                    address_c: 'Hauptstrasse 1'
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        expect(result).to.deep.eql(expected)
+      })
     })
   })
 })


### PR DESCRIPTION
- Selectors (relAddress[publication]) has not been fully supported yet
- apply workaround for redux form to handle [,] in field names
- fix entity mapping for not nesting names containing [,]

Refs: TOCDEV-5365
Changelog: support selectors in forms