### PR TITLE
fix(tocco-ui): support browser plugins for phone numbers

### DIFF
--- a/packages/core/tocco-ui/src/FormattedValue/typeFormatters/PhoneFormatter.js
+++ b/packages/core/tocco-ui/src/FormattedValue/typeFormatters/PhoneFormatter.js
@@ -4,7 +4,15 @@ import {lazy, Suspense} from 'react'
 const LibPhoneFormatter = lazy(() => import(/* webpackChunkName: "phone-formatter" */ './LibPhoneFormatter'))
 
 const LazyPhoneFormatter = props => (
-  <Suspense fallback={props.value}>
+  /**
+   * Having a fallback value of `props.value` leads to react errors
+   * when user has installed a browser plugin that interacts with phone numbers.
+   *
+   * The number is rendered (unformatted) and right afte that React wants to remove fallback node
+   * to replace it with LibPhoneFormatter. When fallback node already has been touched from the
+   * browser plugin react cannot interact with it anymore.
+   */
+  <Suspense fallback="">
     <LibPhoneFormatter {...props} />
   </Suspense>
 )


### PR DESCRIPTION
- 3CX Click2Call chrome plugin was interacting with the html node
of the phone number.
- React Suspense componentent wasn't able to render
 lazy loaded `LibPhoneFormatter` anymore.
- Therefore render phone number only once.

Refs: TOCDEV-5427
Changelog: support browser plugins for phone numbers
Cherry-pick: Up