### PR TITLE
fix(tocco-ui): fix too many debounced callbacks being called

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditorFactory.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditorFactory.js
@@ -52,11 +52,16 @@ const isFlatpickrType = type => ['date', 'datetime'].includes(type)
 const TypeEditorFactory = ({type, value, options, id, events, readOnly = false}) => {
   const flatpickrBlurValue = useRef(undefined)
 
-  const onChange = events.onChange
-  const callback = useCallback(v => {
-    flatpickrBlurValue.current = v
-    onChange(v)
-  }, [onChange])
+  const onChange = events?.onChange
+  const callback = useCallback(
+    v => {
+      flatpickrBlurValue.current = v
+      if (onChange) {
+        onChange(v)
+      }
+    },
+    [onChange]
+  )
 
   if (map[type]) {
     const Component = map[type]

--- a/packages/tocco-ui/src/EditableValue/typeEditorFactory.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditorFactory.js
@@ -1,7 +1,7 @@
 import _isEmpty from 'lodash/isEmpty'
 import _omit from 'lodash/omit'
 import PropTypes from 'prop-types'
-import React, {useRef} from 'react'
+import React, {useRef, useCallback} from 'react'
 
 import BoolEdit from './typeEditors/BoolEdit'
 import CodeEdit from './typeEditors/CodeEdit'
@@ -52,6 +52,12 @@ const isFlatpickrType = type => ['date', 'datetime'].includes(type)
 const TypeEditorFactory = ({type, value, options, id, events, readOnly = false}) => {
   const flatpickrBlurValue = useRef(undefined)
 
+  const onChange = events.onChange
+  const callback = useCallback(v => {
+    flatpickrBlurValue.current = v
+    onChange(v)
+  }, [onChange])
+
   if (map[type]) {
     const Component = map[type]
 
@@ -73,10 +79,7 @@ const TypeEditorFactory = ({type, value, options, id, events, readOnly = false})
       <div {..._omit(events, 'onChange')} data-cy="form-field">
         <Component
           value={value}
-          onChange={v => {
-            flatpickrBlurValue.current = v
-            events.onChange(v)
-          }}
+          onChange={callback}
           {...(_isEmpty(options) ? {} : {options})}
           id={id}
           immutable={readOnly}

--- a/packages/tocco-util/src/react/Debouncer.js
+++ b/packages/tocco-util/src/react/Debouncer.js
@@ -20,9 +20,9 @@ const Debouncer = (Component, delay = 200, func = 'onChange') => {
     useEffect(() => {
       if (internalValue !== value && internalValue === debouncedValue) {
         setInternalValue(value)
+        oldValue.current = value
         // reset debounce value to accept props.value changes anytime (ignore delay in this case)
         setDebouncedValue(value)
-        oldValue.current = value
       }
     }, [value]) // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
- inline functions would always technically be different on re-renders and triggered dependencies in Debouncer

Refs: TOCDEV-5412
Changelog: fix too many field callbacks being called
Cherry-pick: Up