### PR TITLE
fix(app-extensions): fix state handlig for report settings

### DIFF
--- a/packages/app-extensions/src/actions/components/ReportSettings.js
+++ b/packages/app-extensions/src/actions/components/ReportSettings.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, {useState, useMemo, useRef} from 'react'
+import React, {useState, useMemo} from 'react'
 import {FormattedMessage, injectIntl} from 'react-intl'
 import {Button} from 'tocco-ui'
 
@@ -13,25 +13,23 @@ export const ReportSettings = ({settingsDefinition, formApp, onSubmit, listApp, 
     valid: false,
     customSettingsValid: !customSettingsDefined
   })
-  const settingsRef = useRef()
-  settingsRef.current = settings // workaround to read current state in static callbacks (because of memo hook)
 
   const SimpleFormContainer = useMemo(() => simpleFormConnector(formApp), [formApp])
 
   const handleSettingsChange = ({values, valid}) => {
-    setSettings({
-      ...settingsRef.current,
+    setSettings(s => ({
+      ...s,
       values,
       valid
-    })
+    }))
   }
 
   const handleCustomSettingsChange = ({values, valid}) => {
-    setSettings({
-      ...settingsRef.current,
+    setSettings(s => ({
+      ...s,
       customSettings: values,
       customSettingsValid: valid
-    })
+    }))
   }
 
   const handleButtonClick = () => {


### PR DESCRIPTION
- settingsRef was not updated when `setSettings` has
 been called right after each other (withour render in between)
- using `setState` as function to be able to access latest state
 should be the safest option

Refs: TOCDEV-5423
Changelog: fix state handling for report settings
Cherry-pick: Up