### PR TITLE
fix(tocco-ui): render html escape characters in breadcrumbs

### DIFF
--- a/packages/tocco-ui/src/Breadcrumbs/BreadcrumbSeparator.js
+++ b/packages/tocco-ui/src/Breadcrumbs/BreadcrumbSeparator.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+import Icon from '../Icon'
+import {StyledBreadcrumbSeparator} from './StyledBreadcrumbs'
+
+const BreadcrumbSeparator = () => (
+  <StyledBreadcrumbSeparator breakWords>
+    <Icon icon="chevron-right" />
+  </StyledBreadcrumbSeparator>
+)
+
+export default BreadcrumbSeparator

--- a/packages/tocco-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/tocco-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import {Helmet} from 'react-helmet'
+import {html} from 'tocco-util'
 
 import Icon from '../Icon'
 import Typography from '../Typography'
+import BreadcrumbSeparator from './BreadcrumbSeparator'
 import {StyledBreadcrumbs, StyledBreadcrumbsLink, StyledBreadcrumbsTitle} from './StyledBreadcrumbs'
 
 const getTitle = breadcrumbsInfo =>
@@ -32,7 +34,6 @@ const Breadcrumbs = ({pathPrefix, breadcrumbsInfo, currentView, backgroundColor,
         <title>{getTitle(breadcrumbs)}</title>
       </Helmet>
       <div>
-        {' '}
         {breadcrumbs
           .map((b, idx) => {
             const display = b.display || ''
@@ -47,19 +48,12 @@ const Breadcrumbs = ({pathPrefix, breadcrumbsInfo, currentView, backgroundColor,
                 >
                   {b.type === 'list' && <Icon icon="list" />}
                   {b.type === 'error' && <Icon icon="exclamation-circle" />}
-                  {display}
+                  <span dangerouslySetInnerHTML={{__html: html.sanitizeHtml(display)}} />
                 </Comp>
               </Typography.Span>
             )
           })
-          .reduce((prev, curr, idx) => [
-            prev,
-            <Typography.Span key={'icon' + idx}>
-              {' '}
-              <Icon icon="chevron-right" />{' '}
-            </Typography.Span>,
-            curr
-          ])}
+          .reduce((prev, curr, idx) => [prev, <BreadcrumbSeparator key={'icon' + idx} />, curr])}
       </div>
     </StyledBreadcrumbs>
   )

--- a/packages/tocco-ui/src/Breadcrumbs/StyledBreadcrumbs.js
+++ b/packages/tocco-ui/src/Breadcrumbs/StyledBreadcrumbs.js
@@ -2,6 +2,7 @@
 import styled from 'styled-components'
 
 import {AdminLink as StyledLink} from '../AdminLink'
+import {StyledSpan} from '../Typography'
 import {theme} from '../utilStyles'
 
 export const StyledBreadcrumbs = styled.div`
@@ -10,11 +11,6 @@ export const StyledBreadcrumbs = styled.div`
   padding: 0.8rem 1.7rem;
   position: relative;
   z-index: 2; // higher than StyledTether to prevent cover on scroll
-
-  span:nth-child(even) {
-    margin-left: 0.9rem;
-    margin-right: 0.9rem;
-  }
 `
 
 export const StyledBreadcrumbsLink = styled(StyledLink)`
@@ -58,4 +54,9 @@ export const StyledBreadcrumbsTitle = styled.span`
   &:active * {
     color: ${theme.color('primary')};
   }
+`
+
+export const StyledBreadcrumbSeparator = styled(StyledSpan)`
+  margin-left: 0.9rem;
+  margin-right: 0.9rem;
 `


### PR DESCRIPTION
Changelog: render html escape characters in breadcrumbs
Refs: TOCDEV-5492
Cherry-pick: Up