### PR TITLE
chore: do not publish new widget packages

### DIFF
--- a/packages/widgets/address-update/package.json
+++ b/packages/widgets/address-update/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tocco-address-update",
   "version": "0.1.15",
+  "private": true,
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/widgets/wage-view/package.json
+++ b/packages/widgets/wage-view/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tocco-wage-view",
   "version": "0.1.10",
+  "private": true,
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- we use `widget-bundle` as package for now
- can be set back to public anytime

Refs: TOCDEV-5379