### PR TITLE
feat(tocco-ui): show from and to placeholders on number ranges

### DIFF
--- a/packages/tocco-ui/src/EditableValue/typeEditors/NumberEdit.js
+++ b/packages/tocco-ui/src/EditableValue/typeEditors/NumberEdit.js
@@ -98,6 +98,7 @@ const NumberEdit = props => {
         prefix={prefix}
         {...numberFormatOptions}
         format={format}
+        placeholder={props.placeholder}
         onBlur={handleBlur}
       />
     </StyledEditableWrapper>
@@ -109,6 +110,7 @@ NumberEdit.propTypes = {
   value: PropTypes.number,
   name: PropTypes.string,
   id: PropTypes.string,
+  placeholder: PropTypes.string,
   intl: PropTypes.object,
   immutable: PropTypes.bool,
   options: PropTypes.shape({


### PR DESCRIPTION
Changelog: show from and to placeholders on number ranges
Refs: TOCDEV-5189, TOCDEV-5511