### PR TITLE
fix(tocco-ui): prevent infinite re-render loop on table

### DIFF
--- a/packages/tocco-ui/src/Table/selection/useSelection.js
+++ b/packages/tocco-ui/src/Table/selection/useSelection.js
@@ -6,10 +6,10 @@ const removeAllTextSelections = () => {
   }
 }
 
-export default (selection = [], currentKeys, onSelectChange) => {
+export default (selection, currentKeys, onSelectChange) => {
   const [lastSelected, setLastSelected] = useState(null)
 
-  const isSelected = useCallback(key => selection.includes(key), [selection])
+  const isSelected = useCallback(key => (selection || []).includes(key), [selection])
 
   const selectionChange = useCallback(
     (key, value, shiftSelection) => {


### PR DESCRIPTION
- table without selection feature passed undefined selection as prop
- useSelection default value triggered infinite re-render loop

Refs: TOCDEV-5453
Cherry-pick: Up