### PR TITLE
chore: set widget packages to private

### DIFF
--- a/packages/widget-utils/package.json
+++ b/packages/widget-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tocco-widget-utils",
   "version": "0.1.4-hotfix31.3",
+  "private": true,
   "description": "",
   "scripts": {
     "compile:prod": "cd ../../ && npm run compile:prod -- --package=widget-utils",


### PR DESCRIPTION
widgets are currently only developed in the master so we won't bugfix anything