### PR TITLE
refactor(tocco-ui): add initial sorting

### DIFF
--- a/packages/core/tocco-ui/src/ColumnPicker/ColumnPicker.js
+++ b/packages/core/tocco-ui/src/ColumnPicker/ColumnPicker.js
@@ -19,7 +19,8 @@ import {
 const ColumnPicker = ({onOk, dndEnabled, initialColumns, intl, buttonLabel}) => {
   const [columns, setColumns] = useState([])
   const someUnchecked = columns.some(column => column.hidden)
-  useEffect(() => setColumns(initialColumns), [initialColumns])
+  const initialColumnsSorted = initialColumns.sort((a, b) => a.hidden - b.hidden)
+  useEffect(() => setColumns(initialColumnsSorted), [initialColumnsSorted])
   const [searchTerm, setSearchTerm] = useState(null)
   const changeColumnPosition = useCallback(
     (currentlyDragging, currentlyDragOver) => {
@@ -42,6 +43,7 @@ const ColumnPicker = ({onOk, dndEnabled, initialColumns, intl, buttonLabel}) => 
     )
 
     return filteredColumns.map((column, idx) => {
+      const isDraggedOver = dndState.currentlyDragOver === column.id && dndState.currentlyDragging !== column.id
       const handleChange = value => {
         setColumns(
           columns
@@ -61,7 +63,7 @@ const ColumnPicker = ({onOk, dndEnabled, initialColumns, intl, buttonLabel}) => 
         <StyledItem
           key={column.id}
           draggable={dndEnabled}
-          isDraggedOver={dndState.currentlyDragOver === column.id && dndState.currentlyDragging !== column.id}
+          isDraggedOver={isDraggedOver}
           {...(dndEnabled && {...dndEvents(column.id)})}
         >
           <StyledCheckbox type={'checkbox'} id={column.id} checked={!column.hidden} onChange={handleChange} />

--- a/packages/core/tocco-ui/src/ColumnPicker/StyledColumnPicker.js
+++ b/packages/core/tocco-ui/src/ColumnPicker/StyledColumnPicker.js
@@ -50,6 +50,7 @@ export const StyledId = styled.span`
 `
 
 export const StyledItem = styled(StyledLi)`
+  display: flex;
   padding: ${scale.space(-2)} ${scale.space(-2)} ${scale.space(-2)} 0;
   border-right: ${({isDraggedOver, theme}) => (isDraggedOver ? `3px solid ${theme.colors.secondary}` : 'none')};
   ${({draggable, theme}) =>


### PR DESCRIPTION
Refs: TOCDEV-5534
Changelog: add initial column sorting to column picker and fix long labels