### PR TITLE
fix(entity-list): fix loading form definition for dms

### DIFF
--- a/packages/entity-list/src/modules/list/sagas.js
+++ b/packages/entity-list/src/modules/list/sagas.js
@@ -366,7 +366,7 @@ export function* setSorting() {
 
 export function* loadFormDefinition(formName, scope) {
   const {formDefinition} = yield select(listSelector)
-  if (!formDefinition) {
+  if (formDefinition?.id !== `${formName}_${scope}`) {
     const fetchedFormDefinition = yield call(rest.fetchForm, formName, scope)
     yield put(actions.setFormDefinition(fetchedFormDefinition))
     yield call(extractFormInformation, fetchedFormDefinition)

--- a/packages/entity-list/src/modules/list/sagas.spec.js
+++ b/packages/entity-list/src/modules/list/sagas.spec.js
@@ -382,8 +382,8 @@ describe('entity-list', () => {
 
         describe('loadFormDefinition saga', () => {
           test('should load form definition', () => {
-            const fetchedFormDefinition = {}
-            return expectSaga(sagas.loadFormDefinition)
+            const fetchedFormDefinition = {id: 'User_detail'}
+            return expectSaga(sagas.loadFormDefinition, 'User', 'detail')
               .provide([
                 [select(sagas.listSelector), {}],
                 [matchers.call.fn(sagas.extractFormInformation)],
@@ -393,15 +393,30 @@ describe('entity-list', () => {
               .call(sagas.extractFormInformation, fetchedFormDefinition)
               .run()
           })
+
           test('should not load form definition if already loaded', () => {
-            const selectFormDefinition = {}
-            return expectSaga(sagas.loadFormDefinition)
+            const selectFormDefinition = {id: 'User_detail'}
+            return expectSaga(sagas.loadFormDefinition, 'User', 'detail')
               .provide([
                 [select(sagas.listSelector), {formDefinition: selectFormDefinition}],
                 [matchers.call.fn(sagas.extractFormInformation)]
               ])
               .not.put(actions.setFormDefinition(selectFormDefinition))
               .call(sagas.extractFormInformation, selectFormDefinition)
+              .run()
+          })
+
+          test('should load form definition if other formName is passed', () => {
+            const selectFormDefinition = {id: 'Root_docs_list_item_list'}
+            const fetchedFormDefinition = {id: 'Docs_list_item_list'}
+            return expectSaga(sagas.loadFormDefinition, 'Docs_list_item', 'list')
+              .provide([
+                [select(sagas.listSelector), {formDefinition: selectFormDefinition}],
+                [matchers.call.fn(sagas.extractFormInformation)],
+                [matchers.call.fn(rest.fetchForm), fetchedFormDefinition]
+              ])
+              .put(actions.setFormDefinition(fetchedFormDefinition))
+              .call(sagas.extractFormInformation, fetchedFormDefinition)
               .run()
           })
         })


### PR DESCRIPTION
with the commit 555e5b9c8c472cd761e434565af212b88cb02f8d (TOCDEV-5604) the formDefinition passed via input properties there correcly handled. however the dms was now broken as the if condition only checks if the form was already loaded and not of the correct form definition exists (the dms has different forms such as Root_docs_list_item_list and Docs_list_item_list)

Changelog: fix loading form definition for dms
Refs: TOCDEV-5009
Cherry-pick: Up