### PR TITLE
fix(tocco-util): fix datetime in searchforms after using date-fns

### DIFF
--- a/packages/core/tocco-util/src/tqlBuilder/utils.js
+++ b/packages/core/tocco-util/src/tqlBuilder/utils.js
@@ -41,6 +41,10 @@ export const parseInLocalTime = value => {
   if (isMatch(value, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")) {
     return new Date(value)
   }
+
+  if (isMatch(value, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx")) {
+    return new Date(value)
+  }
 }
 
 /**

--- a/packages/core/tocco-util/src/tqlBuilder/utils.spec.js
+++ b/packages/core/tocco-util/src/tqlBuilder/utils.spec.js
@@ -45,6 +45,14 @@ describe('tocco-util', () => {
 
           expect(date.toISOString()).to.eql('2022-01-04T12:00:00.000Z')
         })
+
+        test('should parse datetime string with timezone as local time', () => {
+          const dateTimezoneString = '2022-01-04T14:00:00.000+02:00'
+
+          const date = parseInLocalTime(dateTimezoneString)
+
+          expect(date.toISOString()).to.eql('2022-01-04T12:00:00.000Z')
+        })
       })
 
       describe('parseTime', () => {


### PR DESCRIPTION
Refs: TOCDEV-5625
Changelog: fix datetime in searchforms after using date-fns