### PR TITLE
feat(tocco-util): useAutofocus can prioritize fulltext search fields

### DIFF
--- a/packages/core/entity-list/src/components/AdminSearchForm/SearchView.js
+++ b/packages/core/entity-list/src/components/AdminSearchForm/SearchView.js
@@ -55,7 +55,7 @@ const SearchView = ({
   const [searchFilterExpanded, setSearchFilterExpanded] = useState(false)
   const [showExpandSearchFilter, setShowExpandSearchFilter] = useState(false)
 
-  customHooks.useAutofocus(searchFormEl, [initialized])
+  customHooks.useAutofocus(searchFormEl, {selectFulltextFields: true}, [initialized])
 
   useEffect(() => {
     const searchFilterHeight = searchFilters

--- a/packages/core/entity-list/src/components/BasicSearchForm/BasicSearchForm.js
+++ b/packages/core/entity-list/src/components/BasicSearchForm/BasicSearchForm.js
@@ -25,7 +25,7 @@ const BasicSearchForm = ({
 }) => {
   const searchFormEl = useRef(null)
 
-  customHooks.useAutofocus(searchFormEl, [searchFormDefinition])
+  customHooks.useAutofocus(searchFormEl, {selectFulltextFields: true}, [searchFormDefinition])
 
   if (!searchFormDefinition.children) {
     return null

--- a/packages/core/tocco-util/src/react/useAutofocus.js
+++ b/packages/core/tocco-util/src/react/useAutofocus.js
@@ -1,13 +1,25 @@
 import {useEffect} from 'react'
 
-const useAutofocus = (reference, dependencies = []) =>
+/**
+ * options may contain:
+ * - selectFulltextFields, tries to find a search field with and id ending with txtFulltext first
+ */
+const useAutofocus = (reference, options = {}, dependencies = []) =>
   useEffect(() => {
     if (reference.current) {
-      const firstInput = reference.current.querySelector(
+      if (options.selectFulltextFields) {
+        const firstFulltextInput = reference.current.querySelector('input[id$="txtFulltext"]:not([disabled])')
+        if (firstFulltextInput) {
+          firstFulltextInput.focus()
+          return
+        }
+      }
+
+      const firstTextInput = reference.current.querySelector(
         'input[type = "text"]:not([disabled]), textarea:not([disabled])'
       )
-      if (firstInput) {
-        firstInput.focus()
+      if (firstTextInput) {
+        firstTextInput.focus()
       }
     }
   }, dependencies) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Refs: TOCDEV-5502
Cherry-pick: Up
Changelog: fulltext search fields are now prioritized to be autofocused