### PR TITLE
feat(tocco-ui): allow date inputs without punctuation

### DIFF
--- a/packages/core/tocco-ui/src/EditableValue/editors/DateEdit.js
+++ b/packages/core/tocco-ui/src/EditableValue/editors/DateEdit.js
@@ -5,7 +5,7 @@ import {date} from 'tocco-util'
 import {toLocalDateString} from '../utils'
 import LazyDatePicker from './LazyDatePicker'
 
-const DateFormat = 'P' // MM/dd/yyyy od. dd.MM.yyyy
+const DateFormat = 'P' // MM/dd/yyyy od. dd.MM.y
 
 export const DateEdit = ({onChange, options, id, value, immutable, events, placeholder}) => {
   const intl = useIntl()
@@ -19,13 +19,19 @@ export const DateEdit = ({onChange, options, id, value, immutable, events, place
 
   // to support direct input such as 01032020
   const dateFormatWithoutPunctuation = date.getLocalizedDateFormatWithoutPunctuation(intl.locale)
+  const dateFormats = [
+    DateFormat,
+    dateFormatWithoutPunctuation,
+    date.useTwoDigitYear(DateFormat), // to support direct input such as 01.03.22
+    date.useTwoDigitYear(dateFormatWithoutPunctuation) // to support direct input such as 010322
+  ]
 
   return (
     <LazyDatePicker
       id={id}
       value={value}
       onChange={handleChange}
-      dateFormat={[DateFormat, dateFormatWithoutPunctuation]}
+      dateFormat={dateFormats}
       hasTime={false}
       immutable={immutable}
       events={events}

--- a/packages/core/tocco-ui/src/EditableValue/editors/DateEdit.js
+++ b/packages/core/tocco-ui/src/EditableValue/editors/DateEdit.js
@@ -1,4 +1,6 @@
 import PropTypes from 'prop-types'
+import {useIntl} from 'react-intl'
+import {date} from 'tocco-util'
 
 import {toLocalDateString} from '../utils'
 import LazyDatePicker from './LazyDatePicker'
@@ -6,6 +8,8 @@ import LazyDatePicker from './LazyDatePicker'
 const DateFormat = 'P' // MM/dd/yyyy od. dd.MM.yyyy
 
 export const DateEdit = ({onChange, options, id, value, immutable, events, placeholder}) => {
+  const intl = useIntl()
+
   const handleChange = dateTime => {
     const date = dateTime ? toLocalDateString(dateTime) : null
     onChange(date)
@@ -13,12 +17,15 @@ export const DateEdit = ({onChange, options, id, value, immutable, events, place
 
   const datePickerOptions = options?.datePickerOptions || {}
 
+  // to support direct input such as 01032020
+  const dateFormatWithoutPunctuation = date.getLocalizedDateFormatWithoutPunctuation(intl.locale)
+
   return (
     <LazyDatePicker
       id={id}
       value={value}
       onChange={handleChange}
-      dateFormat={DateFormat}
+      dateFormat={[DateFormat, dateFormatWithoutPunctuation]}
       hasTime={false}
       immutable={immutable}
       events={events}

--- a/packages/core/tocco-ui/src/EditableValue/editors/DatePicker.js
+++ b/packages/core/tocco-ui/src/EditableValue/editors/DatePicker.js
@@ -182,7 +182,7 @@ DatePicker.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
   hasTime: PropTypes.bool,
-  dateFormat: PropTypes.string,
+  dateFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   placeholder: PropTypes.string,
   immutable: PropTypes.bool,
   initialized: PropTypes.func,

--- a/packages/core/tocco-ui/src/EditableValue/editors/DatePicker.spec.js
+++ b/packages/core/tocco-ui/src/EditableValue/editors/DatePicker.spec.js
@@ -2,6 +2,7 @@ import {startOfDay, startOfMonth} from 'date-fns'
 import {mount} from 'enzyme'
 import {IntlProvider} from 'react-intl'
 import {intlEnzyme} from 'tocco-test-util'
+import {date as dateUtil} from 'tocco-util'
 
 import {loadLocales} from '../../DatePicker/utils'
 import DatePicker from './DatePicker'
@@ -84,6 +85,28 @@ describe('tocco-ui', () => {
 
           const expectedDate = new Date('06/14/2022 10:00').toISOString()
           expect(onChangeSpy).to.have.been.calledWith(expectedDate)
+        })
+
+        test('should be able to enter a date in different format', () => {
+          const onChangeSpy = sinon.spy()
+          const wrapper = mount(
+            <IntlProvider locale="de-CH" defaultLocale="de-CH">
+              <DatePicker
+                onChange={onChangeSpy}
+                hasTime
+                dateFormat={['P', dateUtil.getLocalizedDateFormatWithoutPunctuation('de-CH')]}
+              />
+            </IntlProvider>
+          )
+
+          const input = wrapper.find('.react-datepicker__input-container input')
+          input.simulate('focus')
+
+          input.simulate('change', {target: {value: '14062022'}})
+
+          const date = new Date('06/14/2022').toISOString()
+          expect(onChangeSpy).to.have.been.calledOnce
+          expect(onChangeSpy).to.have.been.calledWith(date)
         })
       })
     })

--- a/packages/core/tocco-ui/src/EditableValue/editors/DateTimeEdit.js
+++ b/packages/core/tocco-ui/src/EditableValue/editors/DateTimeEdit.js
@@ -4,7 +4,7 @@ import {date} from 'tocco-util'
 
 import LazyDatePicker from './LazyDatePicker'
 
-const DateTimeFormat = 'Pp' // MM/dd/yyyy hh:mm a.m. od. dd.MM.yyyy hh:mm
+const DateTimeFormat = 'Pp' // MM/dd/yyyy hh:mm a.m. od. dd.MM.y hh:mm
 
 export const DateTimeEdit = ({onChange, options, value, immutable, events, placeholder}) => {
   const intl = useIntl()
@@ -13,12 +13,18 @@ export const DateTimeEdit = ({onChange, options, value, immutable, events, place
 
   // to support direct input such as 01032020 1230
   const dateTimeFormatWithoutPunctuation = date.getLocalizedDateTimeFormatWithoutPunctuation(intl.locale)
+  const dateFormats = [
+    DateTimeFormat,
+    dateTimeFormatWithoutPunctuation,
+    date.useTwoDigitYear(DateTimeFormat), // to support direct input such as 01.03.22 12:30
+    date.useTwoDigitYear(dateTimeFormatWithoutPunctuation) // to support direct input such as 010322 12:30
+  ]
 
   return (
     <LazyDatePicker
       value={value}
       onChange={onChange}
-      dateFormat={[DateTimeFormat, dateTimeFormatWithoutPunctuation]}
+      dateFormat={dateFormats}
       hasTime
       immutable={immutable}
       events={events}

--- a/packages/core/tocco-ui/src/EditableValue/editors/DateTimeEdit.js
+++ b/packages/core/tocco-ui/src/EditableValue/editors/DateTimeEdit.js
@@ -1,18 +1,24 @@
 import PropTypes from 'prop-types'
-import {injectIntl} from 'react-intl'
+import {injectIntl, useIntl} from 'react-intl'
+import {date} from 'tocco-util'
 
 import LazyDatePicker from './LazyDatePicker'
 
-const DateFormat = 'Pp' // MM/dd/yyyy hh:mm a.m. od. dd.MM.yyyy hh:mm
+const DateTimeFormat = 'Pp' // MM/dd/yyyy hh:mm a.m. od. dd.MM.yyyy hh:mm
 
 export const DateTimeEdit = ({onChange, options, value, immutable, events, placeholder}) => {
+  const intl = useIntl()
+
   const datePickerOptions = options?.datePickerOptions || {}
+
+  // to support direct input such as 01032020 1230
+  const dateTimeFormatWithoutPunctuation = date.getLocalizedDateTimeFormatWithoutPunctuation(intl.locale)
 
   return (
     <LazyDatePicker
       value={value}
       onChange={onChange}
-      dateFormat={DateFormat}
+      dateFormat={[DateTimeFormat, dateTimeFormatWithoutPunctuation]}
       hasTime
       immutable={immutable}
       events={events}

--- a/packages/core/tocco-util/src/date/index.js
+++ b/packages/core/tocco-util/src/date/index.js
@@ -5,7 +5,8 @@ import {
   getLocalizedDateFormat,
   getLocalizedDateFormatWithoutPunctuation,
   getLocalizedDateTimeFormatWithoutPunctuation,
-  getLocalizedTimeFormat
+  getLocalizedTimeFormat,
+  useTwoDigitYear
 } from './utils'
 
 export default {
@@ -15,5 +16,6 @@ export default {
   getLocalizedDateFormat,
   getLocalizedDateFormatWithoutPunctuation,
   getLocalizedDateTimeFormatWithoutPunctuation,
-  getLocalizedTimeFormat
+  getLocalizedTimeFormat,
+  useTwoDigitYear
 }

--- a/packages/core/tocco-util/src/date/index.js
+++ b/packages/core/tocco-util/src/date/index.js
@@ -1,3 +1,19 @@
-import {millisecondsToDuration, formatDuration, getDateFnsLocale} from './utils'
+import {
+  millisecondsToDuration,
+  formatDuration,
+  getDateFnsLocale,
+  getLocalizedDateFormat,
+  getLocalizedDateFormatWithoutPunctuation,
+  getLocalizedDateTimeFormatWithoutPunctuation,
+  getLocalizedTimeFormat
+} from './utils'
 
-export default {millisecondsToDuration, formatDuration, getDateFnsLocale}
+export default {
+  millisecondsToDuration,
+  formatDuration,
+  getDateFnsLocale,
+  getLocalizedDateFormat,
+  getLocalizedDateFormatWithoutPunctuation,
+  getLocalizedDateTimeFormatWithoutPunctuation,
+  getLocalizedTimeFormat
+}

--- a/packages/core/tocco-util/src/date/utils.js
+++ b/packages/core/tocco-util/src/date/utils.js
@@ -73,3 +73,20 @@ export const getDateFnsLocale = locale => {
       return de
   }
 }
+
+export const getLocalizedDateFormat = locale => {
+  const {formatLong} = getDateFnsLocale(locale)
+
+  return formatLong.date({width: 'short'})
+}
+
+export const getLocalizedTimeFormat = locale => {
+  const {formatLong} = getDateFnsLocale(locale)
+
+  return formatLong.time({width: 'short'})
+}
+
+export const getLocalizedDateFormatWithoutPunctuation = locale => getLocalizedDateFormat(locale).replace(/[/.]/g, '')
+export const getLocalizedTimeFormatWithoutPunctuation = locale => getLocalizedTimeFormat(locale).replace(/[:]/g, '')
+export const getLocalizedDateTimeFormatWithoutPunctuation = locale =>
+  `${getLocalizedDateFormatWithoutPunctuation(locale)} ${getLocalizedTimeFormatWithoutPunctuation(locale)}`

--- a/packages/core/tocco-util/src/date/utils.js
+++ b/packages/core/tocco-util/src/date/utils.js
@@ -90,3 +90,5 @@ export const getLocalizedDateFormatWithoutPunctuation = locale => getLocalizedDa
 export const getLocalizedTimeFormatWithoutPunctuation = locale => getLocalizedTimeFormat(locale).replace(/[:]/g, '')
 export const getLocalizedDateTimeFormatWithoutPunctuation = locale =>
   `${getLocalizedDateFormatWithoutPunctuation(locale)} ${getLocalizedTimeFormatWithoutPunctuation(locale)}`
+
+export const useTwoDigitYear = format => format.replace(/y+/, 'yy')

--- a/packages/core/tocco-util/src/date/utils.spec.js
+++ b/packages/core/tocco-util/src/date/utils.spec.js
@@ -1,4 +1,11 @@
-import {formatDuration, millisecondsToDuration} from './utils'
+import {
+  formatDuration,
+  millisecondsToDuration,
+  getLocalizedDateFormat,
+  getLocalizedDateFormatWithoutPunctuation,
+  getLocalizedDateTimeFormatWithoutPunctuation,
+  getLocalizedTimeFormat
+} from './utils'
 
 describe('tocco-util', () => {
   describe('date', () => {
@@ -61,6 +68,62 @@ describe('tocco-util', () => {
 
           const duration = '00:02'
           expect(formatDuration(ms)).to.equal(duration)
+        })
+      })
+
+      describe('getLocalizedDateFormat', () => {
+        test('should return P format for de-CH', () => {
+          const format = getLocalizedDateFormat('de-CH')
+
+          expect(format).to.eql('dd.MM.y')
+        })
+
+        test('should return P format for en', () => {
+          const format = getLocalizedDateFormat('en')
+
+          expect(format).to.eql('MM/dd/yyyy')
+        })
+      })
+
+      describe('getLocalizedTimeFormat', () => {
+        test('should return p format for de-CH', () => {
+          const format = getLocalizedTimeFormat('de-CH')
+
+          expect(format).to.eql('HH:mm')
+        })
+
+        test('should return p format for en', () => {
+          const format = getLocalizedTimeFormat('en')
+
+          expect(format).to.eql('h:mm a')
+        })
+      })
+
+      describe('getLocalizedDateFormatWithoutPunctuation', () => {
+        test('should return P format for de-CH without any dots', () => {
+          const format = getLocalizedDateFormatWithoutPunctuation('de-CH')
+
+          expect(format).to.eql('ddMMy')
+        })
+
+        test('should return P format for en without any slashes', () => {
+          const format = getLocalizedDateFormatWithoutPunctuation('en')
+
+          expect(format).to.eql('MMddyyyy')
+        })
+      })
+
+      describe('getLocalizedDateTimeFormatWithoutPunctuation', () => {
+        test('should return Pp format for de-CH without any dots and colons', () => {
+          const format = getLocalizedDateTimeFormatWithoutPunctuation('de-CH')
+
+          expect(format).to.eql('ddMMy HHmm')
+        })
+
+        test('should return Pp format for en without any slashes and colons', () => {
+          const format = getLocalizedDateTimeFormatWithoutPunctuation('en')
+
+          expect(format).to.eql('MMddyyyy hmm a')
         })
       })
     })

--- a/packages/core/tocco-util/src/date/utils.spec.js
+++ b/packages/core/tocco-util/src/date/utils.spec.js
@@ -4,7 +4,8 @@ import {
   getLocalizedDateFormat,
   getLocalizedDateFormatWithoutPunctuation,
   getLocalizedDateTimeFormatWithoutPunctuation,
-  getLocalizedTimeFormat
+  getLocalizedTimeFormat,
+  useTwoDigitYear
 } from './utils'
 
 describe('tocco-util', () => {
@@ -124,6 +125,18 @@ describe('tocco-util', () => {
           const format = getLocalizedDateTimeFormatWithoutPunctuation('en')
 
           expect(format).to.eql('MMddyyyy hmm a')
+        })
+      })
+
+      describe('useTwoDigitYear', () => {
+        test('should replace any year format with two year format', () => {
+          expect(useTwoDigitYear('dd.MM.yyyy')).to.eql('dd.MM.yy')
+          expect(useTwoDigitYear('dd.MM.y')).to.eql('dd.MM.yy')
+          expect(useTwoDigitYear('ddMMy')).to.eql('ddMMyy')
+          expect(useTwoDigitYear('MM/dd/yyyy')).to.eql('MM/dd/yy')
+          expect(useTwoDigitYear('MMddyyyy')).to.eql('MMddyy')
+          expect(useTwoDigitYear('dd.MM.y HH:mm')).to.eql('dd.MM.yy HH:mm')
+          expect(useTwoDigitYear('MMddyyyy hmm a')).to.eql('MMddyy hmm a')
         })
       })
     })


### PR DESCRIPTION
Refs: TOCDEV-5679
Changelog: allow date inputs without punctuation