### PR TITLE
feat(admin): make entity docs sortable

### DIFF
--- a/packages/apps/admin/src/routes/entities/components/DocsView/DocsView.js
+++ b/packages/apps/admin/src/routes/entities/components/DocsView/DocsView.js
@@ -3,7 +3,7 @@ import {useEffect, useState, useCallback} from 'react'
 import {rest} from 'tocco-app-extensions'
 import DocsBrowserApp from 'tocco-docs-browser/src/main'
 
-const DocsView = ({entityName, entityKey, showActions, noLeftPadding, openResource, initialLocation}) => {
+const DocsView = ({entityName, entityKey, showActions, noLeftPadding, openResource, initialLocation, sortable}) => {
   const [folderKey, setFolderKey] = useState(null)
 
   const fetchFolder = useCallback(async () => {
@@ -22,7 +22,7 @@ const DocsView = ({entityName, entityKey, showActions, noLeftPadding, openResour
         routerType="routerless"
         initialLocation={initialLocation}
         noLeftPadding={noLeftPadding}
-        sortable={false}
+        sortable={sortable}
         searchFormType="none"
         rootNodes={[
           {
@@ -47,7 +47,8 @@ DocsView.propTypes = {
   showActions: PropTypes.bool.isRequired,
   noLeftPadding: PropTypes.bool,
   openResource: PropTypes.func,
-  initialLocation: PropTypes.string
+  initialLocation: PropTypes.string,
+  sortable: PropTypes.bool
 }
 
 export default DocsView

--- a/packages/apps/admin/src/routes/entities/components/RelationsView/DocsViewAdapter.js
+++ b/packages/apps/admin/src/routes/entities/components/RelationsView/DocsViewAdapter.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import {currentViewPropType} from '../../utils/propTypes'
 import DocsView from '../DocsView'
 
-const DocsViewAdapter = ({currentViewInfo, history, selectedRelation}) => (
+const DocsViewAdapter = ({currentViewInfo, history, selectedRelation, sortable}) => (
   <DocsView
     entityName={currentViewInfo.model.name}
     entityKey={currentViewInfo.key}
@@ -13,6 +13,7 @@ const DocsViewAdapter = ({currentViewInfo, history, selectedRelation}) => (
     openResource={location => {
       history.push(`${selectedRelation.relationName}/list#${location}`)
     }}
+    sortable={sortable}
   />
 )
 
@@ -21,7 +22,8 @@ DocsViewAdapter.propTypes = {
   selectedRelation: PropTypes.shape({
     relationName: PropTypes.string.isRequired
   }).isRequired,
-  currentViewInfo: currentViewPropType
+  currentViewInfo: currentViewPropType,
+  sortable: PropTypes.bool
 }
 
 export default DocsViewAdapter

--- a/packages/apps/admin/src/routes/entities/components/RelationsView/RelationsView.js
+++ b/packages/apps/admin/src/routes/entities/components/RelationsView/RelationsView.js
@@ -103,6 +103,7 @@ const RelationsView = props => {
               history={history}
               currentViewInfo={currentViewInfo}
               emitAction={emitAction}
+              sortable={true}
             />
           </StyledPreviewBox>
         )}


### PR DESCRIPTION
Cherry-pick: Up
Refs: TOCDEV-5429
Changelog: entity docs can now be sorted