### PR TITLE
feat(app-extensions): add default sorting to remotefields

### DIFF
--- a/packages/app-extensions/src/formData/relationEntities/sagas.js
+++ b/packages/app-extensions/src/formData/relationEntities/sagas.js
@@ -54,7 +54,7 @@ export function* finalizeOptions(entityName, options) {
     return {
       ...options,
       constriction: constriction || getConstriction(remoteFieldFormDefinition),
-      sorting: sorting || getSorting(remoteFieldFormDefinition)
+      sorting: sorting || getSorting(remoteFieldFormDefinition) || [{field: 'update_timestamp', order: 'desc'}]
     }
   }
   return options
@@ -62,7 +62,7 @@ export function* finalizeOptions(entityName, options) {
 
 export const getSorting = formDefinition => {
   const table = getTable(formDefinition)
-  return table?.sorting || []
+  return table?.sorting || null
 }
 
 export const getConstriction = formDefinition => {

--- a/packages/app-extensions/src/formData/relationEntities/sagas.spec.js
+++ b/packages/app-extensions/src/formData/relationEntities/sagas.spec.js
@@ -291,6 +291,32 @@ describe('app-extensions', () => {
               })
           })
 
+          test('should use update_timestamp as fallback sorting', () => {
+            const formDefinitionWithoutSorting = {
+              children: [
+                {
+                  componentType: form.componentTypes.TABLE,
+                  constriction: 'const'
+                }
+              ]
+            }
+            const initialOptions = {loadRemoteFieldConfiguration: true}
+            return expectSaga(sagas.finalizeOptions, 'User', initialOptions)
+              .provide([[matchers.call.fn(rest.fetchForm), formDefinitionWithoutSorting]])
+              .call.like({
+                fn: rest.fetchForm,
+                args: ['User', 'remotefield']
+              })
+              .run()
+              .then(result => {
+                expect(result.returnValue).to.eql({
+                  constriction: 'const',
+                  sorting: [{field: 'update_timestamp', order: 'desc'}],
+                  loadRemoteFieldConfiguration: true
+                })
+              })
+          })
+
           test('should not load form when nothing needs to be loaded', () => {
             const initialOptions = {loadRemoteFieldConfiguration: true, sorting: 'passed', constriction: 'passed'}
             return expectSaga(sagas.finalizeOptions, 'User', initialOptions)


### PR DESCRIPTION
Refs: TOCDEV-5753
Cherry-pick: Up
Changelog: remotefields now sort the same way in select box and advanced search (form sorting first, then last updated)