### PR TITLE
fix(docs-browser): fix navigation to subfolder inside search results

### DIFF
--- a/packages/widgets/docs-browser/src/components/DocsView/DocsView.js
+++ b/packages/widgets/docs-browser/src/components/DocsView/DocsView.js
@@ -91,8 +91,10 @@ const DocsView = props => {
 
   const mounted = useRef(false)
   const searchModeRef = useRef(searchMode)
+  const pathRef = useRef(path)
 
   searchModeRef.current = searchMode
+  pathRef.current = path
 
   useEffect(() => {
     mounted.current = true
@@ -112,7 +114,14 @@ const DocsView = props => {
   const handleRowClick = ({id}) => {
     onSelectChange([id])
 
-    if (searchModeRef.current && isRootLocation(path)) {
+    /**
+     * Workaround for potential EntityList Bug:
+     *   onRowClick event is only attached once initially and does not get proper updates
+     *
+     * - props.searchMode and props.path are potentially outdated at time of invocation
+     * - using those values in refs will return always latest values
+     */
+    if (searchModeRef.current && isRootLocation(pathRef.current)) {
       if (!viewPersistor.viewInfoSelector('search').store) {
         // persist search store to allow a "go back to search"
         const searchStore = viewPersistor.viewInfoSelector(entityListKey).store


### PR DESCRIPTION
- external event `onRowClick` is only attached inititally
  - `handleRowClick` is dependent on props that will change over time
    - e.g. searchMode or path
  - to be able to access latest value we need to use refs

Refs: TOCDEV-5350
Cherry-pick: Up
Changelog: fix navigation to subfolder inside search results