### PR TITLE
chore: fix widget-server setup in cypress

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,6 +196,7 @@ cypress:
     - yarn db:prepare
     - yarn db:dump
     - yarn widgets:serve &
+    - yarn widgets:wait-for-readyness
     - yarn nice2:wait-for-readyness
     - yarn cypress:run
   artifacts:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "storybook": "start-storybook -p 3003 -c ./storybook",
     "storybook:master": "cross-env BACKEND=https://master.tocco.ch yarn storybook",
     "widgets:serve": "node ./scripts/widgets/server.js",
+    "widgets:wait-for-readyness": "bash ./scripts/widgets/wait-for-readyness.sh",
     "nice2:copy-package": "babel-node build/scripts/copy-package-to-nice2",
     "nice2:deploy-package": "both () { yarn compile:prod \"$*\"; yarn nice2:copy-package \"$*\";}; both",
     "nice2:run": "bash ./scripts/nice2/run.sh",

--- a/scripts/nice2/helpers.sh
+++ b/scripts/nice2/helpers.sh
@@ -87,6 +87,21 @@ function waitForNice2() {
   echo "nice2 is connected"
 }
 
+function widgetServerIsReady() {
+  statusCode=$(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:3000)
+  if [[ "$statusCode" -ne 200 ]] ; then
+    return 1;
+  else
+    return 0;
+  fi
+}
+
+function waitForWidgetServer() {
+  echo "wait for widget-server: http://localhost:3000"
+  waitFor widgetServerIsReady
+  echo "widget-server is ready"
+}
+
 function emptyDB() {
   echo "drop database '$databaseDatabasename'"
 

--- a/scripts/widgets/server.js
+++ b/scripts/widgets/server.js
@@ -2,7 +2,7 @@ const compress = require('compression')
 const express = require('express')
 const {createProxyMiddleware} = require('http-proxy-middleware')
 
-const backendUrl = process.env.CYPRESS_BACKEND_URL || 'http://localhost:8080'
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:8080'
 
 const app = express()
 app.use(compress()) // Apply gzip compression

--- a/scripts/widgets/wait-for-readyness.sh
+++ b/scripts/widgets/wait-for-readyness.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+source ./scripts/nice2/helpers.sh
+
+waitForWidgetServer


### PR DESCRIPTION
- replace removed CYPRESS_BACKEND_URL with BACKEND_URL
- ensure widget-server is ready before starting cypress on gitlab