### PR TITLE
refactor(tocco-ui): show collapse icon on mobile

### DIFF
--- a/packages/core/tocco-ui/src/Panel/Panel.js
+++ b/packages/core/tocco-ui/src/Panel/Panel.js
@@ -10,11 +10,11 @@ import StyledPanel from './StyledPanel'
 const Panel = ({children, isFramed = true, controlledIsOpen, isOpenInitial = true, isToggleable = true, onToggle}) => {
   const [isOpen, setIsOpen] = useState(isOpenInitial)
 
-  const controlled = typeof controlledIsOpen === 'boolean'
+  const isControlled = typeof controlledIsOpen === 'boolean'
 
   const toggleOpenState = () => {
     if (isToggleable) {
-      if (controlled) {
+      if (isControlled) {
         if (typeof onToggle === 'function') {
           onToggle(!controlledIsOpen)
         }
@@ -29,7 +29,7 @@ const Panel = ({children, isFramed = true, controlledIsOpen, isOpenInitial = tru
       {React.Children.map(children, child =>
         React.cloneElement(child, {
           isFramed,
-          isOpen: controlled ? controlledIsOpen : isOpen,
+          isOpen: isControlled ? controlledIsOpen : isOpen,
           isToggleable,
           toggleOpenState
         })

--- a/packages/core/tocco-ui/src/Panel/StyledPanelHeaderFooter.js
+++ b/packages/core/tocco-ui/src/Panel/StyledPanelHeaderFooter.js
@@ -48,11 +48,15 @@ const declareDivider = ({theme, isOpen, isFramed}) => {
 }
 
 export const StyledIconWrapper = styled.span`
-  opacity: 0;
   font-size: ${scale.font(1)};
 
-  &:hover {
-    color: ${theme.color('secondaryLight')};
+  /* only hide arrow on non-touch devices */
+  @media (hover: hover) and (pointer: fine) {
+    opacity: 0;
+
+    &:hover {
+      color: ${theme.color('secondaryLight')};
+    }
   }
 `
 
@@ -63,11 +67,14 @@ const StyledPanelHeaderFooter = styled.div`
     padding: ${({isFramed}) => (isFramed ? '4px 8px 4px 8px' : 0)};
     align-items: center;
 
-    &:hover {
-      cursor: pointer;
+    /* only apply arrow styles on non-touch devices */
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        cursor: pointer;
 
-      ${StyledIconWrapper} {
-        opacity: 1;
+        ${StyledIconWrapper} {
+          opacity: 1;
+        }
       }
     }
 


### PR DESCRIPTION
Refs: TOCDEV-5866
Changelog: show collapse/expand icon on touch devices in panel header/footer