### PR TITLE
feat(subscribe-calendar): use more generic error message

### DIFF
--- a/packages/actions/subscribe-calendar/src/modules/subscribeCalendar/sagas.js
+++ b/packages/actions/subscribe-calendar/src/modules/subscribeCalendar/sagas.js
@@ -36,7 +36,7 @@ export function* fetchCalendarLinks() {
     yield put(
       externalEvents.fireExternalEvent('onError', {
         title: 'client.actions.subscribe-calendar.toasterTitle',
-        message: 'client.actions.subscribe-calendar.noLecturerCalendar'
+        message: 'client.actions.subscribe-calendar.noCalendars'
       })
     )
   }

--- a/packages/actions/subscribe-calendar/src/modules/subscribeCalendar/sagas.spec.js
+++ b/packages/actions/subscribe-calendar/src/modules/subscribeCalendar/sagas.spec.js
@@ -90,7 +90,7 @@ describe('subscribe-calendar', () => {
               .put(
                 externalEvents.fireExternalEvent('onError', {
                   title: 'client.actions.subscribe-calendar.toasterTitle',
-                  message: 'client.actions.subscribe-calendar.noLecturerCalendar'
+                  message: 'client.actions.subscribe-calendar.noCalendars'
                 })
               )
               .run()


### PR DESCRIPTION
Refs: TOCDEV-5849
Changelog: use more generic error message when no Calendar_export_conf could be found
Cherry-pick: Up