### PR TITLE
fix: handle default values in expanded Range fields correctly

### DIFF
--- a/packages/core/app-extensions/src/field/editableValueFactory.js
+++ b/packages/core/app-extensions/src/field/editableValueFactory.js
@@ -41,7 +41,8 @@ const EditableValueProvider = ({
       options={options}
       {...(range && {
         fromText: formData.intl.formatMessage({id: 'client.component.range.from'}),
-        toText: formData.intl.formatMessage({id: 'client.component.range.to'})
+        toText: formData.intl.formatMessage({id: 'client.component.range.to'}),
+        expanded: formField.expanded
       })}
     />
   )
@@ -54,7 +55,8 @@ EditableValueProvider.propTypes = {
   formName: PropTypes.string,
   formField: PropTypes.shape({
     dataType: PropTypes.string,
-    componentType: PropTypes.string
+    componentType: PropTypes.string,
+    expanded: PropTypes.bool // only if it's a range component
   }),
   value: PropTypes.any,
   info: PropTypes.object,

--- a/packages/core/app-extensions/src/field/editableValueFactory.spec.js
+++ b/packages/core/app-extensions/src/field/editableValueFactory.spec.js
@@ -1,7 +1,7 @@
 import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {intlEnzyme} from 'tocco-test-util'
-import {EditableValue} from 'tocco-ui'
+import {EditableValue, Range} from 'tocco-ui'
 
 import editableValueFactory from './editableValueFactory'
 
@@ -55,6 +55,51 @@ describe('app-extensions', () => {
 
         expect(wrapper.find(EditableValue)).to.have.length(1)
         expect(wrapper.find(EditableValue).props()).to.have.property('value', 'test')
+      })
+
+      test('should return range component if requested', () => {
+        const Field = editableValueFactory('date')
+
+        const formField = {
+          expanded: true
+        }
+        const modelField = {}
+        const formName = 'searchForm'
+        const value = '2022-04-26'
+        const info = {mandatory: false, readOnly: false}
+        const onChangeSpy = sinon.spy()
+        const events = {onChange: onChangeSpy}
+        const formData = {
+          intl: {
+            formatMessage: obj => obj.id
+          }
+        }
+
+        const wrapper = intlEnzyme.mountWithIntl(
+          <Provider store={store}>
+            <Field
+              formField={formField}
+              modelField={modelField}
+              formName={formName}
+              value={value}
+              info={info}
+              events={events}
+              formData={formData}
+              range
+            />
+          </Provider>
+        )
+
+        const rangeCmp = wrapper.find(Range)
+
+        expect(rangeCmp).to.have.length(1)
+
+        const rangeProps = rangeCmp.props()
+
+        expect(rangeProps).to.have.property('expanded', true)
+        expect(rangeProps).to.have.property('value', '2022-04-26')
+        expect(rangeProps).to.have.property('fromText', 'client.component.range.from')
+        expect(rangeProps).to.have.property('toText', 'client.component.range.to')
       })
     })
   })

--- a/packages/core/tocco-ui/src/Range/Range.spec.js
+++ b/packages/core/tocco-ui/src/Range/Range.spec.js
@@ -21,6 +21,14 @@ describe('tocco-ui', () => {
         expect(wrapper.find(EditableValue)).to.have.length(2)
       })
 
+      test('should change to range value if expanded prop and single value', () => {
+        const onChangeSpy = sinon.spy()
+        intlEnzyme.mountWithIntl(
+          <Range type="number" options={{}} value={3} events={{onChange: onChangeSpy}} expanded />
+        )
+        expect(onChangeSpy).to.have.been.calledWith({isRangeValue: true, from: 3, to: undefined})
+      })
+
       test('should change to range value on expander click', () => {
         const onChangeSpy = sinon.spy()
         const wrapper = intlEnzyme.mountWithIntl(


### PR DESCRIPTION
- New `expanded` prop to display the range field initially expanded
  with a *single* value (before, the expanded mode was only used if
  the value was a range value)
- If a single value is given and expanded mode required, the single
  value will be used as `from` value. This is the same behavior as
  in the legacy client (as of today there is no actual use case
  where we're required to set a `to` value instead of the `from`)
- Example where this is useful: there are a few widgets with a date
  range field in the search form to show records with a date field
  with values starting from today

Refs: TOCDEV-5497
Changelog: default values in initially expanded Range fields handled correctly