### PR TITLE
fix(sso-login): fix null pointer in login box

### DIFF
--- a/packages/widgets/sso-login/src/components/LoginBox/LoginBox.js
+++ b/packages/widgets/sso-login/src/components/LoginBox/LoginBox.js
@@ -6,13 +6,13 @@ import {openLoginWindow} from '../../utils/loginWindow'
 import ProviderButton from '../ProviderButton/ProviderButton'
 import {StyledButtonContainer} from './StyledComponents'
 
-const LoginBox = ({loadProviders, autoLogin, providers, loginEndpoint, loginCompleted}) => {
+const LoginBox = ({loadProviders, autoLogin, providers = [], loginEndpoint, loginCompleted}) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => loadProviders(), []) // only invoke the loadprovider func once at the beginning
   const prevProps = react.usePrevious(providers)
 
   useEffect(() => {
-    if (autoLogin && prevProps.length === 0 && providers.length > 0) {
+    if (autoLogin && (!prevProps || prevProps.length === 0) && providers.length > 0) {
       const autoLoginProvider = providers.find(entity => entity.unique_id === autoLogin)
 
       if (autoLoginProvider) {


### PR DESCRIPTION
On initial render, the `providers` prop might be undefined. We need to check for that.

Refs: TOCDEV-6006
Changelog: fix null pointer in login box
Cherry-pick: Up