### PR TITLE
fix(tocco-util): do not autofocus date fields

### DIFF
--- a/packages/core/tocco-util/src/react/useAutofocus.js
+++ b/packages/core/tocco-util/src/react/useAutofocus.js
@@ -16,7 +16,10 @@ const useAutofocus = (reference, options = {}, dependencies = []) =>
       }
 
       const firstTextInput = reference.current.querySelector(
-        'input[type = "text"]:not([disabled]), textarea:not([disabled])'
+        [
+          ':not(.react-datepicker-wrapper) input[type = "text"]:not([disabled])',
+          ':not(.react-datepicker-wrapper) textarea:not([disabled])'
+        ].join(',')
       )
       if (firstTextInput) {
         firstTextInput.focus()


### PR DESCRIPTION
Refs: TOCDEV-5923
Cherry-pick: Up
Changelog: ignore any text and textarea fields of a datepicker when autofocusing