### PR TITLE
fix(entity-list): do not refresh list multiple times

### DIFF
--- a/packages/core/entity-list/src/main.js
+++ b/packages/core/entity-list/src/main.js
@@ -143,7 +143,7 @@ const EntityListApp = props => {
     const changedProps = _pickBy(props, (value, key) => !_isEqual(value, prevProps[key]))
     if (
       (changedProps.store && typeof prevProps.store !== 'undefined') ||
-      (typeof changedProps.store === 'undefined' && typeof prevProps.store !== 'undefined')
+      (typeof props.store === 'undefined' && typeof prevProps.store !== 'undefined')
     ) {
       /**
        * Whenever the store gets explicitly changed from outside


### PR DESCRIPTION
- changedProps.store is undefined when store has not changed
- nevertheless it could be that store is defined on props
- to figure out if store has been removed from props it's needed to check if store is set on props and not on changedProps

Refs: TOCDEV-5912
Changelog: do not refresh list multiple times