### PR TITLE
fix(entity-list): show correct search form in subgrid

### DIFF
--- a/packages/core/entity-list/src/components/EntityList/EntityListContainer.js
+++ b/packages/core/entity-list/src/components/EntityList/EntityListContainer.js
@@ -14,7 +14,7 @@ const mapActionCreators = {
 }
 
 const mapStateToProps = state => ({
-  searchFormType: state.input.searchFormType,
+  searchFormType: state.entityList.searchFormType,
   searchFormPosition: state.input.searchFormPosition,
   searchFormCollapsed: state.input.searchFormCollapsed,
   scrollBehaviour: state.input.scrollBehaviour

--- a/packages/core/entity-list/src/input.js
+++ b/packages/core/entity-list/src/input.js
@@ -1,6 +1,6 @@
 import {action} from 'tocco-util'
 
-import {setSearchFormType, setSearchFormCollapsedInitialValue} from './modules/entityList/actions'
+import {setSearchFormCollapsedInitialValue, setSearchFormTypeFromInput} from './modules/entityList/actions'
 import {setSearchFilters, setFormDefinition as setListFormDefinition} from './modules/list/actions'
 import {setSimpleSearchFields} from './modules/searchForm/actions'
 import {setSelection} from './modules/selection/actions'
@@ -52,7 +52,7 @@ const actionSettings = [
   },
   {
     name: 'searchFormType',
-    action: setSearchFormType,
+    action: setSearchFormTypeFromInput,
     argsFactory: input => [input.searchFormType],
     reload: reloadOptions.DATA
   },

--- a/packages/core/entity-list/src/modules/entityList/actions.js
+++ b/packages/core/entity-list/src/modules/entityList/actions.js
@@ -1,6 +1,7 @@
 export const SET_INITIALIZED = 'entityList/SET_INITIALIZED'
 export const INITIALIZE = 'entityList/INITIALIZE'
 export const SET_SEARCH_FORM_TYPE = 'entityList/SET_SEARCH_FORM_TYPE'
+export const SET_SEARCH_FORM_TYPE_FROM_INPUT = 'entityList/SET_SEARCH_FORM_TYPE_FROM_INPUT'
 export const RELOAD_ALL = 'entityList/RELOAD_ALL'
 export const RELOAD_DATA = 'entityList/RELOAD_DATA'
 export const SET_SEARCH_FORM_COLLAPSED = 'entityList/SET_SEARCH_FORM_COLLAPSED'
@@ -15,6 +16,13 @@ export const setInitialized = (initialized = true) => ({
 
 export const initialize = () => ({
   type: INITIALIZE
+})
+
+export const setSearchFormTypeFromInput = searchFormType => ({
+  type: SET_SEARCH_FORM_TYPE_FROM_INPUT,
+  payload: {
+    searchFormType
+  }
 })
 
 export const setSearchFormType = searchFormType => ({

--- a/packages/core/entity-list/src/modules/entityList/reducer.js
+++ b/packages/core/entity-list/src/modules/entityList/reducer.js
@@ -15,6 +15,7 @@ const setSearchFormType = (state, {payload}) => {
 const ACTION_HANDLERS = {
   [actions.SET_INITIALIZED]: reducerUtil.singleTransferReducer('initialized'),
   [actions.SET_SEARCH_FORM_TYPE]: setSearchFormType,
+  [actions.SET_SEARCH_FORM_TYPE_FROM_INPUT]: setSearchFormType,
   [actions.SET_SEARCH_FORM_COLLAPSED]: reducerUtil.singleTransferReducer('searchFormCollapsed'),
   [actions.SET_SEARCH_FORM_COLLAPSED_INITIAL_VALUE]: reducerUtil.singleTransferReducer('searchFormCollapsed')
 }

--- a/packages/core/entity-list/src/modules/searchForm/sagas.js
+++ b/packages/core/entity-list/src/modules/searchForm/sagas.js
@@ -11,7 +11,7 @@ import SearchFilterNameForm from '../../components/SearchFilterNameForm'
 import {changeParentFieldType, getEndpoint, getFormFieldFlat} from '../../util/api/forms'
 import searchFormTypes from '../../util/searchFormTypes'
 import {validateSearchFields} from '../../util/searchFormValidation'
-import {setSearchFormType} from '../entityList/actions'
+import {setSearchFormType, SET_SEARCH_FORM_TYPE_FROM_INPUT} from '../entityList/actions'
 import {SET_ENTITY_MODEL, SET_FORM_DEFINITION, setSorting, refresh} from '../list/actions'
 import {getBasicQuery, getSearchViewQuery} from '../list/sagas'
 import * as actions from './actions'
@@ -31,6 +31,7 @@ export default function* sagas() {
     takeLatest(actions.INITIALIZE, initialize),
     takeLatest(formActionTypes.CHANGE, submitSearchFrom),
     takeLatest(actions.SUBMIT_SEARCH_FORM, submitSearchFrom),
+    takeLatest(SET_SEARCH_FORM_TYPE_FROM_INPUT, initSearchFormType),
     takeLatest(actions.RESET_SEARCH, resetSearch),
     takeLatest(actions.SAVE_SEARCH_FILTER, saveSearchFilter),
     takeLatest(actions.DELETE_SEARCH_FILTER, deleteSearchFilter),
@@ -52,13 +53,21 @@ export function* initialize() {
   const {searchFormType} = yield select(entityListSelector)
   const searchFormVisible = searchFormType !== searchFormTypes.NONE
 
-  const formDefinition = searchFormVisible ? yield call(loadSearchForm) : null
+  const formDefinition = yield call(initSearchFormType)
   yield call(setInitialFormValues, searchFormVisible, formDefinition)
   if (searchFormType === searchFormTypes.ADMIN) {
     yield call(loadSearchFilter, entityName)
   }
 
   yield put(actions.setInitialized())
+}
+
+export function* initSearchFormType() {
+  const {searchFormType} = yield select(entityListSelector)
+  const searchFormVisible = searchFormType !== searchFormTypes.NONE
+
+  const formDefinition = searchFormVisible ? yield call(loadSearchForm) : null
+  return formDefinition
 }
 
 export function* getListFormDefinition() {

--- a/packages/core/entity-list/src/modules/searchForm/sagas.spec.js
+++ b/packages/core/entity-list/src/modules/searchForm/sagas.spec.js
@@ -8,7 +8,7 @@ import {form, notification, rest} from 'tocco-app-extensions'
 
 import {getEndpoint} from '../../util/api/forms'
 import {validateSearchFields} from '../../util/searchFormValidation'
-import {setSearchFormType} from '../entityList/actions'
+import {setSearchFormType, SET_SEARCH_FORM_TYPE_FROM_INPUT} from '../entityList/actions'
 import {SET_ENTITY_MODEL, setFormDefinition, setSorting} from '../list/actions'
 import * as listSagas from '../list/sagas'
 import * as actions from './actions'
@@ -27,6 +27,7 @@ describe('entity-list', () => {
                 takeLatest(actions.INITIALIZE, sagas.initialize),
                 takeLatest(formActionTypes.CHANGE, sagas.submitSearchFrom),
                 takeLatest(actions.SUBMIT_SEARCH_FORM, sagas.submitSearchFrom),
+                takeLatest(SET_SEARCH_FORM_TYPE_FROM_INPUT, sagas.initSearchFormType),
                 takeLatest(actions.RESET_SEARCH, sagas.resetSearch),
                 takeLatest(actions.SAVE_SEARCH_FILTER, sagas.saveSearchFilter),
                 takeLatest(actions.DELETE_SEARCH_FILTER, sagas.deleteSearchFilter),


### PR DESCRIPTION
- searchFormType is set from `simple_advanced` to `fulltext` when no form definition exists
- this was only executed initially
- also re-initalize searchFormType whenever is has been change from outside

Refs: TOCDEV-5891
Changelog: show correct search form in subgrid