### PR TITLE
feat(app-extension): change HTTP method of `rest.fetchEntity` to POST

### DIFF
--- a/packages/core/app-extensions/src/rest/helpers.js
+++ b/packages/core/app-extensions/src/rest/helpers.js
@@ -12,17 +12,28 @@ import {requestSaga} from './rest'
  * @param entityName {String} Name of the entity
  * @param key {String} key of the entity
  * @param query {Object} see 'buildRequestQuery' function
+ * @param requestOptions {Object} An object which can contain the following options:
+ * - method {String} HTTP Method of request. Default is POST.
  * @param transformer {function} Function to directly manipulate the result. By default returns data attribute
  */
-export function* fetchEntity(entityName, key, query, transformer = json => json) {
+export function* fetchEntity(entityName, key, query, requestOptions = {}, transformer = json => json) {
+  const {method = 'POST'} = requestOptions
   const requestQuery = yield call(buildRequestQuery, query)
   const options = {
-    method: 'GET',
+    method,
     queryParams: {
-      ...requestQueryToUrlParams(requestQuery),
-      _permissions: true,
-      _omitLinks: true
-    }
+      _omitLinks: true,
+      ...(method === 'GET' && {
+        ...requestQueryToUrlParams(requestQuery),
+        _permissions: true
+      })
+    },
+    ...(method === 'POST' && {
+      body: {
+        ...requestQuery,
+        permissions: true
+      }
+    })
   }
 
   const resp = yield call(requestSaga, `entities/2.0/${entityName}/${key}`, options)
@@ -182,7 +193,8 @@ function* loadDisplays(currentDisplays, type) {
  * - method {String} HTTP Method of request. Default is POST
  * - endpoint {String} To overwrite default endpoint entities/2.0/{entityName}/count
  */
-export function* fetchEntityCount(entityName, query, {method = 'POST', endpoint} = {}) {
+export function* fetchEntityCount(entityName, query, requestOptions = {}) {
+  const {method = 'POST', endpoint} = requestOptions
   const requestQuery = yield call(buildRequestQuery, query)
   const resource = (endpoint || `entities/2.0/${entityName}`) + '/count'
 
@@ -205,12 +217,8 @@ export function* fetchEntityCount(entityName, query, {method = 'POST', endpoint}
  * - endpoint {String} To overwrite default endpoint entities/2.0/{entityName}/search
  * @param transformer {function} Function to directly manipulate the result. By default returns data attribute
  */
-export function* fetchEntities(
-  entityName,
-  query,
-  {method = 'POST', endpoint} = {},
-  transformer = defaultEntityTransformer
-) {
+export function* fetchEntities(entityName, query, requestOptions = {}, transformer = defaultEntityTransformer) {
+  const {method = 'POST', endpoint} = requestOptions
   const requestQuery = yield call(buildRequestQuery, query)
   const resource = endpoint || `entities/2.0/${entityName}${method === 'POST' ? '/search' : ''}`
 

--- a/packages/core/app-extensions/src/rest/helpers.spec.js
+++ b/packages/core/app-extensions/src/rest/helpers.spec.js
@@ -125,15 +125,41 @@ describe('app-extensions', () => {
       })
 
       describe('fetchEntity', () => {
-        test('should call fetch', async () => {
+        test('should send POST request', async () => {
           const query = {
-            paths: ['firstname', 'lastname'],
-            forms: 'User_detail'
+            paths: ['firstname', 'lastname']
+          }
+          const requestOptions = {
+            method: 'POST',
+            queryParams: {_omitLinks: true},
+            body: {paths: ['firstname', 'lastname'], permissions: true}
           }
           const responseEntity = {paths: {firstname: 'Jack'}}
 
           await expectSaga(helpers.fetchEntity, 'User', '1', query)
             .provide([[matchers.call.fn(requestSaga), {body: responseEntity}]])
+            .call(requestSaga, 'entities/2.0/User/1', requestOptions)
+            .returns(responseEntity)
+            .run()
+        })
+
+        test('should send GET request on demand', async () => {
+          const query = {
+            paths: ['firstname', 'lastname']
+          }
+          const requestOptions = {
+            method: 'GET',
+            queryParams: {
+              _omitLinks: true,
+              _paths: 'firstname,lastname',
+              _permissions: true
+            }
+          }
+          const responseEntity = {paths: {firstname: 'Jack'}}
+
+          await expectSaga(helpers.fetchEntity, 'User', '1', query, {method: 'GET'})
+            .provide([[matchers.call.fn(requestSaga), {body: responseEntity}]])
+            .call(requestSaga, 'entities/2.0/User/1', requestOptions)
             .returns(responseEntity)
             .run()
         })


### PR DESCRIPTION
Caution: depends on https://git.tocco.ch/c/nice2/+/45699 (new POST REST
         endpoint must be merged first)

Details:
- When fetching an entity, the field and relation values needed to be specified in the `_paths` query param
- If there are many paths to request, the URL can become very long (longer than 2000 characters which is the de facto limit for the URL length) which causes requests to fail (see TOCDEV-6081).
- To get around the problem, the entity can be fetched via POST request now (send `paths` array in body instead of comma separated `_paths` query param) -> this is also the new default
- If you still want to use GET as the method, you can specify it in the request options for `rest.fetchEntity`

Refs: TOCDEV-6081
Changelog: change HTTP method of `rest.fetchEntity` to POST
Cherry-pick: Up