### PR TITLE
feat(app-extension): change HTTP method of `rest.fetchEntity` to POST

### DIFF
--- a/packages/core/app-extensions/src/rest/helpers.spec.js
+++ b/packages/core/app-extensions/src/rest/helpers.spec.js
@@ -126,15 +126,41 @@ describe('app-extensions', () => {
       })
 
       describe('fetchEntity', () => {
-        test('should call fetch', async () => {
+        test('should send POST request', async () => {
           const query = {
-            paths: ['firstname', 'lastname'],
-            forms: 'User_detail'
+            paths: ['firstname', 'lastname']
+          }
+          const requestOptions = {
+            method: 'POST',
+            queryParams: {_omitLinks: true},
+            body: {paths: ['firstname', 'lastname'], permissions: true}
           }
           const responseEntity = {paths: {firstname: 'Jack'}}
 
           await expectSaga(helpers.fetchEntity, 'User', '1', query)
             .provide([[matchers.call.fn(requestSaga), {body: responseEntity}]])
+            .call(requestSaga, 'entities/2.0/User/1', requestOptions)
+            .returns(responseEntity)
+            .run()
+        })
+
+        test('should send GET request on demand', async () => {
+          const query = {
+            paths: ['firstname', 'lastname']
+          }
+          const requestOptions = {
+            method: 'GET',
+            queryParams: {
+              _omitLinks: true,
+              _paths: 'firstname,lastname',
+              _permissions: true
+            }
+          }
+          const responseEntity = {paths: {firstname: 'Jack'}}
+
+          await expectSaga(helpers.fetchEntity, 'User', '1', query, {method: 'GET'})
+            .provide([[matchers.call.fn(requestSaga), {body: responseEntity}]])
+            .call(requestSaga, 'entities/2.0/User/1', requestOptions)
             .returns(responseEntity)
             .run()
         })


### PR DESCRIPTION
Caution: depends on https://git.tocco.ch/c/nice2/+/45699 (new POST REST
         endpoint must be merged first)

Details:
- When fetching an entity, the field and relation values needed to be specified in the `_paths` query param
- If there are many paths to request, the URL can become very long (longer than 2000 characters which is the de facto limit for the URL length) which causes requests to fail (see TOCDEV-6081).
- To get around the problem, the entity can be fetched via POST request now (send `paths` array in body instead of comma separated `_paths` query param) -> this is also the new default
- If you still want to use GET as the method, you can specify it in the request options for `rest.fetchEntity`

Refs: TOCDEV-6081
Changelog: change HTTP method of `rest.fetchEntity` to POST
Cherry-pick: Up