### PR TITLE
fix(tocco-util): fix escape handling on tql fulltext search

### DIFF
--- a/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.js
+++ b/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.js
@@ -52,6 +52,8 @@ const rangeMappings = type => {
   }
 }
 
+const escapeFulltextValue = value => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
 const typeHandlers = type => {
   switch (type) {
     case 'multi-select-box':
@@ -61,10 +63,12 @@ const typeHandlers = type => {
     case 'single-select-box':
       return (path, value) => `${path}.pk == ${value.key}`
     case 'fulltext-search':
-      return (path, value) =>
-        path === 'txtFulltext'
-          ? `(fulltext("${value}") or fulltext("${value}*"))`
-          : `(fulltext("${value}", ${path}) or fulltext("${value}*", ${path}))`
+      return (path, value) => {
+        const escapedValue = escapeFulltextValue(value)
+        return path === 'txtFulltext'
+          ? `(fulltext("${escapedValue}") or fulltext("${escapedValue}*"))`
+          : `(fulltext("${escapedValue}", ${path}) or fulltext("${escapedValue}*", ${path}))`
+      }
     case 'birthdate':
     case 'date':
     case 'create_timestamp':

--- a/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
+++ b/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
@@ -114,6 +114,39 @@ describe('tocco-util', () => {
         expect(result).to.deep.eql(expectedResult)
       })
 
+      test('should escape double quotes on fulltext fields', () => {
+        const value = '"Test Value"'
+        const path = 'txtFulltext'
+        const fieldType = 'fulltext-search'
+
+        const expectedResult = '(fulltext("\\"Test Value\\"") or fulltext("\\"Test Value\\"*"))'
+        const result = getTql(path, value, fieldType)
+
+        expect(result).to.deep.eql(expectedResult)
+      })
+
+      test('should escape backslashes on fulltext fields', () => {
+        const value = 'Test \\ Value'
+        const path = 'txtFulltext'
+        const fieldType = 'fulltext-search'
+
+        const expectedResult = '(fulltext("Test \\\\ Value") or fulltext("Test \\\\ Value*"))'
+        const result = getTql(path, value, fieldType)
+
+        expect(result).to.deep.eql(expectedResult)
+      })
+
+      test('should escape all in one on fulltext fields', () => {
+        const value = '"Test \\ Value"'
+        const path = 'txtFulltext'
+        const fieldType = 'fulltext-search'
+
+        const expectedResult = '(fulltext("\\"Test \\\\ Value\\"") or fulltext("\\"Test \\\\ Value\\"*"))'
+        const result = getTql(path, value, fieldType)
+
+        expect(result).to.deep.eql(expectedResult)
+      })
+
       test('should handle boolean with true value', () => {
         const value = true
         const path = 'active'


### PR DESCRIPTION
- escape " => \" and \ => \\

Refs: TOCDEV-6013
Changelog: fix escape handling in tql fulltext search
Cherry-pick: Up