### PR TITLE
feat(sso-login): pass redirectUri for sso in widgets

### DIFF
--- a/packages/widgets/sso-login/src/utils/loginWindow.js
+++ b/packages/widgets/sso-login/src/utils/loginWindow.js
@@ -3,9 +3,19 @@ import {env} from 'tocco-util'
 import {getPopUpFeatures} from './popUp'
 
 export const openLoginWindow = (loginEndpoint, loginCompleted, provider) => {
+  const isWidget = env.getEmbedType() === 'widget'
+
   const baseUrl = __DEV__ ? '' : env.getBackendUrl()
-  const encodedWindowUrl = encodeURIComponent(window.location.href)
-  const url = `${baseUrl}${loginEndpoint}?provider=${provider.unique_id}&sourceUri=${encodedWindowUrl}`
+
+  const redirectUri = encodeURIComponent(`${baseUrl}/nice2/sso-callback`)
+  const sourceUri = encodeURIComponent(window.location.href)
+
+  const providerParam = `provider=${provider.unique_id}`
+  const sourceUriParam = `&sourceUri=${sourceUri}`
+  // apply nice_auth cookie on customers extranet domain instead of tocco.ch-domain
+  const redirectUriParam = isWidget ? `&redirectUri=${redirectUri}` : ''
+
+  const url = `${baseUrl}${loginEndpoint}?${providerParam}${sourceUriParam}${redirectUriParam}`
 
   const popUp = window.open(url, provider.label, getPopUpFeatures(650, 500))
 


### PR DESCRIPTION
- nice_auth cookie should be applied on the customers extranet domain
- the backend does not know this domain
- therefore the widget passes the redirectUri as query parameter with the correct domain

Refs: TOCDEV-6061
Changelog: pass redirectUri for sso logins in widgets