### PR TITLE
fix(app-extensions, tocco-ui): increase z-index for selects in modals

### DIFF
--- a/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
+++ b/packages/app-extensions/src/notifier/modules/modalComponents/StyledComponents.js
@@ -49,7 +49,7 @@ export const StyledModalHolder = styled.div`
   left: 0;
   position: absolute;
   // higher than StyledHeader and very high value to prevent other elements blocking it when implemented as a widget
-  z-index: 99999;
+  z-index: 99999999;
 `
 
 export const StyledModalWrapper = styled.div`

--- a/packages/tocco-ui/src/Select/Menu.js
+++ b/packages/tocco-ui/src/Select/Menu.js
@@ -7,7 +7,7 @@ import _omit from 'lodash/omit'
 
 export const StyledTether = styled(TetherComponent)`
   && {
-    z-index: 1;
+    z-index: 99999999 !important;
   }
 `
 


### PR DESCRIPTION
the fix for issue BS-7483 broken BS-6936 again, so the change is reverted. The issue of BS-6936 and BS-8043 is now fixed. BS-7483 was now fixed by changing the z-index of the select dropdown (and not the modal)

Refs: BS-6936, BS-7483, BS-8043
Changelog: increase z-index for selects in modals
Cherry-pick: No