### PR TITLE
fix(widget-code-copy): remove tocco subdomain

### DIFF
--- a/packages/actions/widget-code-copy/src/utils/widgetCode.js
+++ b/packages/actions/widget-code-copy/src/utils/widgetCode.js
@@ -8,7 +8,8 @@ const getBaseUrl = domain => {
     return `https://${domain}`
   }
 
-  return `https://tocco.${domain}`
+  // use either cms tocco backend proxy url or tocco backend url
+  return window.location.origin
 }
 
 export const generateWidgetCode = widgetConfig => {

--- a/packages/actions/widget-code-copy/src/utils/widgetCode.spec.js
+++ b/packages/actions/widget-code-copy/src/utils/widgetCode.spec.js
@@ -32,14 +32,27 @@ describe('widget-code-copy', () => {
           expect(trim(generateWidgetCode(widgetConfig))).to.equal(expectedWidgetCode)
         })
 
-        test('should add tocco subdomain for foreign domains', () => {
+        test('should use tocco backend url instead foreign domain', () => {
           const widgetConfig = {
             key: 1,
             paths: {domain: {value: 'abc.ch'}}
           }
           const expectedWidgetCode = trim(`
             <div data-tocco-widget-key="1"></div>
-            <script src="https://tocco.abc.ch/js/tocco-widget-utils/dist/bootstrap.js"></script>
+            <script src="http://localhost/js/tocco-widget-utils/dist/bootstrap.js"></script>
+          `)
+
+          expect(trim(generateWidgetCode(widgetConfig))).to.equal(expectedWidgetCode)
+        })
+
+        test('should use tocco backend url instead foreign www domain', () => {
+          const widgetConfig = {
+            key: 1,
+            paths: {domain: {value: 'www.abc.ch'}}
+          }
+          const expectedWidgetCode = trim(`
+            <div data-tocco-widget-key="1"></div>
+            <script src="http://localhost/js/tocco-widget-utils/dist/bootstrap.js"></script>
           `)
 
           expect(trim(generateWidgetCode(widgetConfig))).to.equal(expectedWidgetCode)


### PR DESCRIPTION
- having an extranet with tocco subdomain for cookie authentication will not be the main usecase anymore
- instead the cms (mainly wordpress) will have a tocco-proxy (via a plugin) and the widgets will communicate via this proxy to nice2 backend
- therefore tocco subdomain does not exist and asset url has to be tocco backend url directly

Changelog: remove tocco subdomain