### PR TITLE
fix(entity-list): be able to click on row in action cell

### DIFF
--- a/packages/core/entity-list/src/util/StyledComponents.js
+++ b/packages/core/entity-list/src/util/StyledComponents.js
@@ -10,13 +10,10 @@ export const StyledColumnContentWrapper = styled.div`
   }
 `
 
-export const StyledActionWrapper = styled.div`
-  ${StyledButton} {
-    width: 100%;
-    max-width: fit-content;
-    justify-content: center;
-    box-sizing: border-box;
+export const StyledActionWrapper = styled.span`
+  display: inline-block;
 
+  ${StyledButton} {
     > * {
       overflow: hidden;
     }


### PR DESCRIPTION
- action wrapper took full cell width
- therefore no space left for row-click event handler

Refs: TOCDEV-6190
Changelog: be able to click on row in action cell
Cherry-pick: Up