### PR TITLE
fix(tocco-ui): do not collapse sidepanel on top

### DIFF
--- a/packages/core/tocco-ui/src/Sidepanel/SidepanelContext.js
+++ b/packages/core/tocco-ui/src/Sidepanel/SidepanelContext.js
@@ -29,7 +29,7 @@ const SidepanelContextProvider = ({
   const value = useMemo(
     () => ({
       sidepanelPosition,
-      isCollapsed,
+      isCollapsed: sidepanelPosition === SidepanelPosition.left ? isCollapsed : false,
       toggleCollapse,
       scrollBehaviour
     }),


### PR DESCRIPTION
- sidepanel collapse on mobile automatically
- do not collapse (hide) sidepanel when positioned on top

Changelog: do not collapse sidepanel on top
Refs: TOCDEV-5985