### PR TITLE
refactor(widgets): remove div wrapper

### DIFF
--- a/packages/widgets/entity-browser/src/main.js
+++ b/packages/widgets/entity-browser/src/main.js
@@ -18,11 +18,9 @@ const packageName = 'entity-browser'
 
 const LazyEntityBrowserComp = React.lazy(() => import('./components/EntityBrowser'))
 const LazyEntityBrowser = () => (
-  <div>
-    <Suspense fallback="">
-      <LazyEntityBrowserComp />
-    </Suspense>
-  </div>
+  <Suspense fallback="">
+    <LazyEntityBrowserComp />
+  </Suspense>
 )
 
 const textResourceSelector = (state, key) => state.intl.messages[key] || key


### PR DESCRIPTION
Cherry-pick: Up
Refs: TOCDEV-6197
Changelog: remove div wrapper of entity-browser as it was preventing it from filling the full available height when embedded in the old client