### PR TITLE
feat(app-extensions): use selection when loading report settings

### DIFF
--- a/packages/core/app-extensions/src/actions/modules/actionHandlers/report.js
+++ b/packages/core/app-extensions/src/actions/modules/actionHandlers/report.js
@@ -71,10 +71,8 @@ export function* generateReportWithoutSettings(actionDefinition, selection) {
 
 function* getSettingsDefinition(actionDefinition, selection) {
   const options = {
-    queryParams: {
-      model: selection.entityName,
-      ...(selection.mode === 'ID' ? {keys: selection.ids.join(',')} : {})
-    }
+    body: selection,
+    method: 'POST'
   }
 
   const resource = `report/${actionDefinition.reportId}/settings`

--- a/packages/core/tocco-util/src/mockData/reports.js
+++ b/packages/core/tocco-util/src/mockData/reports.js
@@ -2,7 +2,7 @@ import originId from '../originId'
 import {getRandomInt} from './utils'
 
 export const setupReports = (fetchMock, entityStore, webSocketServer, timeout = 2000) => {
-  fetchMock.get(new RegExp('^.*?/nice2/rest/report/.*/settings*?'), require('./data/report_settings.json'))
+  fetchMock.post(new RegExp('^.*?/nice2/rest/report/.*/settings*?'), require('./data/report_settings.json'))
 
   fetchMock.post(new RegExp('^.*?/nice2/rest/report/generation'), (url, opts) => {
     const body = JSON.parse(opts.body)

--- a/packages/core/tocco-util/src/mockData/reports.spec.js
+++ b/packages/core/tocco-util/src/mockData/reports.spec.js
@@ -28,7 +28,7 @@ describe('tocco-util', () => {
           test('should return valid response with generalSettings', () => {
             setupReports(fetchMock)
             const resource = '/nice2/rest/report/sample_report/settings'
-            return fetch(resource)
+            return fetch(resource, {method: 'POST'})
               .then(res => res.json())
               .should.eventually.have.property('generalSettings')
           })


### PR DESCRIPTION
Cherry-pick: Up
Refs: TOCDEV-6247
Changelog: send selection to adjusted POST endpoint when loading report settings