### PR TITLE
fix(tocco-util): fix performance of fulltext search

### DIFF
--- a/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.js
+++ b/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.js
@@ -66,8 +66,8 @@ const typeHandlers = type => {
       return (path, value) => {
         const escapedValue = escapeFulltextValue(value)
         return path === 'txtFulltext'
-          ? `(fulltext("${escapedValue}") or fulltext("${escapedValue}*"))`
-          : `(fulltext("${escapedValue}", ${path}) or fulltext("${escapedValue}*", ${path}))`
+          ? `fulltext("(${escapedValue}) OR (${escapedValue}*)")`
+          : `fulltext("(${escapedValue}) OR (${escapedValue}*)", ${path})`
       }
     case 'birthdate':
     case 'date':

--- a/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
+++ b/packages/core/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
@@ -97,7 +97,7 @@ describe('tocco-util', () => {
         const path = 'txtFulltext'
         const fieldType = 'fulltext-search'
 
-        const expectedResult = '(fulltext("Test") or fulltext("Test*"))'
+        const expectedResult = 'fulltext("(Test) OR (Test*)")'
         const result = getTql(path, value, fieldType)
 
         expect(result).to.deep.eql(expectedResult)
@@ -108,7 +108,7 @@ describe('tocco-util', () => {
         const path = 'relAddress'
         const fieldType = 'fulltext-search'
 
-        const expectedResult = '(fulltext("Test", relAddress) or fulltext("Test*", relAddress))'
+        const expectedResult = 'fulltext("(Test) OR (Test*)", relAddress)'
         const result = getTql(path, value, fieldType)
 
         expect(result).to.deep.eql(expectedResult)
@@ -119,7 +119,7 @@ describe('tocco-util', () => {
         const path = 'txtFulltext'
         const fieldType = 'fulltext-search'
 
-        const expectedResult = '(fulltext("\\"Test Value\\"") or fulltext("\\"Test Value\\"*"))'
+        const expectedResult = 'fulltext("(\\"Test Value\\") OR (\\"Test Value\\"*)")'
         const result = getTql(path, value, fieldType)
 
         expect(result).to.deep.eql(expectedResult)
@@ -130,7 +130,7 @@ describe('tocco-util', () => {
         const path = 'txtFulltext'
         const fieldType = 'fulltext-search'
 
-        const expectedResult = '(fulltext("Test \\\\ Value") or fulltext("Test \\\\ Value*"))'
+        const expectedResult = 'fulltext("(Test \\\\ Value) OR (Test \\\\ Value*)")'
         const result = getTql(path, value, fieldType)
 
         expect(result).to.deep.eql(expectedResult)
@@ -141,7 +141,7 @@ describe('tocco-util', () => {
         const path = 'txtFulltext'
         const fieldType = 'fulltext-search'
 
-        const expectedResult = '(fulltext("\\"Test \\\\ Value\\"") or fulltext("\\"Test \\\\ Value\\"*"))'
+        const expectedResult = 'fulltext("(\\"Test \\\\ Value\\") OR (\\"Test \\\\ Value\\"*)")'
         const result = getTql(path, value, fieldType)
 
         expect(result).to.deep.eql(expectedResult)


### PR DESCRIPTION
just using one fulltext keyword instead of two has a better performance. in the old client the search term "term1 term2 term3" is converted to the TQL "term1 term2 (term3 OR term3*)" which is the equivalent of the TQL  "(term1 term2 term3) OR (term1 term2 term3*)" now implemented in the new client.

Refs: TOCDEV-6080
Changelog: fix performance of fulltext search