### PR TITLE
fix(tocco-util): fix performance of fulltext search

### DIFF
--- a/packages/tocco-util/src/tqlBuilder/tqlBuilder.js
+++ b/packages/tocco-util/src/tqlBuilder/tqlBuilder.js
@@ -61,8 +61,8 @@ const typeHandlers = type => {
     case 'fulltext-search':
       return (path, value) =>
         path === 'txtFulltext'
-          ? `(fulltext("${value}") or fulltext("${value}*"))`
-          : `(fulltext("${value}", ${path}) or fulltext("${value}*", ${path}))`
+          ? `fulltext("(${value}) OR (${value}*)")`
+          : `fulltext("(${value}) OR (${value}*)", ${path})`
     case 'birthdate':
     case 'date':
     case 'create_timestamp':

--- a/packages/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
+++ b/packages/tocco-util/src/tqlBuilder/tqlBuilder.spec.js
@@ -100,7 +100,7 @@ describe('entity-list', () => {
             const path = 'txtFulltext'
             const fieldType = 'fulltext-search'
 
-            const expectedResult = '(fulltext("Test") or fulltext("Test*"))'
+            const expectedResult = 'fulltext("(Test) OR (Test*)")'
             const result = getTql(path, value, fieldType)
 
             expect(result).to.deep.eql(expectedResult)
@@ -111,7 +111,7 @@ describe('entity-list', () => {
             const path = 'relAddress'
             const fieldType = 'fulltext-search'
 
-            const expectedResult = '(fulltext("Test", relAddress) or fulltext("Test*", relAddress))'
+            const expectedResult = 'fulltext("(Test) OR (Test*)", relAddress)'
             const result = getTql(path, value, fieldType)
 
             expect(result).to.deep.eql(expectedResult)


### PR DESCRIPTION
just using one fulltext keyword instead of two has a better performance. in the old client the search term "term1 term2 term3" is converted to the TQL "term1 term2 (term3 OR term3*)" which is the equivalent of the TQL  "(term1 term2 term3) OR (term1 term2 term3*)" now implemented in the new client.

Refs: TOCDEV-6080
Changelog: fix performance of fulltext search