### PR TITLE
fix(tocco-util): allow target attribute in html

### DIFF
--- a/packages/core/tocco-util/src/html/sanitizeHtml.js
+++ b/packages/core/tocco-util/src/html/sanitizeHtml.js
@@ -37,7 +37,8 @@ const sanitizeHtml = html => {
   if (!html) {
     return html
   }
-  return DOMPurify.sanitize(html, {FORBID_TAGS: ['style']})
+
+  return DOMPurify.sanitize(html, {FORBID_TAGS: ['style'], ADD_ATTR: ['target']})
 }
 
 export default sanitizeHtml

--- a/packages/core/tocco-util/src/html/sanitizeHtml.spec.js
+++ b/packages/core/tocco-util/src/html/sanitizeHtml.spec.js
@@ -68,6 +68,16 @@ describe('tocco-util', () => {
         const clean = '<div style="border:1px;width:100%;">Hi!</div>'
         expect(sanitizeHtml(dirty)).to.equal(clean)
       })
+      test('should allow target attribute on links', () => {
+        const dirty = '<a href="https://www.google.ch" target="_blank">Hi!</a>'
+        const clean = '<a target="_blank" href="https://www.google.ch">Hi!</a>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
+      test('should allow links without target attribute', () => {
+        const dirty = '<a href="https://www.google.ch">Hi!</a>'
+        const clean = '<a href="https://www.google.ch">Hi!</a>'
+        expect(sanitizeHtml(dirty)).to.equal(clean)
+      })
     })
   })
 })


### PR DESCRIPTION
- links in freemarker can have target attributes which whould be kept

Refs: TOCDEV-5169
Changelog: allow target attribute in html