### PR TITLE
fix(scheduler): fix null as end date

### DIFF
--- a/packages/core/scheduler/src/components/FullCalendar/FullCalendar.js
+++ b/packages/core/scheduler/src/components/FullCalendar/FullCalendar.js
@@ -102,7 +102,7 @@ const FullCalendar = forwardRef(
     )
 
     const renderEventContent = eventInfo => {
-      const time = getFormattedEventTime(locale, eventInfo.event.start, eventInfo.event.end)
+      const time = getFormattedEventTime(locale, eventInfo.event.start, eventInfo.event.end || eventInfo.event.start)
       const tooltipDescriptionContent = (
         <div>
           <FormattedValue type="html" value={eventInfo.event.extendedProps.description} />


### PR DESCRIPTION
While the start date is inclusive, the end date is exclusive (https://fullcalendar.io/docs/event-parsing). If the same timestamp is passed for start and end of the event, the eventInfo.event.end of the eventContent method is null. Use the start date as fallback if the end date is null

Changelog: fix null as end date
Refs: TOCDEV-6246
Cherry-pick: Up