### PR TITLE
fix(app-extensions): create ENTITY_DOCS selection for legacy actions

### DIFF
--- a/packages/core/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
+++ b/packages/core/app-extensions/src/actions/modules/actionHandlers/legacyAction.js
@@ -7,6 +7,7 @@ import remoteEvents from '../../../remoteEvents'
 import rest from '../../../rest'
 
 const ignoredExceptionMessages = ['Single selection only, aborting...', 'Nothing selected, aborting...']
+const entityDocsEntity = ['Folder', 'Resource']
 
 export const loadScript = src =>
   new Promise((resolve, reject) => {
@@ -159,8 +160,9 @@ export function* getSelection(selection) {
   }
 
   if (selection.type === 'ID') {
+    const isEntityDocsEntity = entityDocsEntity.includes(selection.entityName)
     legacySelection.selectedEntities = selection.ids
-    legacySelection.selectionType = 'SELECTION'
+    legacySelection.selectionType = isEntityDocsEntity ? 'ENTITY_DOCS' : 'SELECTION'
   } else if (selection.type === 'QUERY') {
     const listState = yield select(listSelector)
 

--- a/packages/core/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
+++ b/packages/core/app-extensions/src/actions/modules/actionHandlers/legacyAction.spec.js
@@ -210,6 +210,36 @@ describe('app-extensions', () => {
                 .run()
             })
 
+            test('should use ENTITY_DOCS selection for Folder', () => {
+              const selection = {
+                entityName: 'Folder',
+                type: 'ID',
+                ids: ['5', '18', '3']
+              }
+              return expectSaga(legacyAction.getSelection, selection)
+                .returns({
+                  entityName: 'Folder',
+                  selectionType: 'ENTITY_DOCS',
+                  selectedEntities: ['5', '18', '3']
+                })
+                .run()
+            })
+
+            test('should use ENTITY_DOCS selection for Resource', () => {
+              const selection = {
+                entityName: 'Resource',
+                type: 'ID',
+                ids: ['5', '18', '3']
+              }
+              return expectSaga(legacyAction.getSelection, selection)
+                .returns({
+                  entityName: 'Resource',
+                  selectionType: 'ENTITY_DOCS',
+                  selectedEntities: ['5', '18', '3']
+                })
+                .run()
+            })
+
             test('should return search params for QUERY selection', () => {
               const selection = {
                 entityName: 'User',


### PR DESCRIPTION
- dms entites should handled as entity_docs selection for legacy actions

Refs: TOCDEV-6314
Cherry-pick: Up
Changelog: create ENTITY_DOCS selection for legacy actions