### PR TITLE
refactor(entity-list): prevent button being pushed down

### DIFF
--- a/packages/core/entity-list/src/util/StyledComponents.js
+++ b/packages/core/entity-list/src/util/StyledComponents.js
@@ -14,6 +14,8 @@ export const StyledActionWrapper = styled.span`
   display: inline-block;
 
   ${StyledButton} {
+    display: inline;
+
     > * {
       overflow: hidden;
     }


### PR DESCRIPTION
Refs: TOCDEV-6324
Changelog: prevent action buttons within table of being missaligned in widgets