### PR TITLE
fix(tocco-util): add locale to text resource caching key

### DIFF
--- a/packages/tocco-util/src/intl/intl.js
+++ b/packages/tocco-util/src/intl/intl.js
@@ -76,7 +76,7 @@ export const loadTextResources = async(locale, modules) => {
   const notLoadedModules = []
 
   modules.forEach(module => {
-    const cachedModuleResource = cache.getLongTerm('textResource', module)
+    const cachedModuleResource = cache.getLongTerm('textResource', `${locale}.${module}`)
     if (cachedModuleResource) {
       result = {...result, ...cachedModuleResource}
     } else {
@@ -95,7 +95,7 @@ export const loadTextResources = async(locale, modules) => {
           [key]: resources[key]
         }), {})
 
-      cache.addLongTerm('textResource', module, filtered)
+      cache.addLongTerm('textResource', `${locale}.${module}`, filtered)
       result = {...result, ...filtered}
     })
   }

--- a/packages/tocco-util/src/intl/intl.spec.js
+++ b/packages/tocco-util/src/intl/intl.spec.js
@@ -84,9 +84,9 @@ describe('tocco-util', () => {
         const resources2 = await loadTextResources('en-GB', ['merge', 'components', 'actions.[^.]*\\.title'])
         expect(resources2).to.eql(resources)
 
-        expect(cache.getLongTerm('textResource', 'merge')).to.eql(mergeMessages)
-        expect(cache.getLongTerm('textResource', 'components')).to.eql(componentsMessages)
-        expect(cache.getLongTerm('textResource', 'actions.[^.]*\\.title')).to.eql(actionTitles)
+        expect(cache.getLongTerm('textResource', 'en-GB.merge')).to.eql(mergeMessages)
+        expect(cache.getLongTerm('textResource', 'en-GB.components')).to.eql(componentsMessages)
+        expect(cache.getLongTerm('textResource', 'en-GB.actions.[^.]*\\.title')).to.eql(actionTitles)
       })
     })
   })


### PR DESCRIPTION
cherrypick part of commit cf4e60af79da7ce3f274bb1bb4a006fd1746992b

Changelog: add locale to text resource caching key
Refs: TOCDEV-6435
Cherry-pick: Up