### PR TITLE
fix(tocco-util): fix object cache

### DIFF
--- a/packages/core/tocco-util/src/cache/cache.js
+++ b/packages/core/tocco-util/src/cache/cache.js
@@ -1,5 +1,3 @@
-import _get from 'lodash/get'
-import _set from 'lodash/set'
 import _unset from 'lodash/unset'
 
 import nice from '../nice'
@@ -25,7 +23,9 @@ const getKey = (type, id) => `${prefix}.${type}.${id}`
 
 const objectCache = {}
 
-const objectWriter = (key, value) => _set(objectCache, key, value)
+const objectWriter = (key, value) => {
+  objectCache[key] = value
+}
 const storageWriter = storage => (key, value) => storage.setItem(key, JSON.stringify(value))
 
 export const addObjectCache = (type, id, value) => add(type, id, value, objectWriter)
@@ -40,7 +40,7 @@ const add = (type, id, value, write) => {
   return write(getKey(type, id), value)
 }
 
-export const getObjectCache = (type, id) => _get(objectCache, getKey(type, id))
+export const getObjectCache = (type, id) => objectCache[getKey(type, id)]
 export const getShortTerm = (type, id) => getFromStorage(type, id, sessionStorage)
 export const getLongTerm = (type, id) => getFromStorage(type, id, localStorage)
 

--- a/packages/core/tocco-util/src/cache/cache.spec.js
+++ b/packages/core/tocco-util/src/cache/cache.spec.js
@@ -21,7 +21,7 @@ describe('tocco-util', () => {
       test('should return cached longterm value', () => {
         const value = 'Test'
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         addLongTerm(type, id, value)
 
@@ -32,7 +32,7 @@ describe('tocco-util', () => {
       test('should return cached shortterm value', () => {
         const value = 'Test'
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         addShortTerm(type, id, value)
 
@@ -43,7 +43,7 @@ describe('tocco-util', () => {
       test('should return cached object value', () => {
         const value = 'Test'
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         addObjectCache(type, id, value)
 
@@ -53,7 +53,7 @@ describe('tocco-util', () => {
 
       test('should return undefined on uncached value', () => {
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         expect(getLongTerm(type, id)).to.be.undefined
         expect(getShortTerm(type, id)).to.be.undefined
@@ -63,7 +63,7 @@ describe('tocco-util', () => {
       test('should return undefined if added short term but get on long term', () => {
         const value = 'Test'
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         addShortTerm(type, id, value)
 
@@ -73,7 +73,7 @@ describe('tocco-util', () => {
 
       test('should return null values', () => {
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         addLongTerm(type, id, null)
         expect(getLongTerm(type, id)).to.be.null
@@ -88,7 +88,7 @@ describe('tocco-util', () => {
       test('should cache object', () => {
         const value = {a: 21}
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         addLongTerm(type, id, value)
         expect(getLongTerm(type, id).a).to.eql(21)
@@ -103,7 +103,7 @@ describe('tocco-util', () => {
       test('should not cache if __DEV__', () => {
         const value = 'Test'
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         const resetDEVValue = __DEV__
         // eslint-disable-next-line no-global-assign
@@ -120,7 +120,7 @@ describe('tocco-util', () => {
       test('should not cache if nice env is not production', () => {
         const value = 'Test'
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         global.app = {
           getRunEnv: () => 'DEVELOPMENT'
@@ -134,7 +134,7 @@ describe('tocco-util', () => {
       test('should cache if nice env is production', () => {
         const value = 'Test'
         const type = 'label'
-        const id = 1
+        const id = 'entity.1'
 
         global.app = {
           getRunEnv: () => 'PRODUCTION'
@@ -148,7 +148,7 @@ describe('tocco-util', () => {
 
     describe('clear', () => {
       test('should clear all cache', () => {
-        const id = 'id'
+        const id = 'entity.1'
         const type = 'label'
 
         addLongTerm(type, id, 'test')
@@ -164,7 +164,7 @@ describe('tocco-util', () => {
 
       test('should clear short term cache', () => {
         const value = 'test'
-        const id = 'id'
+        const id = 'entity.1'
         const type = 'label'
 
         addShortTerm(type, id, value)
@@ -181,8 +181,8 @@ describe('tocco-util', () => {
       test('should remove single item from long term cache', () => {
         const value1 = 'test1'
         const value2 = 'test2'
-        const id1 = 'id1'
-        const id2 = 'id2'
+        const id1 = 'id.1'
+        const id2 = 'id.2'
         const type = 'label'
 
         addLongTerm(type, id1, value1)
@@ -197,8 +197,8 @@ describe('tocco-util', () => {
       test('should remove single item from object cache', () => {
         const value1 = 'test1'
         const value2 = 'test2'
-        const id1 = 'id1'
-        const id2 = 'id2'
+        const id1 = 'id.1'
+        const id2 = 'id.2'
         const type = 'label'
 
         addObjectCache(type, id1, value1)


### PR DESCRIPTION
- getter / setter from lodash will set nested objects when path includes `.`
- we do want to have a flat object with key names like `tocco.cache.display.Entity.1`
- therefore cannot use getters / setters from lodash
- however unset from loadash is working properly for our usecase

Refs: TOCDEV-6442
Changelog: fix object cache
Cherry-pick: Up